### PR TITLE
Support __stdcall calling convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Debug/
 ipch/
 TestResults/
 tests/cmake-build-debug/
+*/.vs/
 
 # Eclipse
 .settings/

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ For example:
 ```
 * To use fakeit with **NUnit** in a managed Visual Studio C++/CLI project, add the standalone/nunit folder to your project include path. Note, it is useful to define your mocks 
 in `#pragma unmanaged` sections so that you can use lambda expressions.
-```
+
 * To use fakeit with **CUTE** add the *include* folder and the *config/cute* folder to the include path of your test project:
 ```
 -I"<fakeit_folder>/include" -I"<fakeit_folder>/config/cute"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ in `#pragma unmanaged` sections so that you can use lambda expressions.
 -I"<fakeit_folder>/include" -I"<fakeit_folder>/config/standalone"
 ```
 It is recommended to build and run the unit tests to make sure FakeIt fits your environment.
+For GCC, it is recommended to build the test project with -O1 or -O0 flags. Some features of Fakeit may not work with stonger optimizations!!
 
 #### Building and Running the Unit Tests with GCC
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Depending on the unit testing framework you use, simply add one of the pre-packa
 * <fakeit_folder>/single\_header/[mettle](https://github.com/jimporter/mettle)
 * <fakeit_folder>/single\_header/qtest
 * <fakeit_folder>/single\_header/nunit - (See caveats in config/nunit/fakeit\_instance.hpp)
+* <fakeit_folder>/single\_header/[cute](https://github.com/PeterSommerlad/CUTE)  
 * <fakeit_folder>/single\_header/standalone
 
 For example, to use fakeit with **Google Test** simply add the *single_header/gtest* folder to the include path of your test project:
@@ -125,6 +126,11 @@ For example:
 ```
 * To use fakeit with **NUnit** in a managed Visual Studio C++/CLI project, add the standalone/nunit folder to your project include path. Note, it is useful to define your mocks 
 in `#pragma unmanaged` sections so that you can use lambda expressions.
+```
+* To use fakeit with **CUTE** add the *include* folder and the *config/cute* folder to the include path of your test project:
+```
+-I"<fakeit_folder>/include" -I"<fakeit_folder>/config/cute"
+```
 * To use fakeit without any testing framework integration (**standalone**) add the *include* folder and the *config/standalone* folder to the include path of your test project:
 ```
 -I"<fakeit_folder>/include" -I"<fakeit_folder>/config/standalone"

--- a/README.md
+++ b/README.md
@@ -75,22 +75,26 @@ If you don't find your unit testing framework on the list, simply use the *stand
 ### Using a pre-packaged single header file
 Pre-packaged single header versions of FakeIt are located under the *single_header* folder.
 Depending on the unit testing framework you use, simply add one of the pre-packaged versions to the include path of your test project:
-* <fakeit_folder>/single_header/[gtest](https://github.com/google/googletest)
-* <fakeit_folder>/single_header/mstest
-* <fakeit_folder>/single_header/boost
-* <fakeit_folder>/single_header/[catch](https://github.com/philsquared/Catch) (Tested with Catch 2.0.1)
-* <fakeit_folder>/single_header/[tpunit](https://github.com/tpounds/tpunitpp)
-* <fakeit_folder>/single_header/[mettle](https://github.com/jimporter/mettle)
-* <fakeit_folder>/single_header/qtest
-* <fakeit_folder>/single_header/standalone
+
+* <fakeit_folder>/single\_header/[gtest](https://github.com/google/googletest)
+* <fakeit_folder>/single\_header/mstest
+* <fakeit_folder>/single\_header/boost
+* <fakeit_folder>/single\_header/[catch](https://github.com/philsquared/Catch) (Tested with Catch 2.0.1)
+* <fakeit_folder>/single\_header/[tpunit](https://github.com/tpounds/tpunitpp)
+* <fakeit_folder>/single\_header/[mettle](https://github.com/jimporter/mettle)
+* <fakeit_folder>/single\_header/qtest
+* <fakeit_folder>/single\_header/nunit - (See caveats in config/nunit/fakeit\_instance.hpp)
+* <fakeit_folder>/single\_header/standalone
 
 For example, to use fakeit with **Google Test** simply add the *single_header/gtest* folder to the include path of your test project:
 ```
 -I"<fakeit_folder>/single_header/gtest"
 ```
+
 ### Using the source header files
 Fakeit source code header files are located under the *include* foler. To use FakeIt directly from the source code all you need to do is to download the source files and add the *include* folder and the configuration folder of your choice to the include path of your project.
 For example:
+
 * To use fakeit with **Google Test** add the *include* folder and the *config/gtest* folder to the include path of your test project:
 ```
 -I"<fakeit_folder>/include" -I"<fakeit_folder>/config/gtest"
@@ -119,11 +123,14 @@ For example:
 ```
 -I"<fakeit_folder>/include" -I"<fakeit_folder>/config/qtest"
 ```
+* To use fakeit with **NUnit** in a managed Visual Studio C++/CLI project, add the standalone/nunit folder to your project include path. Note, it is useful to define your mocks 
+in `#pragma unmanaged` sections so that you can use lambda expressions.
 * To use fakeit without any testing framework integration (**standalone**) add the *include* folder and the *config/standalone* folder to the include path of your test project:
 ```
 -I"<fakeit_folder>/include" -I"<fakeit_folder>/config/standalone"
 ```
 It is recommended to build and run the unit tests to make sure FakeIt fits your environment.
+
 #### Building and Running the Unit Tests with GCC
 ```
 cd build
@@ -133,6 +140,7 @@ run the tests by typing
 ```
 ./fakeit_tests.exe
 ```
+
 #### Building and Running the Unit Tests with Clang
 ```
 cd build
@@ -142,8 +150,10 @@ run the tests by typing
 ```
 ./fakeit_tests.exe
 ```
+
 #### Building and Running the Unit Tests with Visual Studio 
 Open the tests/all_tests.vcxproj project file with Visual Studio 2013. Build and run the project and check the test results. 
+
 ## Limitations
 * Currently only GCC, Clang and MSC++ are supported.
 * Can't mock classes with multiple inheritance.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ run the tests by typing
 ```
 
 #### Building and Running the Unit Tests with Visual Studio 
-Open the tests/all_tests.vcxproj project file with Visual Studio 2013. Build and run the project and check the test results. 
+Open the tests/all_tests.vcxproj project file with Visual Studio. Build and run the project and check the test results. 
 
 ## Limitations
 * Currently only GCC, Clang and MSC++ are supported.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ in `#pragma unmanaged` sections so that you can use lambda expressions.
 -I"<fakeit_folder>/include" -I"<fakeit_folder>/config/standalone"
 ```
 It is recommended to build and run the unit tests to make sure FakeIt fits your environment.
+
 For GCC, it is recommended to build the test project with -O1 or -O0 flags. Some features of Fakeit may not work with stonger optimizations!!
 
 #### Building and Running the Unit Tests with GCC

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Verify(Method(mock,foo).Using(1));
 
 Checkout the [Quickstart](https://github.com/eranpeer/FakeIt/wiki/Quickstart) for many more examples!
 
-Download the [Latest Release](https://github.com/eranpeer/FakeIt/releases/latest) and start using FakeIt now!
+The master branch has the stable version of FakeIt. Include the most suitable single header in your test project and you are good to go.
 
 ## Features
 * Packaged as a **single header file**.
@@ -156,6 +156,7 @@ Open the tests/all_tests.vcxproj project file with Visual Studio 2013. Build and
 
 ## Limitations
 * Currently only GCC, Clang and MSC++ are supported.
+* In MSC++, your project must have Edit And Continue debug mode on (https://msdn.microsoft.com/en-us/library/esaeyddf.aspx) which is same of /ZI compiler switch. If you don't use this, you will have exceptions mocking destructors (which includes unique_ptr and other smart pointers). 
 * Can't mock classes with multiple inheritance.
 * Can't mock classes with virtual inheritance.
 * Currently mocks are not thread safe. 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Open the tests/all_tests.vcxproj project file with Visual Studio. Build and run 
 
 ## Limitations
 * Currently only GCC, Clang and MSC++ are supported.
+* On GCC, optimization flag O2 and O3 are not supported. You bust compile the test project with -O1 or -O0.
 * In MSC++, your project must have Edit And Continue debug mode on (https://msdn.microsoft.com/en-us/library/esaeyddf.aspx) which is same of /ZI compiler switch. If you don't use this, you will have exceptions mocking destructors (which includes unique_ptr and other smart pointers). 
 * Can't mock classes with multiple inheritance.
 * Can't mock classes with virtual inheritance.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ FakeIt
 [![Join the chat at https://gitter.im/eranpeer/FakeIt](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/eranpeer/FakeIt?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 GCC: [![Build Status GCC](https://travis-ci.org/eranpeer/FakeIt.svg?branch=master)](https://travis-ci.org/eranpeer/FakeIt)
-[![Coverage Status](https://coveralls.io/repos/eranpeer/FakeIt/badge.svg?branch=master&service=github)](https://coveralls.io/github/eranpeer/FakeIt?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/eranpeer/FakeIt/badge.svg?branch=master)](https://coveralls.io/github/eranpeer/FakeIt?branch=master)
 
 MSC: [![Build status MSC](https://ci.appveyor.com/api/projects/status/sy2dk8se2yoxaqve)](https://ci.appveyor.com/project/eranpeer/fakeit)
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Open the tests/all_tests.vcxproj project file with Visual Studio. Build and run 
 
 ## Limitations
 * Currently only GCC, Clang and MSC++ are supported.
-* On GCC, optimization flag O2 and O3 are not supported. You bust compile the test project with -O1 or -O0.
+* On GCC, optimization flag O2 and O3 are not supported. You must compile the test project with -O1 or -O0.
 * In MSC++, your project must have Edit And Continue debug mode on (https://msdn.microsoft.com/en-us/library/esaeyddf.aspx) which is same of /ZI compiler switch. If you don't use this, you will have exceptions mocking destructors (which includes unique_ptr and other smart pointers). 
 * Can't mock classes with multiple inheritance.
 * Can't mock classes with virtual inheritance.

--- a/build/makefile
+++ b/build/makefile
@@ -1,3 +1,5 @@
+LD := g++
+CXX := g++
 
 RM := rm -rf
 
@@ -7,38 +9,40 @@ OBJS += $(subst .cpp,.o,$(CPP_SRCS))
 
 CPP_DEPS += $(subst .cpp,.d,$(CPP_SRCS))
 
+EXE := .exe
+
 all: fakeit_test_application
 
 coverage: fakeit_test_application_with_coverage
 
 check: fakeit_test_application
-	./fakeit_tests.exe
+	./fakeit_tests$(EXE)
 
-fakeit_test_application: $(OBJS) 
-	@echo 'Building test application: fakeit_tests.exe'
+fakeit_test_application: $(OBJS)
+	@echo 'Building test application: fakeit_tests$(EXE)'
 	@echo 'Invoking: GCC C++ Linker'
-	g++ -flto -Wl,-allow-multiple-definition -o "fakeit_tests.exe" $(OBJS) 
-	@echo 'Finished building test application: fakeit_tests.exe'
+	$(LD) -flto -o "fakeit_tests$(EXE)" $(OBJS)
+	@echo 'Finished building test application: fakeit_tests$(EXE)'
 	@echo ' '
 
-fakeit_test_application_with_coverage: $(subst .cpp,_with_coverage,$(CPP_SRCS)) 
-	@echo 'Building test application: fakeit_tests.exe'
+fakeit_test_application_with_coverage: $(subst .cpp,_with_coverage,$(CPP_SRCS))
+	@echo 'Building test application: fakeit_tests$(EXE)'
 	@echo 'Invoking: GCC C++ Linker'
-	g++ --coverage -o "fakeit_tests.exe" $(OBJS) 
-	@echo 'Finished building test application: fakeit_tests.exe'
+	$(LD) --coverage -o "fakeit_tests$(EXE)" $(OBJS)
+	@echo 'Finished building test application: fakeit_tests$(EXE)'
 	@echo ' '
 
 %.o: ../tests/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	g++ -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	$(CXX) -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 
 %_with_coverage: ../tests/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	g++ --coverage -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%_with_coverage=%.d)" -MT"$(@:%_with_coverage=%.d)" -o $(subst _with_coverage,.o,"$@") "$<"
+	$(CXX) --coverage -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%_with_coverage=%.d)" -MT"$(@:%_with_coverage=%.d)" -o $(subst _with_coverage,.o,"$@") "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 
@@ -48,5 +52,5 @@ endif
 
 # Other Targets
 clean:
-	-$(RM) $(OBJS)$(CPP_DEPS) fakeit_tests.exe *.gc*
+	-$(RM) $(OBJS)$(CPP_DEPS) fakeit_tests$(EXE) *.gc*
 	-@echo ' '

--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -3,7 +3,11 @@
 #include "fakeit/DefaultFakeit.hpp"
 #include "fakeit/EventHandler.hpp"
 #include "mockutils/to_string.hpp"
-#include "catch.hpp"
+#if __has_include("catch2/catch.hpp")
+#   include "catch2/catch.hpp"
+#else
+#   include "catch.hpp"
+#endif
 
 namespace fakeit {
 

--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -87,12 +87,13 @@ namespace fakeit {
                 std::string fomattedMessage,
                 Catch::ResultWas::OfType resultWas = Catch::ResultWas::OfType::ExpressionFailed ){
             Catch::AssertionHandler catchAssertionHandler( vetificationType, sourceLineInfo, failingExpression, Catch::ResultDisposition::Normal );
-            INTERNAL_CATCH_TRY( catchAssertionHandler ) { \
+            INTERNAL_CATCH_TRY { \
                 CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
-                catchAssertionHandler.handle( resultWas , fomattedMessage); \
+                catchAssertionHandler.handleMessage(resultWas, fomattedMessage); \
                 CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
-            } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
-            INTERNAL_CATCH_REACT( catchAssertionHandler )
+            } INTERNAL_CATCH_CATCH(catchAssertionHandler) { \
+                INTERNAL_CATCH_REACT(catchAssertionHandler) \
+            }
         }
 
         virtual void handle(const UnexpectedMethodCallEvent &evt) override {

--- a/config/cute/CuteFakeit.hpp
+++ b/config/cute/CuteFakeit.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "fakeit/DefaultFakeit.hpp"
+#include "cute.h"
+
+namespace fakeit {
+
+	struct CuteAdapter : public EventHandler {
+		virtual ~CuteAdapter() = default;
+
+		CuteAdapter(EventFormatter &formatter)
+			: _formatter(formatter) {
+		}
+
+		virtual void handle(const UnexpectedMethodCallEvent &evt) override {
+			std::string format = _formatter.format(evt);
+			throw std::string(format);
+        }
+
+		virtual void handle(const SequenceVerificationEvent &evt) override {
+			std::string format(_formatter.format(evt));
+			throw cute::test_failure(format, evt.file(), evt.line());
+
+        }
+
+		virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {
+			std::string format = _formatter.format(evt);
+			throw cute::test_failure(format, evt.file(), evt.line());
+        }
+
+	private:
+		EventFormatter &_formatter;
+	};
+
+    class CuteFakeit : public DefaultFakeit {
+
+    public:
+        virtual ~CuteFakeit() = default;
+
+        CuteFakeit(): _CuteAdapter(*this) {
+        }
+
+        static CuteFakeit &getInstance() {
+            static CuteFakeit instance;
+            return instance;
+        }
+        
+    protected:
+
+        fakeit::EventHandler &accessTestingFrameworkAdapter() override {
+            return _CuteAdapter;
+        }
+
+    private:
+
+        CuteAdapter _CuteAdapter;
+    };
+}

--- a/config/cute/CuteFakeit.hpp
+++ b/config/cute/CuteFakeit.hpp
@@ -20,7 +20,6 @@ namespace fakeit {
 		virtual void handle(const SequenceVerificationEvent &evt) override {
 			std::string format(_formatter.format(evt));
 			throw cute::test_failure(format, evt.file(), evt.line());
-
         }
 
 		virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {

--- a/config/cute/fakeit.hpp
+++ b/config/cute/fakeit.hpp
@@ -1,0 +1,7 @@
+#ifndef fakeit_h__
+#define fakeit_h__
+
+#include "fakeit_instance.hpp"
+#include "fakeit/fakeit_root.hpp"
+
+#endif

--- a/config/cute/fakeit_instance.hpp
+++ b/config/cute/fakeit_instance.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "CuteFakeit.hpp"
+
+static fakeit::DefaultFakeit& Fakeit = fakeit::CuteFakeit::getInstance();

--- a/config/nunit/NUnitFakeit.hpp
+++ b/config/nunit/NUnitFakeit.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "fakeit/DefaultFakeit.hpp"
+
+namespace fakeit {
+
+	struct NUnitAdapter : public EventHandler {
+		virtual ~NUnitAdapter() = default;
+
+		NUnitAdapter(EventFormatter &formatter)
+			: _formatter(formatter) {
+		}
+
+		virtual void handle(const UnexpectedMethodCallEvent &evt) override {
+			std::string format = _formatter.format(evt);
+			NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+		}
+
+		virtual void handle(const SequenceVerificationEvent &evt) override {
+			std::string format(_formatter.format(evt));
+			//The GTest example I copied used evt.file(), evt.line(), and ::testing::TestPartResult::kFatalFailure
+			//I am not here for simplicity. 
+			NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+	        }
+
+		virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {
+			std::string format = _formatter.format(evt);
+			//The GTest example I copied used evt.file(), evt.line(), and ::testing::TestPartResult::kFatalFailure
+			//I am not here for simplicity. 
+			NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+	        }
+
+	private:
+		EventFormatter &_formatter;
+	};
+
+    class NUnitFakeit : public DefaultFakeit {
+
+    public:
+        virtual ~NUnitFakeit() = default;
+
+        NUnitFakeit(): _nUnitAdapter(*this) {
+        }
+
+        static NUnitFakeit &getInstance() {
+            static NUnitFakeit instance;
+            return instance;
+        }
+        
+    protected:
+
+        fakeit::EventHandler &accessTestingFrameworkAdapter() override {
+            return _nUnitAdapter;
+        }
+
+    private:
+
+        NUnitAdapter _nUnitAdapter;
+    };
+}

--- a/config/nunit/fakeit.hpp
+++ b/config/nunit/fakeit.hpp
@@ -1,0 +1,7 @@
+#ifndef fakeit_h__
+#define fakeit_h__
+
+#include "fakeit_instance.hpp"
+#include "fakeit/fakeit_root.hpp"
+
+#endif

--- a/config/nunit/fakeit_instance.hpp
+++ b/config/nunit/fakeit_instance.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "NUnitFakeit.hpp"
+
+/**
+ * The main instance of Fakeit for use from tests.
+ */
+static fakeit::DefaultFakeit& Fakeit = fakeit::NUnitFakeit::getInstance();
+
+/**
+ * There are funny rules in managed C++ about when native code can create static objects. It is a very
+ * long story. Short of it is: if you get a crash about atExit not being valid outside of the default
+ * domain, then you need to make sure that the function creating the static object is called from a static
+ * scope. 
+ * This statement fixes that crash for UnknownMethod::instance.
+ * Some additional information is here: https://www.codeproject.com/Articles/442784/Best-gotchas-of-Cplusplus-CLI
+ */
+static fakeit::MethodInfo& scopeFixer = fakeit::UnknownMethod::instance();
+

--- a/config/nunit/fakeit_instance.hpp
+++ b/config/nunit/fakeit_instance.hpp
@@ -17,3 +17,5 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::NUnitFakeit::getInstance();
  */
 static fakeit::MethodInfo& scopeFixer = fakeit::UnknownMethod::instance();
 
+// NOTE: You may find it highly useful to use a section with #pragma unmanaged when writing mocks because it 
+// will allow you to use lamba expressions.

--- a/include/fakeit/DefaultEventFormatter.hpp
+++ b/include/fakeit/DefaultEventFormatter.hpp
@@ -20,7 +20,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -63,7 +63,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -110,8 +110,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";

--- a/include/fakeit/DefaultEventFormatter.hpp
+++ b/include/fakeit/DefaultEventFormatter.hpp
@@ -110,8 +110,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";

--- a/include/fakeit/FakeitContext.hpp
+++ b/include/fakeit/FakeitContext.hpp
@@ -11,6 +11,9 @@
 #include <vector>
 #include "fakeit/EventHandler.hpp"
 #include "fakeit/EventFormatter.hpp"
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 

--- a/include/fakeit/FakeitExceptions.hpp
+++ b/include/fakeit/FakeitExceptions.hpp
@@ -8,9 +8,20 @@
 #pragma once
 
 #include "fakeit/FakeitEvents.hpp"
+#include <exception>
+
 
 namespace fakeit {
-    
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
+
     struct FakeitException {
         std::exception err;
 

--- a/include/fakeit/MatchAnalysis.hpp
+++ b/include/fakeit/MatchAnalysis.hpp
@@ -12,15 +12,10 @@ namespace fakeit {
         std::vector<Invocation *> actualSequence;
         std::vector<Invocation *> matchedInvocations;
         int count;
-		// After this index in actualSequence, there are no more matches of the expected pattern
-		// We may use this for better formatting of the verification error.
-		int noMatchZoneStart;
 
         void run(InvocationsSourceProxy &involvedInvocationSources, std::vector<Sequence *> &expectedPattern) {
             getActualInvocationSequence(involvedInvocationSources, actualSequence);
-			noMatchZoneStart = 0;
-			count = 0;
-			countMatches(expectedPattern, actualSequence, matchedInvocations);
+            count = countMatches(expectedPattern, actualSequence, matchedInvocations);
         }
 
     private:
@@ -31,13 +26,16 @@ namespace fakeit {
             InvocationUtils::sortByInvocationOrder(actualInvocations, actualSequence);
         }
 
-        void countMatches(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
+        static int countMatches(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
                                 std::vector<Invocation *> &matchedInvocations) {
             int end = -1;
-            while (findNextMatch(pattern, actualSequence, noMatchZoneStart, end, matchedInvocations)) {
+            int count = 0;
+            int startSearchIndex = 0;
+            while (findNextMatch(pattern, actualSequence, startSearchIndex, end, matchedInvocations)) {
                 count++;
-				noMatchZoneStart = end;
+                startSearchIndex = end;
             }
+            return count;
         }
 
         static void collectActualInvocations(InvocationsSourceProxy &involvedMocks,

--- a/include/fakeit/MatchAnalysis.hpp
+++ b/include/fakeit/MatchAnalysis.hpp
@@ -12,10 +12,15 @@ namespace fakeit {
         std::vector<Invocation *> actualSequence;
         std::vector<Invocation *> matchedInvocations;
         int count;
+		// After this index in actualSequence, there are no more matches of the expected pattern
+		// We may use this for better formatting of the verification error.
+		int noMatchZoneStart;
 
         void run(InvocationsSourceProxy &involvedInvocationSources, std::vector<Sequence *> &expectedPattern) {
             getActualInvocationSequence(involvedInvocationSources, actualSequence);
-            count = countMatches(expectedPattern, actualSequence, matchedInvocations);
+			noMatchZoneStart = 0;
+			count = 0;
+			countMatches(expectedPattern, actualSequence, matchedInvocations);
         }
 
     private:
@@ -26,16 +31,13 @@ namespace fakeit {
             InvocationUtils::sortByInvocationOrder(actualInvocations, actualSequence);
         }
 
-        static int countMatches(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
+        void countMatches(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
                                 std::vector<Invocation *> &matchedInvocations) {
             int end = -1;
-            int count = 0;
-            int startSearchIndex = 0;
-            while (findNextMatch(pattern, actualSequence, startSearchIndex, end, matchedInvocations)) {
+            while (findNextMatch(pattern, actualSequence, noMatchZoneStart, end, matchedInvocations)) {
                 count++;
-                startSearchIndex = end;
+				noMatchZoneStart = end;
             }
-            return count;
         }
 
         static void collectActualInvocations(InvocationsSourceProxy &involvedMocks,

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -17,6 +17,91 @@ namespace fakeit {
     }
     using namespace fakeit::internal;
 
+	// Function type manipulation utilities.
+	struct func_traits{
+
+	#ifdef _MSC_VER
+		// On MSC, always define the __cdecl variants. Only they are needed in x64.
+		#define CC_CDECL __cdecl
+	#else
+		// On non-MSC, don't worry about it.
+		#define CC_CDECL
+	#endif
+	
+		// These are the default implementations whose presence always makes sense.
+
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
+			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+		};
+	
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) volatile ))( arglist... ) {
+			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) const ))( arglist... ) {
+			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) ))( arglist... ) {
+			return vMethod;
+		};
+
+	// On 32-bit msc, define also the other calling conventions.
+	#if defined( _MSC_VER ) && ! defined( _WIN64 )
+
+		// __stdcall, used in normal functions and COM interfaces.
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
+			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+		};
+	
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
+			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const ))( arglist... ) {
+			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) ))( arglist... ) {
+			return vMethod;
+		};
+
+		// __thiscall, used in member functions.
+	
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
+			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+		};
+	
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
+			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const ))( arglist... ) {
+			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) ))( arglist... ) {
+			return vMethod;
+		};
+	#endif
+
+		template<typename Func>
+		using remove_cv_t = decltype( remove_cv( std::declval<Func>() ) );
+	};
+
     template<typename C, typename ... baseclasses>
     class Mock : public ActualInvocationsSource {
         MockImpl<C, baseclasses...> impl;
@@ -111,6 +196,9 @@ namespace fakeit {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
+
+		//template<int it, typename Method >
+//		auto stub( Method func ) -> decltype(  )
 
         DtorMockingContext dtor() {
             return impl.stubDtor();

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -35,7 +35,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+        
+		C &operator()() {
             return get();
         }
 

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -35,9 +35,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+//		std::shared_ptr<C> getShared() {
+//			return impl.getShared();
+//		}
         
 		C &operator()() {
             return get();

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -32,17 +32,17 @@ namespace fakeit {
 
 		template<typename T, typename R, typename... arglist>
 		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
-			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
 		};
 	
 		template<typename T, typename R, typename... arglist>
 		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) volatile ))( arglist... ) {
-			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
 		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) const ))( arglist... ) {
-			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
@@ -57,17 +57,17 @@ namespace fakeit {
 
 		template<typename T, typename R, typename... arglist>
 		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
-			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
 		};
 	
 		template<typename T, typename R, typename... arglist>
 		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
-			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
 		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const ))( arglist... ) {
-			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
@@ -79,17 +79,17 @@ namespace fakeit {
 	
 		template<typename T, typename R, typename... arglist>
 		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
-			return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
 		};
 	
 		template<typename T, typename R, typename... arglist>
 		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
-			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
 		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const ))( arglist... ) {
-			return reinterpret_cast<void (__stdcall T::*)(arglist...)>(vMethod)
+			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
@@ -136,66 +136,30 @@ namespace fakeit {
 			impl.clear();
 		}
 
-        template<class DATA_TYPE, typename ... arglist,
+		template<class DATA_TYPE, typename ... arglist,
                 class = typename std::enable_if<std::is_member_object_pointer<DATA_TYPE C::*>::value>::type>
         DataMemberStubbingRoot<C, DATA_TYPE> Stub(DATA_TYPE C::* member, const arglist &... ctorargs) {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
+        MockingContext<R, arglist...> stubImpl(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
+        MockingContext<void, arglist...> stubImpl(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
+		template<int id, typename Func>
+		auto stub( Func func ) -> decltype( stubImpl<id>( func_traits::remove_cv( func ) ) )
+		{
+			return stubImpl<id>( func_traits::remove_cv( func ) );
+		}
 
 		//template<int it, typename Method >
 //		auto stub( Method func ) -> decltype(  )
@@ -209,5 +173,4 @@ namespace fakeit {
         }
 
     };
-
 }

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -78,22 +78,22 @@ namespace fakeit {
 		// __thiscall, used in member functions.
 	
 		template<typename T, typename R, typename... arglist>
-		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
 			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
 		};
 	
 		template<typename T, typename R, typename... arglist>
-		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
-			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
+			return reinterpret_cast< R( __thiscall T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
-		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const ))( arglist... ) {
-			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) const ))( arglist... ) {
+			return reinterpret_cast< R( __thiscall T::* )( arglist... ) >( vMethod );
 		};
 
 		template<typename T, typename R, typename... arglist>
-		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) ))( arglist... ) {
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) ))( arglist... ) {
 			return vMethod;
 		};
 	#endif

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -152,7 +152,8 @@ namespace fakeit {
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stubImpl(R(CC_CDECL T::*vMethod)(arglist...)) {
-            return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethod ) );
+			auto vMethodWithoutConstVolatile = reinterpret_cast< void( CC_CDECL T::* )( arglist... ) >( vMethod );
+            return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethodWithoutConstVolatile ) );
         }
 
 		// On 32-bit msc, define also the other calling conventions.
@@ -168,7 +169,8 @@ namespace fakeit {
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
 			MockingContext<void, arglist...> stubImpl( R( __stdcall T::* vMethod )( arglist... ) )
 		{
-			return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethod ) );
+			auto vMethodWithoutConstVolatile = reinterpret_cast< void( __stdcall T::* )( arglist... ) >( vMethod );
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethodWithoutConstVolatile ) );
 		}
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
@@ -181,7 +183,8 @@ namespace fakeit {
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
 			MockingContext<void, arglist...> stubImpl( R( __thiscall T::* vMethod )( arglist... ) )
 		{
-			return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethod ) );
+			auto vMethodWithoutConstVolatile = reinterpret_cast< void( __thiscall T::* )( arglist... ) >( vMethod );
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethodWithoutConstVolatile ) );
 		}
 
 	#endif

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -146,14 +146,17 @@ namespace fakeit {
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubImpl(R(CC_CDECL T::*vMethod)(arglist...)) {
-            return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethod ) );
+			R( CC_CDECL C:: * cMethod )( arglist... ) = vMethod;
+            return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stubImpl(R(CC_CDECL T::*vMethod)(arglist...)) {
 			auto vMethodWithoutConstVolatile = reinterpret_cast< void( CC_CDECL T::* )( arglist... ) >( vMethod );
-            return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethodWithoutConstVolatile ) );
+			// Convert to a pointer to a method of C so that Wrap generates a correctly typed FuncWithConvention.
+			void( CC_CDECL C:: * cMethod )( arglist... ) = vMethodWithoutConstVolatile;
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
         }
 
 		// On 32-bit msc, define also the other calling conventions.
@@ -162,7 +165,8 @@ namespace fakeit {
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubImpl(R(__stdcall T::*vMethod)(arglist...)) {
-            return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethod ) );
+			R( __stdcall C:: * cMethod )( arglist... ) = vMethod;
+            return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
@@ -170,13 +174,17 @@ namespace fakeit {
 			MockingContext<void, arglist...> stubImpl( R( __stdcall T::* vMethod )( arglist... ) )
 		{
 			auto vMethodWithoutConstVolatile = reinterpret_cast< void( __stdcall T::* )( arglist... ) >( vMethod );
-			return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethodWithoutConstVolatile ) );
+			// Convert to a pointer to a method of C so that Wrap generates a correctly typed FuncWithConvention.
+			void( __stdcall C:: * cMethod )( arglist... ) = vMethodWithoutConstVolatile;
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
 		}
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubImpl(R(__thiscall T::*vMethod)(arglist...)) {
-            return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethod ) );
+			// Convert to a pointer to a method of C so that Wrap generates a correctly typed FuncWithConvention.
+			R( __thiscall C:: * cMethod )( arglist... ) = vMethod;
+            return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
@@ -184,7 +192,9 @@ namespace fakeit {
 			MockingContext<void, arglist...> stubImpl( R( __thiscall T::* vMethod )( arglist... ) )
 		{
 			auto vMethodWithoutConstVolatile = reinterpret_cast< void( __thiscall T::* )( arglist... ) >( vMethod );
-			return impl.template stubMethod<id>( ConventionHelper::Wrap( vMethodWithoutConstVolatile ) );
+			// Convert to a pointer to a method of C so that Wrap generates a correctly typed FuncWithConvention.
+			void( __thiscall C:: * cMethod )( arglist... ) = vMethodWithoutConstVolatile;
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
 		}
 
 	#endif

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -19,6 +19,7 @@
 #include "fakeit/DomainObjects.hpp"
 #include "fakeit/FakeitContext.hpp"
 #include "fakeit/ActualInvocationHandler.hpp"
+#include "mockutils/mscpp/FunctionWithConvention.hpp"
 
 namespace fakeit {
 
@@ -89,9 +90,9 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DATA_TYPE>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
-            return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
+        template<int id, typename R, typename CONVENTION, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stubMethod( FuncWithConvention< T, R, CONVENTION, arglist... > vMethod ) {
+            return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, CONVENTION, arglist... >
                    (*this, vMethod));
         }
 
@@ -167,20 +168,20 @@ namespace fakeit {
 
         };
 
-        template<typename R, typename ... arglist>
+        
+        template<typename R, typename CONVENTION, typename ... arglist>
         class MethodMockingContextImpl : public MethodMockingContextBase<R, arglist...> {
         protected:
 
-            R (C::*_vMethod)(arglist...);
-            
+           FuncWithConvention<C, R, CONVENTION, arglist...> _vMethod;
+
         public:
             virtual ~MethodMockingContextImpl() = default;
 
-            MethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
+            MethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, FuncWithConvention<C, R, CONVENTION, arglist...> vMethod)
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
 
-            
             virtual std::function<R(arglist&...)> getOriginalMethod() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
                 C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
@@ -191,21 +192,20 @@ namespace fakeit {
             }
         };
 
-
-        template<int id, typename R, typename ... arglist>
-        class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
+        template<int id, typename R, typename CONVENTION, typename ... arglist>
+        class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, CONVENTION, arglist...> {
         protected:
 
             virtual RecordedMethodBody<R, arglist...> &getRecordedMethodBody() override {
                 return MethodMockingContextBase<R, arglist...>::_mock.template stubMethodIfNotStubbed<id>(
                         MethodMockingContextBase<R, arglist...>::_mock._proxy,
-                        MethodMockingContextImpl<R, arglist...>::_vMethod);
+                        MethodMockingContextImpl<R, CONVENTION, arglist...>::_vMethod);
             }
 
         public:
 
-            UniqueMethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
-                    : MethodMockingContextImpl<R, arglist...>(mock, vMethod) {
+            UniqueMethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, FuncWithConvention<C, R, CONVENTION, arglist...> vMethod)
+                    : MethodMockingContextImpl<R, CONVENTION, arglist...>(mock, vMethod) {
             }
         };
 
@@ -265,8 +265,8 @@ namespace fakeit {
 			return reinterpret_cast<C *>(fake);
         }
 
-        template<typename R, typename ... arglist>
-        void *getOriginalMethod(R (C::*vMethod)(arglist...)) {
+        template<typename R, typename CONVENTION, typename ... arglist>
+        void *getOriginalMethod(FuncWithConvention<C, R, CONVENTION, arglist...> vMethod) {
             auto vt = _proxy.getOriginalVT();
             auto offset = VTUtils::getOffset(vMethod);
             void *origMethodPtr = vt.getMethod(offset);

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -90,8 +90,8 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DATA_TYPE>();
         }
 
-        template<int id, typename R, typename CONVENTION, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stubMethod( FuncWithConvention< T, R, CONVENTION, arglist... > vMethod ) {
+        template<int id, typename R, typename CONVENTION, typename ... arglist>
+        MockingContext<R, arglist...> stubMethod( FuncWithConvention< C, R, CONVENTION, arglist... > vMethod ) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, CONVENTION, arglist... >
                    (*this, vMethod));
         }

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -235,7 +235,7 @@ namespace fakeit {
         }
 
         static C *createFakeInstance() {
-            FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>(1);
+            FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
 			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
 			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
@@ -283,7 +283,7 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _fakeit(fakeit), _isOwner(!isSpy) {
+                : _isOwner(!isSpy), _instance(&obj), _fakeit(fakeit), pInstance(nullptr), _proxy{ obj }  {
         }
 
         template<typename R, typename ... arglist>

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -99,11 +99,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+//		std::shared_ptr<C> getShared() {
+//			auto * a = &_instanceOwner;
+//			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+//			return *b;
+//		}
 
     private:
 		// Keep members in this order! _proxy should be deleted before _inatanceOwner.

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -280,11 +280,11 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<unsigned int id, typename R, typename CONVENTION, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
-                                                                  R (C::*vMethod)(arglist...)) {
+                                                                  FuncWithConvention<C, R, CONVENTION, arglist... > vMethod ) {
             if (!proxy.isMethodStubbed(vMethod)) {
-                proxy.template stubMethod<id>(vMethod, createRecordedMethodBody < R, arglist... > (*this, vMethod));
+                proxy.template stubMethod<id>(vMethod, createRecordedMethodBody <R, CONVENTION, arglist... > (*this, vMethod ));
             }
             Destructible *d = proxy.getMethodMock(vMethod);
             RecordedMethodBody<R, arglist...> *methodMock = dynamic_cast<RecordedMethodBody<R, arglist...> *>(d);
@@ -300,10 +300,10 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        template<typename R, typename ... arglist>
+        template<typename R, typename CONVENTION, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
-                                                                           R(C::*vMethod)(arglist...)) {
-            return new RecordedMethodBody<R, arglist...>(mock.getFakeIt(), typeid(vMethod).name());
+                                                                           FuncWithConvention<C, R, CONVENTION, arglist... > vMethod) {
+            return new RecordedMethodBody<R, arglist...>(mock.getFakeIt(), typeid(vMethod._vMethod).name());
         }
 
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -99,6 +99,12 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
         DynamicProxy<C, baseclasses...> _proxy;
         C *_instance; //
@@ -298,6 +304,5 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }

--- a/include/fakeit/SequenceVerificationExpectation.hpp
+++ b/include/fakeit/SequenceVerificationExpectation.hpp
@@ -13,7 +13,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);

--- a/include/fakeit/SequenceVerificationExpectation.hpp
+++ b/include/fakeit/SequenceVerificationExpectation.hpp
@@ -104,12 +104,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/include/fakeit/VerifyNoOtherInvocationsVerificationProgress.hpp
+++ b/include/fakeit/VerifyNoOtherInvocationsVerificationProgress.hpp
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include "fakeit/FakeitExceptions.hpp"
 #include "fakeit/FakeitContext.hpp"
 #include "fakeit/ThrowFalseEventHandler.hpp"
 
@@ -22,7 +23,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/include/fakeit/WhenFunctor.hpp
+++ b/include/fakeit/WhenFunctor.hpp
@@ -10,6 +10,7 @@
 #include "fakeit/StubbingImpl.hpp"
 #include "fakeit/StubbingProgress.hpp"
 #include "fakeit/FakeitContext.hpp"
+#include "fakeit/FakeitExceptions.hpp"
 
 #include "mockutils/smart_ptr.hpp"
 #include "mockutils/Destructible.hpp"
@@ -25,7 +26,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/include/fakeit/api_macros.hpp
+++ b/include/fakeit/api_macros.hpp
@@ -5,7 +5,7 @@
 #endif
 
 #define MOCK_TYPE(mock) \
-    std::remove_reference<decltype(mock.get())>::type
+    std::remove_reference<decltype((mock).get())>::type
 
 #define OVERLOADED_METHOD_PTR(mock, method, prototype) \
     fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
@@ -14,16 +14,16 @@
     fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
 
 #define Dtor(mock) \
-    mock.dtor().setMethodDetails(#mock,"destructor")
+    (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -76,12 +76,17 @@ namespace fakeit {
         }
 
         void detach() {
-            getFake().setVirtualTable(originalVtHandle.restore());
-        }
+			//_methodMocks = {};
+			//_methodMocks.resize(VTUtils::getVTSize<C>());
+			//_members = {};
+			//_offsets = {};
+			//_offsets.resize(VTUtils::getVTSize<C>());
+		}
 
         ~DynamicProxy() {
-            _cloneVt.dispose();
-        }
+			getFake().setVirtualTable(originalVtHandle.restore());
+			_cloneVt.dispose();
+		}
 
         C &get() {
             return instance;

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -100,17 +100,23 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
-        void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
+        template<int id, typename R, typename CONVENTION, typename ... arglist>
+        void stubMethod(FuncWithConvention<C, R, CONVENTION, arglist... > vMethod, MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
-            MethodProxyCreator<R, arglist...> creator;
-            bind(creator.template createMethodProxy<id + 1>(offset), methodInvocationHandler);
+            MethodProxyCreator<R, CONVENTION, arglist...> creator;
+            bind(creator.createMethodProxy<id + 1, CONVENTION>(offset), methodInvocationHandler);
         }
 
         void stubDtor(MethodInvocationHandler<void> *methodInvocationHandler) {
             auto offset = VTUtils::getDestructorOffset<C>();
             MethodProxyCreator<void> creator;
             bindDtor(creator.createMethodProxy<0>(offset), methodInvocationHandler);
+        }
+
+        template<typename R, typename CONVENTION, typename ... arglist>
+        bool isMethodStubbed(FuncWithConvention<C, R, CONVENTION, arglist... > vMethod) {
+            unsigned int offset = VTUtils::getOffset(vMethod);
+            return isBinded(offset);
         }
 
         template<typename R, typename ... arglist>
@@ -124,8 +130,8 @@ namespace fakeit {
             return isBinded(offset);
         }
 
-        template<typename R, typename ... arglist>
-        Destructible *getMethodMock(R(C::*vMethod)(arglist...)) {
+        template<typename R, typename CONVENTION, typename ... arglist>
+        Destructible *getMethodMock(FuncWithConvention<C, R, CONVENTION, arglist... > vMethod) {
             auto offset = VTUtils::getOffset(vMethod);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -109,8 +109,9 @@ namespace fakeit {
 
         void stubDtor(MethodInvocationHandler<void> *methodInvocationHandler) {
             auto offset = VTUtils::getDestructorOffset<C>();
-            MethodProxyCreator<void> creator;
-            bindDtor(creator.createMethodProxy<0>(offset), methodInvocationHandler);
+			// For the cases we care about (COM), the destructor uses the default calling convention.
+            MethodProxyCreator<void, ConventionHelper::DefaultConvention> creator;
+            bindDtor(creator.createMethodProxy<0,ConventionHelper::DefaultConvention>(offset), methodInvocationHandler);
         }
 
         template<typename R, typename CONVENTION, typename ... arglist>

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -76,17 +76,12 @@ namespace fakeit {
         }
 
         void detach() {
-			//_methodMocks = {};
-			//_methodMocks.resize(VTUtils::getVTSize<C>());
-			//_members = {};
-			//_offsets = {};
-			//_offsets.resize(VTUtils::getVTSize<C>());
-		}
+            getFake().setVirtualTable(originalVtHandle.restore());
+        }
 
         ~DynamicProxy() {
-			getFake().setVirtualTable(originalVtHandle.restore());
-			_cloneVt.dispose();
-		}
+            _cloneVt.dispose();
+        }
 
         C &get() {
             return instance;

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include "mockutils/VirtualTable.hpp"
 #include "mockutils/union_cast.hpp"

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
@@ -46,7 +47,7 @@ namespace fakeit {
                 _methodMocks(methodMocks), _offsets(offsets) {
 			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
-				*it = INT_MAX;
+				*it = std::numeric_limits<int>::max();
 			}
         }
 

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -43,6 +43,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = INT_MAX;
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {

--- a/include/mockutils/FakeObject.hpp
+++ b/include/mockutils/FakeObject.hpp
@@ -15,6 +15,7 @@ namespace fakeit {
 // silent GCC compiler warning: iso c++ forbids zero-size array [-Wpedantic]
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif

--- a/include/mockutils/FakeObject.hpp
+++ b/include/mockutils/FakeObject.hpp
@@ -39,7 +39,7 @@ namespace fakeit {
 
     public:
 
-        FakeObject(int a) : vtable() {
+        FakeObject() : vtable() {
             initializeDataMembersArea();
         }
 

--- a/include/mockutils/FakeObject.hpp
+++ b/include/mockutils/FakeObject.hpp
@@ -39,7 +39,7 @@ namespace fakeit {
 
     public:
 
-        FakeObject() : vtable() {
+        FakeObject(int a) : vtable() {
             initializeDataMembersArea();
         }
 

--- a/include/mockutils/Formatter.hpp
+++ b/include/mockutils/Formatter.hpp
@@ -37,6 +37,35 @@ namespace fakeit {
 		}
 	};
 
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
+		}
+	};
+
 	template<class C>
 	struct Formatter<C, typename std::enable_if<!is_ostreamable<C>::value>::type> {
 		static std::string format(C const &)

--- a/include/mockutils/VTUtils.hpp
+++ b/include/mockutils/VTUtils.hpp
@@ -14,7 +14,8 @@
 #include "mockutils/union_cast.hpp"
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -40,6 +41,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {

--- a/include/mockutils/VTUtils.hpp
+++ b/include/mockutils/VTUtils.hpp
@@ -46,7 +46,8 @@ namespace fakeit {
         template<typename C>
         static typename std::enable_if<std::has_virtual_destructor<C>::value, unsigned int>::type
         getDestructorOffset() {
-            VirtualOffsetSelector offsetSelctor;
+			// Destructors always use the default convention (at least when dealing with COM, which is all we care about).
+            VirtualOffsetSelector<ConventionHelper::DefaultConvention> offsetSelctor;
             union_cast<C *>(&offsetSelctor)->~C();
             return offsetSelctor.offset;
         }

--- a/include/mockutils/VTUtils.hpp
+++ b/include/mockutils/VTUtils.hpp
@@ -76,7 +76,7 @@ namespace fakeit {
                 }
             };
 
-            unsigned int vtSize = getOffset(&Derrived::endOfVt);
+            unsigned int vtSize = getOffset( ConventionHelper::Wrap( &Derrived::endOfVt ) );
             return vtSize;
         }
     };

--- a/include/mockutils/VTUtils.hpp
+++ b/include/mockutils/VTUtils.hpp
@@ -14,7 +14,8 @@
 #include "mockutils/union_cast.hpp"
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 

--- a/include/mockutils/VTUtils.hpp
+++ b/include/mockutils/VTUtils.hpp
@@ -22,10 +22,24 @@ namespace fakeit {
     class VTUtils {
     public:
 
+        template<typename C, typename R,  typename ... arglist>
+        static unsigned int getOffset(FuncWithConvention<C, R, Thiscall, arglist...> vMethod) {
+            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector<Thiscall>::*)(int)>(vMethod._vMethod);
+            VirtualOffsetSelector<Thiscall> offsetSelctor;
+            return (offsetSelctor.*sMethod)(0);
+        }
+
+        template<typename C, typename R,  typename ... arglist>
+        static unsigned int getOffset(FuncWithConvention<C, R, Cdecl, arglist...> vMethod) {
+            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector<Cdecl>::*)(int)>(vMethod._vMethod);
+            VirtualOffsetSelector<Cdecl> offsetSelctor;
+            return (offsetSelctor.*sMethod)(0);
+        }
+
         template<typename C, typename R, typename ... arglist>
-        static unsigned int getOffset(R (C::*vMethod)(arglist...)) {
-            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector::*)(int)>(vMethod);
-            VirtualOffsetSelector offsetSelctor;
+        static unsigned int getOffset(FuncWithConvention<C, R, Stdcall, arglist...> vMethod) {
+            auto sMethod = reinterpret_cast<unsigned int (__stdcall VirtualOffsetSelector<Stdcall>::*)(int)>(vMethod._vMethod);
+            VirtualOffsetSelector<Stdcall> offsetSelctor;
             return (offsetSelctor.*sMethod)(0);
         }
 

--- a/include/mockutils/VirtualOffestSelector.hpp
+++ b/include/mockutils/VirtualOffestSelector.hpp
@@ -9,6 +9,9 @@
 
 namespace fakeit {
 
+    /// This class contains virtual methods that return their position in the virtual method table.
+    /// Casting a pointer to the n:th virtual method of a class to a pointer to a method of this class
+    /// will return a pointer to the n:th virtual method of this class, which when called will return n.
     struct VirtualOffsetSelector {
 
         unsigned int offset;

--- a/include/mockutils/VirtualOffestSelector.hpp
+++ b/include/mockutils/VirtualOffestSelector.hpp
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include "mockutils/mscpp/FunctionWithConvention.hpp"
+
 namespace fakeit {
 
     /// This class contains virtual methods that return their position in the virtual method table.

--- a/include/mockutils/VirtualOffestSelector.hpp
+++ b/include/mockutils/VirtualOffestSelector.hpp
@@ -12,4021 +12,4031 @@ namespace fakeit {
     /// This class contains virtual methods that return their position in the virtual method table.
     /// Casting a pointer to the n:th virtual method of a class to a pointer to a method of this class
     /// will return a pointer to the n:th virtual method of this class, which when called will return n.
-    struct VirtualOffsetSelector {
-
-        unsigned int offset;
-
-        virtual unsigned int offset0(int) {
-            return offset = 0;
-        }
-
-        virtual unsigned int offset1(int) {
-            return offset = 1;
-        }
-
-        virtual unsigned int offset2(int) {
-            return offset = 2;
-        }
-
-        virtual unsigned int offset3(int) {
-            return offset = 3;
-        }
-
-        virtual unsigned int offset4(int) {
-            return offset = 4;
-        }
-
-        virtual unsigned int offset5(int) {
-            return offset = 5;
-        }
-
-        virtual unsigned int offset6(int) {
-            return offset = 6;
-        }
-
-        virtual unsigned int offset7(int) {
-            return offset = 7;
-        }
-
-        virtual unsigned int offset8(int) {
-            return offset = 8;
-        }
-
-        virtual unsigned int offset9(int) {
-            return offset = 9;
-        }
-
-        virtual unsigned int offset10(int) {
-            return offset = 10;
-        }
-
-        virtual unsigned int offset11(int) {
-            return offset = 11;
-        }
-
-        virtual unsigned int offset12(int) {
-            return offset = 12;
-        }
-
-        virtual unsigned int offset13(int) {
-            return offset = 13;
-        }
-
-        virtual unsigned int offset14(int) {
-            return offset = 14;
-        }
-
-        virtual unsigned int offset15(int) {
-            return offset = 15;
-        }
-
-        virtual unsigned int offset16(int) {
-            return offset = 16;
-        }
-
-        virtual unsigned int offset17(int) {
-            return offset = 17;
-        }
-
-        virtual unsigned int offset18(int) {
-            return offset = 18;
-        }
-
-        virtual unsigned int offset19(int) {
-            return offset = 19;
-        }
-
-        virtual unsigned int offset20(int) {
-            return offset = 20;
-        }
-
-        virtual unsigned int offset21(int) {
-            return offset = 21;
-        }
-
-        virtual unsigned int offset22(int) {
-            return offset = 22;
-        }
-
-        virtual unsigned int offset23(int) {
-            return offset = 23;
-        }
-
-        virtual unsigned int offset24(int) {
-            return offset = 24;
-        }
-
-        virtual unsigned int offset25(int) {
-            return offset = 25;
-        }
-
-        virtual unsigned int offset26(int) {
-            return offset = 26;
-        }
-
-        virtual unsigned int offset27(int) {
-            return offset = 27;
-        }
-
-        virtual unsigned int offset28(int) {
-            return offset = 28;
-        }
-
-        virtual unsigned int offset29(int) {
-            return offset = 29;
-        }
-
-        virtual unsigned int offset30(int) {
-            return offset = 30;
-        }
-
-        virtual unsigned int offset31(int) {
-            return offset = 31;
-        }
-
-        virtual unsigned int offset32(int) {
-            return offset = 32;
-        }
-
-        virtual unsigned int offset33(int) {
-            return offset = 33;
-        }
-
-        virtual unsigned int offset34(int) {
-            return offset = 34;
-        }
-
-        virtual unsigned int offset35(int) {
-            return offset = 35;
-        }
-
-        virtual unsigned int offset36(int) {
-            return offset = 36;
-        }
-
-        virtual unsigned int offset37(int) {
-            return offset = 37;
-        }
-
-        virtual unsigned int offset38(int) {
-            return offset = 38;
-        }
-
-        virtual unsigned int offset39(int) {
-            return offset = 39;
-        }
-
-        virtual unsigned int offset40(int) {
-            return offset = 40;
-        }
-
-        virtual unsigned int offset41(int) {
-            return offset = 41;
-        }
-
-        virtual unsigned int offset42(int) {
-            return offset = 42;
-        }
-
-        virtual unsigned int offset43(int) {
-            return offset = 43;
-        }
-
-        virtual unsigned int offset44(int) {
-            return offset = 44;
-        }
-
-        virtual unsigned int offset45(int) {
-            return offset = 45;
-        }
-
-        virtual unsigned int offset46(int) {
-            return offset = 46;
-        }
-
-        virtual unsigned int offset47(int) {
-            return offset = 47;
-        }
-
-        virtual unsigned int offset48(int) {
-            return offset = 48;
-        }
-
-        virtual unsigned int offset49(int) {
-            return offset = 49;
-        }
-
-        virtual unsigned int offset50(int) {
-            return offset = 50;
-        }
-
-        virtual unsigned int offset51(int) {
-            return offset = 51;
-        }
-
-        virtual unsigned int offset52(int) {
-            return offset = 52;
-        }
-
-        virtual unsigned int offset53(int) {
-            return offset = 53;
-        }
-
-        virtual unsigned int offset54(int) {
-            return offset = 54;
-        }
-
-        virtual unsigned int offset55(int) {
-            return offset = 55;
-        }
-
-        virtual unsigned int offset56(int) {
-            return offset = 56;
-        }
-
-        virtual unsigned int offset57(int) {
-            return offset = 57;
-        }
-
-        virtual unsigned int offset58(int) {
-            return offset = 58;
-        }
-
-        virtual unsigned int offset59(int) {
-            return offset = 59;
-        }
-
-        virtual unsigned int offset60(int) {
-            return offset = 60;
-        }
-
-        virtual unsigned int offset61(int) {
-            return offset = 61;
-        }
-
-        virtual unsigned int offset62(int) {
-            return offset = 62;
-        }
-
-        virtual unsigned int offset63(int) {
-            return offset = 63;
-        }
-
-        virtual unsigned int offset64(int) {
-            return offset = 64;
-        }
-
-        virtual unsigned int offset65(int) {
-            return offset = 65;
-        }
-
-        virtual unsigned int offset66(int) {
-            return offset = 66;
-        }
-
-        virtual unsigned int offset67(int) {
-            return offset = 67;
-        }
-
-        virtual unsigned int offset68(int) {
-            return offset = 68;
-        }
-
-        virtual unsigned int offset69(int) {
-            return offset = 69;
-        }
-
-        virtual unsigned int offset70(int) {
-            return offset = 70;
-        }
-
-        virtual unsigned int offset71(int) {
-            return offset = 71;
-        }
-
-        virtual unsigned int offset72(int) {
-            return offset = 72;
-        }
-
-        virtual unsigned int offset73(int) {
-            return offset = 73;
-        }
-
-        virtual unsigned int offset74(int) {
-            return offset = 74;
-        }
-
-        virtual unsigned int offset75(int) {
-            return offset = 75;
-        }
-
-        virtual unsigned int offset76(int) {
-            return offset = 76;
-        }
-
-        virtual unsigned int offset77(int) {
-            return offset = 77;
-        }
-
-        virtual unsigned int offset78(int) {
-            return offset = 78;
-        }
-
-        virtual unsigned int offset79(int) {
-            return offset = 79;
-        }
-
-        virtual unsigned int offset80(int) {
-            return offset = 80;
-        }
-
-        virtual unsigned int offset81(int) {
-            return offset = 81;
-        }
-
-        virtual unsigned int offset82(int) {
-            return offset = 82;
-        }
-
-        virtual unsigned int offset83(int) {
-            return offset = 83;
-        }
-
-        virtual unsigned int offset84(int) {
-            return offset = 84;
-        }
-
-        virtual unsigned int offset85(int) {
-            return offset = 85;
-        }
-
-        virtual unsigned int offset86(int) {
-            return offset = 86;
-        }
-
-        virtual unsigned int offset87(int) {
-            return offset = 87;
-        }
-
-        virtual unsigned int offset88(int) {
-            return offset = 88;
-        }
-
-        virtual unsigned int offset89(int) {
-            return offset = 89;
-        }
-
-        virtual unsigned int offset90(int) {
-            return offset = 90;
-        }
-
-        virtual unsigned int offset91(int) {
-            return offset = 91;
-        }
-
-        virtual unsigned int offset92(int) {
-            return offset = 92;
-        }
-
-        virtual unsigned int offset93(int) {
-            return offset = 93;
-        }
-
-        virtual unsigned int offset94(int) {
-            return offset = 94;
-        }
-
-        virtual unsigned int offset95(int) {
-            return offset = 95;
-        }
-
-        virtual unsigned int offset96(int) {
-            return offset = 96;
-        }
-
-        virtual unsigned int offset97(int) {
-            return offset = 97;
-        }
-
-        virtual unsigned int offset98(int) {
-            return offset = 98;
-        }
-
-        virtual unsigned int offset99(int) {
-            return offset = 99;
-        }
-
-        virtual unsigned int offset100(int) {
-            return offset = 100;
-        }
-
-        virtual unsigned int offset101(int) {
-            return offset = 101;
-        }
-
-        virtual unsigned int offset102(int) {
-            return offset = 102;
-        }
-
-        virtual unsigned int offset103(int) {
-            return offset = 103;
-        }
-
-        virtual unsigned int offset104(int) {
-            return offset = 104;
-        }
-
-        virtual unsigned int offset105(int) {
-            return offset = 105;
-        }
-
-        virtual unsigned int offset106(int) {
-            return offset = 106;
-        }
-
-        virtual unsigned int offset107(int) {
-            return offset = 107;
-        }
-
-        virtual unsigned int offset108(int) {
-            return offset = 108;
-        }
-
-        virtual unsigned int offset109(int) {
-            return offset = 109;
-        }
-
-        virtual unsigned int offset110(int) {
-            return offset = 110;
-        }
-
-        virtual unsigned int offset111(int) {
-            return offset = 111;
-        }
-
-        virtual unsigned int offset112(int) {
-            return offset = 112;
-        }
-
-        virtual unsigned int offset113(int) {
-            return offset = 113;
-        }
-
-        virtual unsigned int offset114(int) {
-            return offset = 114;
-        }
-
-        virtual unsigned int offset115(int) {
-            return offset = 115;
-        }
-
-        virtual unsigned int offset116(int) {
-            return offset = 116;
-        }
-
-        virtual unsigned int offset117(int) {
-            return offset = 117;
-        }
-
-        virtual unsigned int offset118(int) {
-            return offset = 118;
-        }
-
-        virtual unsigned int offset119(int) {
-            return offset = 119;
-        }
-
-        virtual unsigned int offset120(int) {
-            return offset = 120;
-        }
-
-        virtual unsigned int offset121(int) {
-            return offset = 121;
-        }
-
-        virtual unsigned int offset122(int) {
-            return offset = 122;
-        }
-
-        virtual unsigned int offset123(int) {
-            return offset = 123;
-        }
-
-        virtual unsigned int offset124(int) {
-            return offset = 124;
-        }
-
-        virtual unsigned int offset125(int) {
-            return offset = 125;
-        }
-
-        virtual unsigned int offset126(int) {
-            return offset = 126;
-        }
-
-        virtual unsigned int offset127(int) {
-            return offset = 127;
-        }
-
-        virtual unsigned int offset128(int) {
-            return offset = 128;
-        }
-
-        virtual unsigned int offset129(int) {
-            return offset = 129;
-        }
-
-        virtual unsigned int offset130(int) {
-            return offset = 130;
-        }
-
-        virtual unsigned int offset131(int) {
-            return offset = 131;
-        }
-
-        virtual unsigned int offset132(int) {
-            return offset = 132;
-        }
-
-        virtual unsigned int offset133(int) {
-            return offset = 133;
-        }
-
-        virtual unsigned int offset134(int) {
-            return offset = 134;
-        }
-
-        virtual unsigned int offset135(int) {
-            return offset = 135;
-        }
-
-        virtual unsigned int offset136(int) {
-            return offset = 136;
-        }
-
-        virtual unsigned int offset137(int) {
-            return offset = 137;
-        }
-
-        virtual unsigned int offset138(int) {
-            return offset = 138;
-        }
-
-        virtual unsigned int offset139(int) {
-            return offset = 139;
-        }
-
-        virtual unsigned int offset140(int) {
-            return offset = 140;
-        }
-
-        virtual unsigned int offset141(int) {
-            return offset = 141;
-        }
-
-        virtual unsigned int offset142(int) {
-            return offset = 142;
-        }
-
-        virtual unsigned int offset143(int) {
-            return offset = 143;
-        }
-
-        virtual unsigned int offset144(int) {
-            return offset = 144;
-        }
-
-        virtual unsigned int offset145(int) {
-            return offset = 145;
-        }
-
-        virtual unsigned int offset146(int) {
-            return offset = 146;
-        }
-
-        virtual unsigned int offset147(int) {
-            return offset = 147;
-        }
-
-        virtual unsigned int offset148(int) {
-            return offset = 148;
-        }
-
-        virtual unsigned int offset149(int) {
-            return offset = 149;
-        }
-
-        virtual unsigned int offset150(int) {
-            return offset = 150;
-        }
-
-        virtual unsigned int offset151(int) {
-            return offset = 151;
-        }
-
-        virtual unsigned int offset152(int) {
-            return offset = 152;
-        }
-
-        virtual unsigned int offset153(int) {
-            return offset = 153;
-        }
-
-        virtual unsigned int offset154(int) {
-            return offset = 154;
-        }
-
-        virtual unsigned int offset155(int) {
-            return offset = 155;
-        }
-
-        virtual unsigned int offset156(int) {
-            return offset = 156;
-        }
-
-        virtual unsigned int offset157(int) {
-            return offset = 157;
-        }
-
-        virtual unsigned int offset158(int) {
-            return offset = 158;
-        }
-
-        virtual unsigned int offset159(int) {
-            return offset = 159;
-        }
-
-        virtual unsigned int offset160(int) {
-            return offset = 160;
-        }
-
-        virtual unsigned int offset161(int) {
-            return offset = 161;
-        }
-
-        virtual unsigned int offset162(int) {
-            return offset = 162;
-        }
-
-        virtual unsigned int offset163(int) {
-            return offset = 163;
-        }
-
-        virtual unsigned int offset164(int) {
-            return offset = 164;
-        }
-
-        virtual unsigned int offset165(int) {
-            return offset = 165;
-        }
-
-        virtual unsigned int offset166(int) {
-            return offset = 166;
-        }
-
-        virtual unsigned int offset167(int) {
-            return offset = 167;
-        }
-
-        virtual unsigned int offset168(int) {
-            return offset = 168;
-        }
-
-        virtual unsigned int offset169(int) {
-            return offset = 169;
-        }
-
-        virtual unsigned int offset170(int) {
-            return offset = 170;
-        }
-
-        virtual unsigned int offset171(int) {
-            return offset = 171;
-        }
-
-        virtual unsigned int offset172(int) {
-            return offset = 172;
-        }
-
-        virtual unsigned int offset173(int) {
-            return offset = 173;
-        }
-
-        virtual unsigned int offset174(int) {
-            return offset = 174;
-        }
-
-        virtual unsigned int offset175(int) {
-            return offset = 175;
-        }
-
-        virtual unsigned int offset176(int) {
-            return offset = 176;
-        }
-
-        virtual unsigned int offset177(int) {
-            return offset = 177;
-        }
-
-        virtual unsigned int offset178(int) {
-            return offset = 178;
-        }
-
-        virtual unsigned int offset179(int) {
-            return offset = 179;
-        }
-
-        virtual unsigned int offset180(int) {
-            return offset = 180;
-        }
-
-        virtual unsigned int offset181(int) {
-            return offset = 181;
-        }
-
-        virtual unsigned int offset182(int) {
-            return offset = 182;
-        }
-
-        virtual unsigned int offset183(int) {
-            return offset = 183;
-        }
-
-        virtual unsigned int offset184(int) {
-            return offset = 184;
-        }
-
-        virtual unsigned int offset185(int) {
-            return offset = 185;
-        }
-
-        virtual unsigned int offset186(int) {
-            return offset = 186;
-        }
-
-        virtual unsigned int offset187(int) {
-            return offset = 187;
-        }
-
-        virtual unsigned int offset188(int) {
-            return offset = 188;
-        }
-
-        virtual unsigned int offset189(int) {
-            return offset = 189;
-        }
-
-        virtual unsigned int offset190(int) {
-            return offset = 190;
-        }
-
-        virtual unsigned int offset191(int) {
-            return offset = 191;
-        }
-
-        virtual unsigned int offset192(int) {
-            return offset = 192;
-        }
-
-        virtual unsigned int offset193(int) {
-            return offset = 193;
-        }
-
-        virtual unsigned int offset194(int) {
-            return offset = 194;
-        }
-
-        virtual unsigned int offset195(int) {
-            return offset = 195;
-        }
-
-        virtual unsigned int offset196(int) {
-            return offset = 196;
-        }
-
-        virtual unsigned int offset197(int) {
-            return offset = 197;
-        }
-
-        virtual unsigned int offset198(int) {
-            return offset = 198;
-        }
-
-        virtual unsigned int offset199(int) {
-            return offset = 199;
-        }
-
-
-        virtual unsigned int offset200(int) {
-            return offset = 200;
-        }
-
-        virtual unsigned int offset201(int) {
-            return offset = 201;
-        }
-
-        virtual unsigned int offset202(int) {
-            return offset = 202;
-        }
-
-        virtual unsigned int offset203(int) {
-            return offset = 203;
-        }
-
-        virtual unsigned int offset204(int) {
-            return offset = 204;
-        }
-
-        virtual unsigned int offset205(int) {
-            return offset = 205;
-        }
-
-        virtual unsigned int offset206(int) {
-            return offset = 206;
-        }
-
-        virtual unsigned int offset207(int) {
-            return offset = 207;
-        }
-
-        virtual unsigned int offset208(int) {
-            return offset = 208;
-        }
-
-        virtual unsigned int offset209(int) {
-            return offset = 209;
-        }
-
-        virtual unsigned int offset210(int) {
-            return offset = 210;
-        }
-
-        virtual unsigned int offset211(int) {
-            return offset = 211;
-        }
-
-        virtual unsigned int offset212(int) {
-            return offset = 212;
-        }
-
-        virtual unsigned int offset213(int) {
-            return offset = 213;
-        }
-
-        virtual unsigned int offset214(int) {
-            return offset = 214;
-        }
-
-        virtual unsigned int offset215(int) {
-            return offset = 215;
-        }
-
-        virtual unsigned int offset216(int) {
-            return offset = 216;
-        }
-
-        virtual unsigned int offset217(int) {
-            return offset = 217;
-        }
-
-        virtual unsigned int offset218(int) {
-            return offset = 218;
-        }
-
-        virtual unsigned int offset219(int) {
-            return offset = 219;
-        }
-
-        virtual unsigned int offset220(int) {
-            return offset = 220;
-        }
-
-        virtual unsigned int offset221(int) {
-            return offset = 221;
-        }
-
-        virtual unsigned int offset222(int) {
-            return offset = 222;
-        }
-
-        virtual unsigned int offset223(int) {
-            return offset = 223;
-        }
-
-        virtual unsigned int offset224(int) {
-            return offset = 224;
-        }
-
-        virtual unsigned int offset225(int) {
-            return offset = 225;
-        }
-
-        virtual unsigned int offset226(int) {
-            return offset = 226;
-        }
-
-        virtual unsigned int offset227(int) {
-            return offset = 227;
-        }
-
-        virtual unsigned int offset228(int) {
-            return offset = 228;
-        }
-
-        virtual unsigned int offset229(int) {
-            return offset = 229;
-        }
-
-        virtual unsigned int offset230(int) {
-            return offset = 230;
-        }
-
-        virtual unsigned int offset231(int) {
-            return offset = 231;
-        }
-
-        virtual unsigned int offset232(int) {
-            return offset = 232;
-        }
-
-        virtual unsigned int offset233(int) {
-            return offset = 233;
-        }
-
-        virtual unsigned int offset234(int) {
-            return offset = 234;
-        }
-
-        virtual unsigned int offset235(int) {
-            return offset = 235;
-        }
-
-        virtual unsigned int offset236(int) {
-            return offset = 236;
-        }
-
-        virtual unsigned int offset237(int) {
-            return offset = 237;
-        }
-
-        virtual unsigned int offset238(int) {
-            return offset = 238;
-        }
-
-        virtual unsigned int offset239(int) {
-            return offset = 239;
-        }
-
-        virtual unsigned int offset240(int) {
-            return offset = 240;
-        }
-
-        virtual unsigned int offset241(int) {
-            return offset = 241;
-        }
-
-        virtual unsigned int offset242(int) {
-            return offset = 242;
-        }
-
-        virtual unsigned int offset243(int) {
-            return offset = 243;
-        }
-
-        virtual unsigned int offset244(int) {
-            return offset = 244;
-        }
-
-        virtual unsigned int offset245(int) {
-            return offset = 245;
-        }
-
-        virtual unsigned int offset246(int) {
-            return offset = 246;
-        }
-
-        virtual unsigned int offset247(int) {
-            return offset = 247;
-        }
-
-        virtual unsigned int offset248(int) {
-            return offset = 248;
-        }
-
-        virtual unsigned int offset249(int) {
-            return offset = 249;
-        }
-
-        virtual unsigned int offset250(int) {
-            return offset = 250;
-        }
-
-        virtual unsigned int offset251(int) {
-            return offset = 251;
-        }
-
-        virtual unsigned int offset252(int) {
-            return offset = 252;
-        }
-
-        virtual unsigned int offset253(int) {
-            return offset = 253;
-        }
-
-        virtual unsigned int offset254(int) {
-            return offset = 254;
-        }
-
-        virtual unsigned int offset255(int) {
-            return offset = 255;
-        }
-
-        virtual unsigned int offset256(int) {
-            return offset = 256;
-        }
-
-        virtual unsigned int offset257(int) {
-            return offset = 257;
-        }
-
-        virtual unsigned int offset258(int) {
-            return offset = 258;
-        }
-
-        virtual unsigned int offset259(int) {
-            return offset = 259;
-        }
-
-        virtual unsigned int offset260(int) {
-            return offset = 260;
-        }
-
-        virtual unsigned int offset261(int) {
-            return offset = 261;
-        }
-
-        virtual unsigned int offset262(int) {
-            return offset = 262;
-        }
-
-        virtual unsigned int offset263(int) {
-            return offset = 263;
-        }
-
-        virtual unsigned int offset264(int) {
-            return offset = 264;
-        }
-
-        virtual unsigned int offset265(int) {
-            return offset = 265;
-        }
-
-        virtual unsigned int offset266(int) {
-            return offset = 266;
-        }
-
-        virtual unsigned int offset267(int) {
-            return offset = 267;
-        }
-
-        virtual unsigned int offset268(int) {
-            return offset = 268;
-        }
-
-        virtual unsigned int offset269(int) {
-            return offset = 269;
-        }
-
-        virtual unsigned int offset270(int) {
-            return offset = 270;
-        }
-
-        virtual unsigned int offset271(int) {
-            return offset = 271;
-        }
-
-        virtual unsigned int offset272(int) {
-            return offset = 272;
-        }
-
-        virtual unsigned int offset273(int) {
-            return offset = 273;
-        }
-
-        virtual unsigned int offset274(int) {
-            return offset = 274;
-        }
-
-        virtual unsigned int offset275(int) {
-            return offset = 275;
-        }
-
-        virtual unsigned int offset276(int) {
-            return offset = 276;
-        }
-
-        virtual unsigned int offset277(int) {
-            return offset = 277;
-        }
-
-        virtual unsigned int offset278(int) {
-            return offset = 278;
-        }
-
-        virtual unsigned int offset279(int) {
-            return offset = 279;
-        }
-
-        virtual unsigned int offset280(int) {
-            return offset = 280;
-        }
-
-        virtual unsigned int offset281(int) {
-            return offset = 281;
-        }
-
-        virtual unsigned int offset282(int) {
-            return offset = 282;
-        }
-
-        virtual unsigned int offset283(int) {
-            return offset = 283;
-        }
-
-        virtual unsigned int offset284(int) {
-            return offset = 284;
-        }
-
-        virtual unsigned int offset285(int) {
-            return offset = 285;
-        }
-
-        virtual unsigned int offset286(int) {
-            return offset = 286;
-        }
-
-        virtual unsigned int offset287(int) {
-            return offset = 287;
-        }
-
-        virtual unsigned int offset288(int) {
-            return offset = 288;
-        }
-
-        virtual unsigned int offset289(int) {
-            return offset = 289;
-        }
-
-        virtual unsigned int offset290(int) {
-            return offset = 290;
-        }
-
-        virtual unsigned int offset291(int) {
-            return offset = 291;
-        }
-
-        virtual unsigned int offset292(int) {
-            return offset = 292;
-        }
-
-        virtual unsigned int offset293(int) {
-            return offset = 293;
-        }
-
-        virtual unsigned int offset294(int) {
-            return offset = 294;
-        }
-
-        virtual unsigned int offset295(int) {
-            return offset = 295;
-        }
-
-        virtual unsigned int offset296(int) {
-            return offset = 296;
-        }
-
-        virtual unsigned int offset297(int) {
-            return offset = 297;
-        }
-
-        virtual unsigned int offset298(int) {
-            return offset = 298;
-        }
-
-        virtual unsigned int offset299(int) {
-            return offset = 299;
-        }
-
-
-        virtual unsigned int offset300(int) {
-            return offset = 300;
-        }
-
-        virtual unsigned int offset301(int) {
-            return offset = 301;
-        }
-
-        virtual unsigned int offset302(int) {
-            return offset = 302;
-        }
-
-        virtual unsigned int offset303(int) {
-            return offset = 303;
-        }
-
-        virtual unsigned int offset304(int) {
-            return offset = 304;
-        }
-
-        virtual unsigned int offset305(int) {
-            return offset = 305;
-        }
-
-        virtual unsigned int offset306(int) {
-            return offset = 306;
-        }
-
-        virtual unsigned int offset307(int) {
-            return offset = 307;
-        }
-
-        virtual unsigned int offset308(int) {
-            return offset = 308;
-        }
-
-        virtual unsigned int offset309(int) {
-            return offset = 309;
-        }
-
-        virtual unsigned int offset310(int) {
-            return offset = 310;
-        }
-
-        virtual unsigned int offset311(int) {
-            return offset = 311;
-        }
-
-        virtual unsigned int offset312(int) {
-            return offset = 312;
-        }
-
-        virtual unsigned int offset313(int) {
-            return offset = 313;
-        }
-
-        virtual unsigned int offset314(int) {
-            return offset = 314;
-        }
-
-        virtual unsigned int offset315(int) {
-            return offset = 315;
-        }
-
-        virtual unsigned int offset316(int) {
-            return offset = 316;
-        }
-
-        virtual unsigned int offset317(int) {
-            return offset = 317;
-        }
-
-        virtual unsigned int offset318(int) {
-            return offset = 318;
-        }
-
-        virtual unsigned int offset319(int) {
-            return offset = 319;
-        }
-
-        virtual unsigned int offset320(int) {
-            return offset = 320;
-        }
-
-        virtual unsigned int offset321(int) {
-            return offset = 321;
-        }
-
-        virtual unsigned int offset322(int) {
-            return offset = 322;
-        }
-
-        virtual unsigned int offset323(int) {
-            return offset = 323;
-        }
-
-        virtual unsigned int offset324(int) {
-            return offset = 324;
-        }
-
-        virtual unsigned int offset325(int) {
-            return offset = 325;
-        }
-
-        virtual unsigned int offset326(int) {
-            return offset = 326;
-        }
-
-        virtual unsigned int offset327(int) {
-            return offset = 327;
-        }
-
-        virtual unsigned int offset328(int) {
-            return offset = 328;
-        }
-
-        virtual unsigned int offset329(int) {
-            return offset = 329;
-        }
-
-        virtual unsigned int offset330(int) {
-            return offset = 330;
-        }
-
-        virtual unsigned int offset331(int) {
-            return offset = 331;
-        }
-
-        virtual unsigned int offset332(int) {
-            return offset = 332;
-        }
-
-        virtual unsigned int offset333(int) {
-            return offset = 333;
-        }
-
-        virtual unsigned int offset334(int) {
-            return offset = 334;
-        }
-
-        virtual unsigned int offset335(int) {
-            return offset = 335;
-        }
-
-        virtual unsigned int offset336(int) {
-            return offset = 336;
-        }
-
-        virtual unsigned int offset337(int) {
-            return offset = 337;
-        }
-
-        virtual unsigned int offset338(int) {
-            return offset = 338;
-        }
-
-        virtual unsigned int offset339(int) {
-            return offset = 339;
-        }
-
-        virtual unsigned int offset340(int) {
-            return offset = 340;
-        }
-
-        virtual unsigned int offset341(int) {
-            return offset = 341;
-        }
-
-        virtual unsigned int offset342(int) {
-            return offset = 342;
-        }
-
-        virtual unsigned int offset343(int) {
-            return offset = 343;
-        }
-
-        virtual unsigned int offset344(int) {
-            return offset = 344;
-        }
-
-        virtual unsigned int offset345(int) {
-            return offset = 345;
-        }
-
-        virtual unsigned int offset346(int) {
-            return offset = 346;
-        }
-
-        virtual unsigned int offset347(int) {
-            return offset = 347;
-        }
-
-        virtual unsigned int offset348(int) {
-            return offset = 348;
-        }
-
-        virtual unsigned int offset349(int) {
-            return offset = 349;
-        }
-
-        virtual unsigned int offset350(int) {
-            return offset = 350;
-        }
-
-        virtual unsigned int offset351(int) {
-            return offset = 351;
-        }
-
-        virtual unsigned int offset352(int) {
-            return offset = 352;
-        }
-
-        virtual unsigned int offset353(int) {
-            return offset = 353;
-        }
-
-        virtual unsigned int offset354(int) {
-            return offset = 354;
-        }
-
-        virtual unsigned int offset355(int) {
-            return offset = 355;
-        }
-
-        virtual unsigned int offset356(int) {
-            return offset = 356;
-        }
-
-        virtual unsigned int offset357(int) {
-            return offset = 357;
-        }
-
-        virtual unsigned int offset358(int) {
-            return offset = 358;
-        }
-
-        virtual unsigned int offset359(int) {
-            return offset = 359;
-        }
-
-        virtual unsigned int offset360(int) {
-            return offset = 360;
-        }
-
-        virtual unsigned int offset361(int) {
-            return offset = 361;
-        }
-
-        virtual unsigned int offset362(int) {
-            return offset = 362;
-        }
-
-        virtual unsigned int offset363(int) {
-            return offset = 363;
-        }
-
-        virtual unsigned int offset364(int) {
-            return offset = 364;
-        }
-
-        virtual unsigned int offset365(int) {
-            return offset = 365;
-        }
-
-        virtual unsigned int offset366(int) {
-            return offset = 366;
-        }
-
-        virtual unsigned int offset367(int) {
-            return offset = 367;
-        }
-
-        virtual unsigned int offset368(int) {
-            return offset = 368;
-        }
-
-        virtual unsigned int offset369(int) {
-            return offset = 369;
-        }
-
-        virtual unsigned int offset370(int) {
-            return offset = 370;
-        }
-
-        virtual unsigned int offset371(int) {
-            return offset = 371;
-        }
-
-        virtual unsigned int offset372(int) {
-            return offset = 372;
-        }
-
-        virtual unsigned int offset373(int) {
-            return offset = 373;
-        }
-
-        virtual unsigned int offset374(int) {
-            return offset = 374;
-        }
-
-        virtual unsigned int offset375(int) {
-            return offset = 375;
-        }
-
-        virtual unsigned int offset376(int) {
-            return offset = 376;
-        }
-
-        virtual unsigned int offset377(int) {
-            return offset = 377;
-        }
-
-        virtual unsigned int offset378(int) {
-            return offset = 378;
-        }
-
-        virtual unsigned int offset379(int) {
-            return offset = 379;
-        }
-
-        virtual unsigned int offset380(int) {
-            return offset = 380;
-        }
-
-        virtual unsigned int offset381(int) {
-            return offset = 381;
-        }
-
-        virtual unsigned int offset382(int) {
-            return offset = 382;
-        }
-
-        virtual unsigned int offset383(int) {
-            return offset = 383;
-        }
-
-        virtual unsigned int offset384(int) {
-            return offset = 384;
-        }
-
-        virtual unsigned int offset385(int) {
-            return offset = 385;
-        }
-
-        virtual unsigned int offset386(int) {
-            return offset = 386;
-        }
-
-        virtual unsigned int offset387(int) {
-            return offset = 387;
-        }
-
-        virtual unsigned int offset388(int) {
-            return offset = 388;
-        }
-
-        virtual unsigned int offset389(int) {
-            return offset = 389;
-        }
-
-        virtual unsigned int offset390(int) {
-            return offset = 390;
-        }
-
-        virtual unsigned int offset391(int) {
-            return offset = 391;
-        }
-
-        virtual unsigned int offset392(int) {
-            return offset = 392;
-        }
-
-        virtual unsigned int offset393(int) {
-            return offset = 393;
-        }
-
-        virtual unsigned int offset394(int) {
-            return offset = 394;
-        }
-
-        virtual unsigned int offset395(int) {
-            return offset = 395;
-        }
-
-        virtual unsigned int offset396(int) {
-            return offset = 396;
-        }
-
-        virtual unsigned int offset397(int) {
-            return offset = 397;
-        }
-
-        virtual unsigned int offset398(int) {
-            return offset = 398;
-        }
-
-        virtual unsigned int offset399(int) {
-            return offset = 399;
-        }
-
-
-        virtual unsigned int offset400(int) {
-            return offset = 400;
-        }
-
-        virtual unsigned int offset401(int) {
-            return offset = 401;
-        }
-
-        virtual unsigned int offset402(int) {
-            return offset = 402;
-        }
-
-        virtual unsigned int offset403(int) {
-            return offset = 403;
-        }
-
-        virtual unsigned int offset404(int) {
-            return offset = 404;
-        }
-
-        virtual unsigned int offset405(int) {
-            return offset = 405;
-        }
-
-        virtual unsigned int offset406(int) {
-            return offset = 406;
-        }
-
-        virtual unsigned int offset407(int) {
-            return offset = 407;
-        }
-
-        virtual unsigned int offset408(int) {
-            return offset = 408;
-        }
-
-        virtual unsigned int offset409(int) {
-            return offset = 409;
-        }
-
-        virtual unsigned int offset410(int) {
-            return offset = 410;
-        }
-
-        virtual unsigned int offset411(int) {
-            return offset = 411;
-        }
-
-        virtual unsigned int offset412(int) {
-            return offset = 412;
-        }
-
-        virtual unsigned int offset413(int) {
-            return offset = 413;
-        }
-
-        virtual unsigned int offset414(int) {
-            return offset = 414;
-        }
-
-        virtual unsigned int offset415(int) {
-            return offset = 415;
-        }
-
-        virtual unsigned int offset416(int) {
-            return offset = 416;
-        }
-
-        virtual unsigned int offset417(int) {
-            return offset = 417;
-        }
-
-        virtual unsigned int offset418(int) {
-            return offset = 418;
-        }
-
-        virtual unsigned int offset419(int) {
-            return offset = 419;
-        }
-
-        virtual unsigned int offset420(int) {
-            return offset = 420;
-        }
-
-        virtual unsigned int offset421(int) {
-            return offset = 421;
-        }
-
-        virtual unsigned int offset422(int) {
-            return offset = 422;
-        }
-
-        virtual unsigned int offset423(int) {
-            return offset = 423;
-        }
-
-        virtual unsigned int offset424(int) {
-            return offset = 424;
-        }
-
-        virtual unsigned int offset425(int) {
-            return offset = 425;
-        }
-
-        virtual unsigned int offset426(int) {
-            return offset = 426;
-        }
-
-        virtual unsigned int offset427(int) {
-            return offset = 427;
-        }
-
-        virtual unsigned int offset428(int) {
-            return offset = 428;
-        }
-
-        virtual unsigned int offset429(int) {
-            return offset = 429;
-        }
-
-        virtual unsigned int offset430(int) {
-            return offset = 430;
-        }
-
-        virtual unsigned int offset431(int) {
-            return offset = 431;
-        }
-
-        virtual unsigned int offset432(int) {
-            return offset = 432;
-        }
-
-        virtual unsigned int offset433(int) {
-            return offset = 433;
-        }
-
-        virtual unsigned int offset434(int) {
-            return offset = 434;
-        }
-
-        virtual unsigned int offset435(int) {
-            return offset = 435;
-        }
-
-        virtual unsigned int offset436(int) {
-            return offset = 436;
-        }
-
-        virtual unsigned int offset437(int) {
-            return offset = 437;
-        }
-
-        virtual unsigned int offset438(int) {
-            return offset = 438;
-        }
-
-        virtual unsigned int offset439(int) {
-            return offset = 439;
-        }
-
-        virtual unsigned int offset440(int) {
-            return offset = 440;
-        }
-
-        virtual unsigned int offset441(int) {
-            return offset = 441;
-        }
-
-        virtual unsigned int offset442(int) {
-            return offset = 442;
-        }
-
-        virtual unsigned int offset443(int) {
-            return offset = 443;
-        }
-
-        virtual unsigned int offset444(int) {
-            return offset = 444;
-        }
-
-        virtual unsigned int offset445(int) {
-            return offset = 445;
-        }
-
-        virtual unsigned int offset446(int) {
-            return offset = 446;
-        }
-
-        virtual unsigned int offset447(int) {
-            return offset = 447;
-        }
-
-        virtual unsigned int offset448(int) {
-            return offset = 448;
-        }
-
-        virtual unsigned int offset449(int) {
-            return offset = 449;
-        }
-
-        virtual unsigned int offset450(int) {
-            return offset = 450;
-        }
-
-        virtual unsigned int offset451(int) {
-            return offset = 451;
-        }
-
-        virtual unsigned int offset452(int) {
-            return offset = 452;
-        }
-
-        virtual unsigned int offset453(int) {
-            return offset = 453;
-        }
-
-        virtual unsigned int offset454(int) {
-            return offset = 454;
-        }
-
-        virtual unsigned int offset455(int) {
-            return offset = 455;
-        }
-
-        virtual unsigned int offset456(int) {
-            return offset = 456;
-        }
-
-        virtual unsigned int offset457(int) {
-            return offset = 457;
-        }
-
-        virtual unsigned int offset458(int) {
-            return offset = 458;
-        }
-
-        virtual unsigned int offset459(int) {
-            return offset = 459;
-        }
-
-        virtual unsigned int offset460(int) {
-            return offset = 460;
-        }
-
-        virtual unsigned int offset461(int) {
-            return offset = 461;
-        }
-
-        virtual unsigned int offset462(int) {
-            return offset = 462;
-        }
-
-        virtual unsigned int offset463(int) {
-            return offset = 463;
-        }
-
-        virtual unsigned int offset464(int) {
-            return offset = 464;
-        }
-
-        virtual unsigned int offset465(int) {
-            return offset = 465;
-        }
-
-        virtual unsigned int offset466(int) {
-            return offset = 466;
-        }
-
-        virtual unsigned int offset467(int) {
-            return offset = 467;
-        }
-
-        virtual unsigned int offset468(int) {
-            return offset = 468;
-        }
-
-        virtual unsigned int offset469(int) {
-            return offset = 469;
-        }
-
-        virtual unsigned int offset470(int) {
-            return offset = 470;
-        }
-
-        virtual unsigned int offset471(int) {
-            return offset = 471;
-        }
-
-        virtual unsigned int offset472(int) {
-            return offset = 472;
-        }
-
-        virtual unsigned int offset473(int) {
-            return offset = 473;
-        }
-
-        virtual unsigned int offset474(int) {
-            return offset = 474;
-        }
-
-        virtual unsigned int offset475(int) {
-            return offset = 475;
-        }
-
-        virtual unsigned int offset476(int) {
-            return offset = 476;
-        }
-
-        virtual unsigned int offset477(int) {
-            return offset = 477;
-        }
-
-        virtual unsigned int offset478(int) {
-            return offset = 478;
-        }
-
-        virtual unsigned int offset479(int) {
-            return offset = 479;
-        }
-
-        virtual unsigned int offset480(int) {
-            return offset = 480;
-        }
-
-        virtual unsigned int offset481(int) {
-            return offset = 481;
-        }
-
-        virtual unsigned int offset482(int) {
-            return offset = 482;
-        }
-
-        virtual unsigned int offset483(int) {
-            return offset = 483;
-        }
-
-        virtual unsigned int offset484(int) {
-            return offset = 484;
-        }
-
-        virtual unsigned int offset485(int) {
-            return offset = 485;
-        }
-
-        virtual unsigned int offset486(int) {
-            return offset = 486;
-        }
-
-        virtual unsigned int offset487(int) {
-            return offset = 487;
-        }
-
-        virtual unsigned int offset488(int) {
-            return offset = 488;
-        }
-
-        virtual unsigned int offset489(int) {
-            return offset = 489;
-        }
-
-        virtual unsigned int offset490(int) {
-            return offset = 490;
-        }
-
-        virtual unsigned int offset491(int) {
-            return offset = 491;
-        }
-
-        virtual unsigned int offset492(int) {
-            return offset = 492;
-        }
-
-        virtual unsigned int offset493(int) {
-            return offset = 493;
-        }
-
-        virtual unsigned int offset494(int) {
-            return offset = 494;
-        }
-
-        virtual unsigned int offset495(int) {
-            return offset = 495;
-        }
-
-        virtual unsigned int offset496(int) {
-            return offset = 496;
-        }
-
-        virtual unsigned int offset497(int) {
-            return offset = 497;
-        }
-
-        virtual unsigned int offset498(int) {
-            return offset = 498;
-        }
-
-        virtual unsigned int offset499(int) {
-            return offset = 499;
-        }
-
-
-        virtual unsigned int offset500(int) {
-            return offset = 500;
-        }
-
-        virtual unsigned int offset501(int) {
-            return offset = 501;
-        }
-
-        virtual unsigned int offset502(int) {
-            return offset = 502;
-        }
-
-        virtual unsigned int offset503(int) {
-            return offset = 503;
-        }
-
-        virtual unsigned int offset504(int) {
-            return offset = 504;
-        }
-
-        virtual unsigned int offset505(int) {
-            return offset = 505;
-        }
-
-        virtual unsigned int offset506(int) {
-            return offset = 506;
-        }
-
-        virtual unsigned int offset507(int) {
-            return offset = 507;
-        }
-
-        virtual unsigned int offset508(int) {
-            return offset = 508;
-        }
-
-        virtual unsigned int offset509(int) {
-            return offset = 509;
-        }
-
-        virtual unsigned int offset510(int) {
-            return offset = 510;
-        }
-
-        virtual unsigned int offset511(int) {
-            return offset = 511;
-        }
-
-        virtual unsigned int offset512(int) {
-            return offset = 512;
-        }
-
-        virtual unsigned int offset513(int) {
-            return offset = 513;
-        }
-
-        virtual unsigned int offset514(int) {
-            return offset = 514;
-        }
-
-        virtual unsigned int offset515(int) {
-            return offset = 515;
-        }
-
-        virtual unsigned int offset516(int) {
-            return offset = 516;
-        }
-
-        virtual unsigned int offset517(int) {
-            return offset = 517;
-        }
-
-        virtual unsigned int offset518(int) {
-            return offset = 518;
-        }
-
-        virtual unsigned int offset519(int) {
-            return offset = 519;
-        }
-
-        virtual unsigned int offset520(int) {
-            return offset = 520;
-        }
-
-        virtual unsigned int offset521(int) {
-            return offset = 521;
-        }
-
-        virtual unsigned int offset522(int) {
-            return offset = 522;
-        }
-
-        virtual unsigned int offset523(int) {
-            return offset = 523;
-        }
-
-        virtual unsigned int offset524(int) {
-            return offset = 524;
-        }
-
-        virtual unsigned int offset525(int) {
-            return offset = 525;
-        }
-
-        virtual unsigned int offset526(int) {
-            return offset = 526;
-        }
-
-        virtual unsigned int offset527(int) {
-            return offset = 527;
-        }
-
-        virtual unsigned int offset528(int) {
-            return offset = 528;
-        }
-
-        virtual unsigned int offset529(int) {
-            return offset = 529;
-        }
-
-        virtual unsigned int offset530(int) {
-            return offset = 530;
-        }
-
-        virtual unsigned int offset531(int) {
-            return offset = 531;
-        }
-
-        virtual unsigned int offset532(int) {
-            return offset = 532;
-        }
-
-        virtual unsigned int offset533(int) {
-            return offset = 533;
-        }
-
-        virtual unsigned int offset534(int) {
-            return offset = 534;
-        }
-
-        virtual unsigned int offset535(int) {
-            return offset = 535;
-        }
-
-        virtual unsigned int offset536(int) {
-            return offset = 536;
-        }
-
-        virtual unsigned int offset537(int) {
-            return offset = 537;
-        }
-
-        virtual unsigned int offset538(int) {
-            return offset = 538;
-        }
-
-        virtual unsigned int offset539(int) {
-            return offset = 539;
-        }
-
-        virtual unsigned int offset540(int) {
-            return offset = 540;
-        }
-
-        virtual unsigned int offset541(int) {
-            return offset = 541;
-        }
-
-        virtual unsigned int offset542(int) {
-            return offset = 542;
-        }
-
-        virtual unsigned int offset543(int) {
-            return offset = 543;
-        }
-
-        virtual unsigned int offset544(int) {
-            return offset = 544;
-        }
-
-        virtual unsigned int offset545(int) {
-            return offset = 545;
-        }
-
-        virtual unsigned int offset546(int) {
-            return offset = 546;
-        }
-
-        virtual unsigned int offset547(int) {
-            return offset = 547;
-        }
-
-        virtual unsigned int offset548(int) {
-            return offset = 548;
-        }
-
-        virtual unsigned int offset549(int) {
-            return offset = 549;
-        }
-
-        virtual unsigned int offset550(int) {
-            return offset = 550;
-        }
-
-        virtual unsigned int offset551(int) {
-            return offset = 551;
-        }
-
-        virtual unsigned int offset552(int) {
-            return offset = 552;
-        }
-
-        virtual unsigned int offset553(int) {
-            return offset = 553;
-        }
-
-        virtual unsigned int offset554(int) {
-            return offset = 554;
-        }
-
-        virtual unsigned int offset555(int) {
-            return offset = 555;
-        }
-
-        virtual unsigned int offset556(int) {
-            return offset = 556;
-        }
-
-        virtual unsigned int offset557(int) {
-            return offset = 557;
-        }
-
-        virtual unsigned int offset558(int) {
-            return offset = 558;
-        }
-
-        virtual unsigned int offset559(int) {
-            return offset = 559;
-        }
-
-        virtual unsigned int offset560(int) {
-            return offset = 560;
-        }
-
-        virtual unsigned int offset561(int) {
-            return offset = 561;
-        }
-
-        virtual unsigned int offset562(int) {
-            return offset = 562;
-        }
-
-        virtual unsigned int offset563(int) {
-            return offset = 563;
-        }
-
-        virtual unsigned int offset564(int) {
-            return offset = 564;
-        }
-
-        virtual unsigned int offset565(int) {
-            return offset = 565;
-        }
-
-        virtual unsigned int offset566(int) {
-            return offset = 566;
-        }
-
-        virtual unsigned int offset567(int) {
-            return offset = 567;
-        }
-
-        virtual unsigned int offset568(int) {
-            return offset = 568;
-        }
-
-        virtual unsigned int offset569(int) {
-            return offset = 569;
-        }
-
-        virtual unsigned int offset570(int) {
-            return offset = 570;
-        }
-
-        virtual unsigned int offset571(int) {
-            return offset = 571;
-        }
-
-        virtual unsigned int offset572(int) {
-            return offset = 572;
-        }
-
-        virtual unsigned int offset573(int) {
-            return offset = 573;
-        }
-
-        virtual unsigned int offset574(int) {
-            return offset = 574;
-        }
-
-        virtual unsigned int offset575(int) {
-            return offset = 575;
-        }
-
-        virtual unsigned int offset576(int) {
-            return offset = 576;
-        }
-
-        virtual unsigned int offset577(int) {
-            return offset = 577;
-        }
-
-        virtual unsigned int offset578(int) {
-            return offset = 578;
-        }
-
-        virtual unsigned int offset579(int) {
-            return offset = 579;
-        }
-
-        virtual unsigned int offset580(int) {
-            return offset = 580;
-        }
-
-        virtual unsigned int offset581(int) {
-            return offset = 581;
-        }
-
-        virtual unsigned int offset582(int) {
-            return offset = 582;
-        }
-
-        virtual unsigned int offset583(int) {
-            return offset = 583;
-        }
-
-        virtual unsigned int offset584(int) {
-            return offset = 584;
-        }
-
-        virtual unsigned int offset585(int) {
-            return offset = 585;
-        }
-
-        virtual unsigned int offset586(int) {
-            return offset = 586;
-        }
-
-        virtual unsigned int offset587(int) {
-            return offset = 587;
-        }
-
-        virtual unsigned int offset588(int) {
-            return offset = 588;
-        }
-
-        virtual unsigned int offset589(int) {
-            return offset = 589;
-        }
-
-        virtual unsigned int offset590(int) {
-            return offset = 590;
-        }
-
-        virtual unsigned int offset591(int) {
-            return offset = 591;
-        }
-
-        virtual unsigned int offset592(int) {
-            return offset = 592;
-        }
-
-        virtual unsigned int offset593(int) {
-            return offset = 593;
-        }
-
-        virtual unsigned int offset594(int) {
-            return offset = 594;
-        }
-
-        virtual unsigned int offset595(int) {
-            return offset = 595;
-        }
-
-        virtual unsigned int offset596(int) {
-            return offset = 596;
-        }
-
-        virtual unsigned int offset597(int) {
-            return offset = 597;
-        }
-
-        virtual unsigned int offset598(int) {
-            return offset = 598;
-        }
-
-        virtual unsigned int offset599(int) {
-            return offset = 599;
-        }
-
-
-        virtual unsigned int offset600(int) {
-            return offset = 600;
-        }
-
-        virtual unsigned int offset601(int) {
-            return offset = 601;
-        }
-
-        virtual unsigned int offset602(int) {
-            return offset = 602;
-        }
-
-        virtual unsigned int offset603(int) {
-            return offset = 603;
-        }
-
-        virtual unsigned int offset604(int) {
-            return offset = 604;
-        }
-
-        virtual unsigned int offset605(int) {
-            return offset = 605;
-        }
-
-        virtual unsigned int offset606(int) {
-            return offset = 606;
-        }
-
-        virtual unsigned int offset607(int) {
-            return offset = 607;
-        }
-
-        virtual unsigned int offset608(int) {
-            return offset = 608;
-        }
-
-        virtual unsigned int offset609(int) {
-            return offset = 609;
-        }
-
-        virtual unsigned int offset610(int) {
-            return offset = 610;
-        }
-
-        virtual unsigned int offset611(int) {
-            return offset = 611;
-        }
-
-        virtual unsigned int offset612(int) {
-            return offset = 612;
-        }
-
-        virtual unsigned int offset613(int) {
-            return offset = 613;
-        }
-
-        virtual unsigned int offset614(int) {
-            return offset = 614;
-        }
-
-        virtual unsigned int offset615(int) {
-            return offset = 615;
-        }
-
-        virtual unsigned int offset616(int) {
-            return offset = 616;
-        }
-
-        virtual unsigned int offset617(int) {
-            return offset = 617;
-        }
-
-        virtual unsigned int offset618(int) {
-            return offset = 618;
-        }
-
-        virtual unsigned int offset619(int) {
-            return offset = 619;
-        }
-
-        virtual unsigned int offset620(int) {
-            return offset = 620;
-        }
-
-        virtual unsigned int offset621(int) {
-            return offset = 621;
-        }
-
-        virtual unsigned int offset622(int) {
-            return offset = 622;
-        }
-
-        virtual unsigned int offset623(int) {
-            return offset = 623;
-        }
-
-        virtual unsigned int offset624(int) {
-            return offset = 624;
-        }
-
-        virtual unsigned int offset625(int) {
-            return offset = 625;
-        }
-
-        virtual unsigned int offset626(int) {
-            return offset = 626;
-        }
-
-        virtual unsigned int offset627(int) {
-            return offset = 627;
-        }
-
-        virtual unsigned int offset628(int) {
-            return offset = 628;
-        }
-
-        virtual unsigned int offset629(int) {
-            return offset = 629;
-        }
-
-        virtual unsigned int offset630(int) {
-            return offset = 630;
-        }
-
-        virtual unsigned int offset631(int) {
-            return offset = 631;
-        }
-
-        virtual unsigned int offset632(int) {
-            return offset = 632;
-        }
-
-        virtual unsigned int offset633(int) {
-            return offset = 633;
-        }
-
-        virtual unsigned int offset634(int) {
-            return offset = 634;
-        }
-
-        virtual unsigned int offset635(int) {
-            return offset = 635;
-        }
-
-        virtual unsigned int offset636(int) {
-            return offset = 636;
-        }
-
-        virtual unsigned int offset637(int) {
-            return offset = 637;
-        }
-
-        virtual unsigned int offset638(int) {
-            return offset = 638;
-        }
-
-        virtual unsigned int offset639(int) {
-            return offset = 639;
-        }
-
-        virtual unsigned int offset640(int) {
-            return offset = 640;
-        }
-
-        virtual unsigned int offset641(int) {
-            return offset = 641;
-        }
-
-        virtual unsigned int offset642(int) {
-            return offset = 642;
-        }
-
-        virtual unsigned int offset643(int) {
-            return offset = 643;
-        }
-
-        virtual unsigned int offset644(int) {
-            return offset = 644;
-        }
-
-        virtual unsigned int offset645(int) {
-            return offset = 645;
-        }
-
-        virtual unsigned int offset646(int) {
-            return offset = 646;
-        }
-
-        virtual unsigned int offset647(int) {
-            return offset = 647;
-        }
-
-        virtual unsigned int offset648(int) {
-            return offset = 648;
-        }
-
-        virtual unsigned int offset649(int) {
-            return offset = 649;
-        }
-
-        virtual unsigned int offset650(int) {
-            return offset = 650;
-        }
-
-        virtual unsigned int offset651(int) {
-            return offset = 651;
-        }
-
-        virtual unsigned int offset652(int) {
-            return offset = 652;
-        }
-
-        virtual unsigned int offset653(int) {
-            return offset = 653;
-        }
-
-        virtual unsigned int offset654(int) {
-            return offset = 654;
-        }
-
-        virtual unsigned int offset655(int) {
-            return offset = 655;
-        }
-
-        virtual unsigned int offset656(int) {
-            return offset = 656;
-        }
-
-        virtual unsigned int offset657(int) {
-            return offset = 657;
-        }
-
-        virtual unsigned int offset658(int) {
-            return offset = 658;
-        }
-
-        virtual unsigned int offset659(int) {
-            return offset = 659;
-        }
-
-        virtual unsigned int offset660(int) {
-            return offset = 660;
-        }
-
-        virtual unsigned int offset661(int) {
-            return offset = 661;
-        }
-
-        virtual unsigned int offset662(int) {
-            return offset = 662;
-        }
-
-        virtual unsigned int offset663(int) {
-            return offset = 663;
-        }
-
-        virtual unsigned int offset664(int) {
-            return offset = 664;
-        }
-
-        virtual unsigned int offset665(int) {
-            return offset = 665;
-        }
-
-        virtual unsigned int offset666(int) {
-            return offset = 666;
-        }
-
-        virtual unsigned int offset667(int) {
-            return offset = 667;
-        }
-
-        virtual unsigned int offset668(int) {
-            return offset = 668;
-        }
-
-        virtual unsigned int offset669(int) {
-            return offset = 669;
-        }
-
-        virtual unsigned int offset670(int) {
-            return offset = 670;
-        }
-
-        virtual unsigned int offset671(int) {
-            return offset = 671;
-        }
-
-        virtual unsigned int offset672(int) {
-            return offset = 672;
-        }
-
-        virtual unsigned int offset673(int) {
-            return offset = 673;
-        }
-
-        virtual unsigned int offset674(int) {
-            return offset = 674;
-        }
-
-        virtual unsigned int offset675(int) {
-            return offset = 675;
-        }
-
-        virtual unsigned int offset676(int) {
-            return offset = 676;
-        }
-
-        virtual unsigned int offset677(int) {
-            return offset = 677;
-        }
-
-        virtual unsigned int offset678(int) {
-            return offset = 678;
-        }
-
-        virtual unsigned int offset679(int) {
-            return offset = 679;
-        }
-
-        virtual unsigned int offset680(int) {
-            return offset = 680;
-        }
-
-        virtual unsigned int offset681(int) {
-            return offset = 681;
-        }
-
-        virtual unsigned int offset682(int) {
-            return offset = 682;
-        }
-
-        virtual unsigned int offset683(int) {
-            return offset = 683;
-        }
-
-        virtual unsigned int offset684(int) {
-            return offset = 684;
-        }
-
-        virtual unsigned int offset685(int) {
-            return offset = 685;
-        }
-
-        virtual unsigned int offset686(int) {
-            return offset = 686;
-        }
-
-        virtual unsigned int offset687(int) {
-            return offset = 687;
-        }
-
-        virtual unsigned int offset688(int) {
-            return offset = 688;
-        }
-
-        virtual unsigned int offset689(int) {
-            return offset = 689;
-        }
-
-        virtual unsigned int offset690(int) {
-            return offset = 690;
-        }
-
-        virtual unsigned int offset691(int) {
-            return offset = 691;
-        }
-
-        virtual unsigned int offset692(int) {
-            return offset = 692;
-        }
-
-        virtual unsigned int offset693(int) {
-            return offset = 693;
-        }
-
-        virtual unsigned int offset694(int) {
-            return offset = 694;
-        }
-
-        virtual unsigned int offset695(int) {
-            return offset = 695;
-        }
-
-        virtual unsigned int offset696(int) {
-            return offset = 696;
-        }
-
-        virtual unsigned int offset697(int) {
-            return offset = 697;
-        }
-
-        virtual unsigned int offset698(int) {
-            return offset = 698;
-        }
-
-        virtual unsigned int offset699(int) {
-            return offset = 699;
-        }
-
-
-        virtual unsigned int offset700(int) {
-            return offset = 700;
-        }
-
-        virtual unsigned int offset701(int) {
-            return offset = 701;
-        }
-
-        virtual unsigned int offset702(int) {
-            return offset = 702;
-        }
-
-        virtual unsigned int offset703(int) {
-            return offset = 703;
-        }
-
-        virtual unsigned int offset704(int) {
-            return offset = 704;
-        }
-
-        virtual unsigned int offset705(int) {
-            return offset = 705;
-        }
-
-        virtual unsigned int offset706(int) {
-            return offset = 706;
-        }
-
-        virtual unsigned int offset707(int) {
-            return offset = 707;
-        }
-
-        virtual unsigned int offset708(int) {
-            return offset = 708;
-        }
-
-        virtual unsigned int offset709(int) {
-            return offset = 709;
-        }
-
-        virtual unsigned int offset710(int) {
-            return offset = 710;
-        }
-
-        virtual unsigned int offset711(int) {
-            return offset = 711;
-        }
-
-        virtual unsigned int offset712(int) {
-            return offset = 712;
-        }
-
-        virtual unsigned int offset713(int) {
-            return offset = 713;
-        }
-
-        virtual unsigned int offset714(int) {
-            return offset = 714;
-        }
-
-        virtual unsigned int offset715(int) {
-            return offset = 715;
-        }
-
-        virtual unsigned int offset716(int) {
-            return offset = 716;
-        }
-
-        virtual unsigned int offset717(int) {
-            return offset = 717;
-        }
-
-        virtual unsigned int offset718(int) {
-            return offset = 718;
-        }
-
-        virtual unsigned int offset719(int) {
-            return offset = 719;
-        }
-
-        virtual unsigned int offset720(int) {
-            return offset = 720;
-        }
-
-        virtual unsigned int offset721(int) {
-            return offset = 721;
-        }
-
-        virtual unsigned int offset722(int) {
-            return offset = 722;
-        }
-
-        virtual unsigned int offset723(int) {
-            return offset = 723;
-        }
-
-        virtual unsigned int offset724(int) {
-            return offset = 724;
-        }
-
-        virtual unsigned int offset725(int) {
-            return offset = 725;
-        }
-
-        virtual unsigned int offset726(int) {
-            return offset = 726;
-        }
-
-        virtual unsigned int offset727(int) {
-            return offset = 727;
-        }
-
-        virtual unsigned int offset728(int) {
-            return offset = 728;
-        }
-
-        virtual unsigned int offset729(int) {
-            return offset = 729;
-        }
-
-        virtual unsigned int offset730(int) {
-            return offset = 730;
-        }
-
-        virtual unsigned int offset731(int) {
-            return offset = 731;
-        }
-
-        virtual unsigned int offset732(int) {
-            return offset = 732;
-        }
-
-        virtual unsigned int offset733(int) {
-            return offset = 733;
-        }
-
-        virtual unsigned int offset734(int) {
-            return offset = 734;
-        }
-
-        virtual unsigned int offset735(int) {
-            return offset = 735;
-        }
-
-        virtual unsigned int offset736(int) {
-            return offset = 736;
-        }
-
-        virtual unsigned int offset737(int) {
-            return offset = 737;
-        }
-
-        virtual unsigned int offset738(int) {
-            return offset = 738;
-        }
-
-        virtual unsigned int offset739(int) {
-            return offset = 739;
-        }
-
-        virtual unsigned int offset740(int) {
-            return offset = 740;
-        }
-
-        virtual unsigned int offset741(int) {
-            return offset = 741;
-        }
-
-        virtual unsigned int offset742(int) {
-            return offset = 742;
-        }
-
-        virtual unsigned int offset743(int) {
-            return offset = 743;
-        }
-
-        virtual unsigned int offset744(int) {
-            return offset = 744;
-        }
-
-        virtual unsigned int offset745(int) {
-            return offset = 745;
-        }
-
-        virtual unsigned int offset746(int) {
-            return offset = 746;
-        }
-
-        virtual unsigned int offset747(int) {
-            return offset = 747;
-        }
-
-        virtual unsigned int offset748(int) {
-            return offset = 748;
-        }
-
-        virtual unsigned int offset749(int) {
-            return offset = 749;
-        }
-
-        virtual unsigned int offset750(int) {
-            return offset = 750;
-        }
-
-        virtual unsigned int offset751(int) {
-            return offset = 751;
-        }
-
-        virtual unsigned int offset752(int) {
-            return offset = 752;
-        }
-
-        virtual unsigned int offset753(int) {
-            return offset = 753;
-        }
-
-        virtual unsigned int offset754(int) {
-            return offset = 754;
-        }
-
-        virtual unsigned int offset755(int) {
-            return offset = 755;
-        }
-
-        virtual unsigned int offset756(int) {
-            return offset = 756;
-        }
-
-        virtual unsigned int offset757(int) {
-            return offset = 757;
-        }
-
-        virtual unsigned int offset758(int) {
-            return offset = 758;
-        }
-
-        virtual unsigned int offset759(int) {
-            return offset = 759;
-        }
-
-        virtual unsigned int offset760(int) {
-            return offset = 760;
-        }
-
-        virtual unsigned int offset761(int) {
-            return offset = 761;
-        }
-
-        virtual unsigned int offset762(int) {
-            return offset = 762;
-        }
-
-        virtual unsigned int offset763(int) {
-            return offset = 763;
-        }
-
-        virtual unsigned int offset764(int) {
-            return offset = 764;
-        }
-
-        virtual unsigned int offset765(int) {
-            return offset = 765;
-        }
-
-        virtual unsigned int offset766(int) {
-            return offset = 766;
-        }
-
-        virtual unsigned int offset767(int) {
-            return offset = 767;
-        }
-
-        virtual unsigned int offset768(int) {
-            return offset = 768;
-        }
-
-        virtual unsigned int offset769(int) {
-            return offset = 769;
-        }
-
-        virtual unsigned int offset770(int) {
-            return offset = 770;
-        }
-
-        virtual unsigned int offset771(int) {
-            return offset = 771;
-        }
-
-        virtual unsigned int offset772(int) {
-            return offset = 772;
-        }
-
-        virtual unsigned int offset773(int) {
-            return offset = 773;
-        }
-
-        virtual unsigned int offset774(int) {
-            return offset = 774;
-        }
-
-        virtual unsigned int offset775(int) {
-            return offset = 775;
-        }
-
-        virtual unsigned int offset776(int) {
-            return offset = 776;
-        }
-
-        virtual unsigned int offset777(int) {
-            return offset = 777;
-        }
-
-        virtual unsigned int offset778(int) {
-            return offset = 778;
-        }
-
-        virtual unsigned int offset779(int) {
-            return offset = 779;
-        }
-
-        virtual unsigned int offset780(int) {
-            return offset = 780;
-        }
-
-        virtual unsigned int offset781(int) {
-            return offset = 781;
-        }
-
-        virtual unsigned int offset782(int) {
-            return offset = 782;
-        }
-
-        virtual unsigned int offset783(int) {
-            return offset = 783;
-        }
-
-        virtual unsigned int offset784(int) {
-            return offset = 784;
-        }
-
-        virtual unsigned int offset785(int) {
-            return offset = 785;
-        }
-
-        virtual unsigned int offset786(int) {
-            return offset = 786;
-        }
-
-        virtual unsigned int offset787(int) {
-            return offset = 787;
-        }
-
-        virtual unsigned int offset788(int) {
-            return offset = 788;
-        }
-
-        virtual unsigned int offset789(int) {
-            return offset = 789;
-        }
-
-        virtual unsigned int offset790(int) {
-            return offset = 790;
-        }
-
-        virtual unsigned int offset791(int) {
-            return offset = 791;
-        }
-
-        virtual unsigned int offset792(int) {
-            return offset = 792;
-        }
-
-        virtual unsigned int offset793(int) {
-            return offset = 793;
-        }
-
-        virtual unsigned int offset794(int) {
-            return offset = 794;
-        }
-
-        virtual unsigned int offset795(int) {
-            return offset = 795;
-        }
-
-        virtual unsigned int offset796(int) {
-            return offset = 796;
-        }
-
-        virtual unsigned int offset797(int) {
-            return offset = 797;
-        }
-
-        virtual unsigned int offset798(int) {
-            return offset = 798;
-        }
-
-        virtual unsigned int offset799(int) {
-            return offset = 799;
-        }
-
-
-        virtual unsigned int offset800(int) {
-            return offset = 800;
-        }
-
-        virtual unsigned int offset801(int) {
-            return offset = 801;
-        }
-
-        virtual unsigned int offset802(int) {
-            return offset = 802;
-        }
-
-        virtual unsigned int offset803(int) {
-            return offset = 803;
-        }
-
-        virtual unsigned int offset804(int) {
-            return offset = 804;
-        }
-
-        virtual unsigned int offset805(int) {
-            return offset = 805;
-        }
-
-        virtual unsigned int offset806(int) {
-            return offset = 806;
-        }
-
-        virtual unsigned int offset807(int) {
-            return offset = 807;
-        }
-
-        virtual unsigned int offset808(int) {
-            return offset = 808;
-        }
-
-        virtual unsigned int offset809(int) {
-            return offset = 809;
-        }
-
-        virtual unsigned int offset810(int) {
-            return offset = 810;
-        }
-
-        virtual unsigned int offset811(int) {
-            return offset = 811;
-        }
-
-        virtual unsigned int offset812(int) {
-            return offset = 812;
-        }
-
-        virtual unsigned int offset813(int) {
-            return offset = 813;
-        }
-
-        virtual unsigned int offset814(int) {
-            return offset = 814;
-        }
-
-        virtual unsigned int offset815(int) {
-            return offset = 815;
-        }
-
-        virtual unsigned int offset816(int) {
-            return offset = 816;
-        }
-
-        virtual unsigned int offset817(int) {
-            return offset = 817;
-        }
-
-        virtual unsigned int offset818(int) {
-            return offset = 818;
-        }
-
-        virtual unsigned int offset819(int) {
-            return offset = 819;
-        }
-
-        virtual unsigned int offset820(int) {
-            return offset = 820;
-        }
-
-        virtual unsigned int offset821(int) {
-            return offset = 821;
-        }
-
-        virtual unsigned int offset822(int) {
-            return offset = 822;
-        }
-
-        virtual unsigned int offset823(int) {
-            return offset = 823;
-        }
-
-        virtual unsigned int offset824(int) {
-            return offset = 824;
-        }
-
-        virtual unsigned int offset825(int) {
-            return offset = 825;
-        }
-
-        virtual unsigned int offset826(int) {
-            return offset = 826;
-        }
-
-        virtual unsigned int offset827(int) {
-            return offset = 827;
-        }
-
-        virtual unsigned int offset828(int) {
-            return offset = 828;
-        }
-
-        virtual unsigned int offset829(int) {
-            return offset = 829;
-        }
-
-        virtual unsigned int offset830(int) {
-            return offset = 830;
-        }
-
-        virtual unsigned int offset831(int) {
-            return offset = 831;
-        }
-
-        virtual unsigned int offset832(int) {
-            return offset = 832;
-        }
-
-        virtual unsigned int offset833(int) {
-            return offset = 833;
-        }
-
-        virtual unsigned int offset834(int) {
-            return offset = 834;
-        }
-
-        virtual unsigned int offset835(int) {
-            return offset = 835;
-        }
-
-        virtual unsigned int offset836(int) {
-            return offset = 836;
-        }
-
-        virtual unsigned int offset837(int) {
-            return offset = 837;
-        }
-
-        virtual unsigned int offset838(int) {
-            return offset = 838;
-        }
-
-        virtual unsigned int offset839(int) {
-            return offset = 839;
-        }
-
-        virtual unsigned int offset840(int) {
-            return offset = 840;
-        }
-
-        virtual unsigned int offset841(int) {
-            return offset = 841;
-        }
-
-        virtual unsigned int offset842(int) {
-            return offset = 842;
-        }
-
-        virtual unsigned int offset843(int) {
-            return offset = 843;
-        }
-
-        virtual unsigned int offset844(int) {
-            return offset = 844;
-        }
-
-        virtual unsigned int offset845(int) {
-            return offset = 845;
-        }
-
-        virtual unsigned int offset846(int) {
-            return offset = 846;
-        }
-
-        virtual unsigned int offset847(int) {
-            return offset = 847;
-        }
-
-        virtual unsigned int offset848(int) {
-            return offset = 848;
-        }
-
-        virtual unsigned int offset849(int) {
-            return offset = 849;
-        }
-
-        virtual unsigned int offset850(int) {
-            return offset = 850;
-        }
-
-        virtual unsigned int offset851(int) {
-            return offset = 851;
-        }
-
-        virtual unsigned int offset852(int) {
-            return offset = 852;
-        }
-
-        virtual unsigned int offset853(int) {
-            return offset = 853;
-        }
-
-        virtual unsigned int offset854(int) {
-            return offset = 854;
-        }
-
-        virtual unsigned int offset855(int) {
-            return offset = 855;
-        }
-
-        virtual unsigned int offset856(int) {
-            return offset = 856;
-        }
-
-        virtual unsigned int offset857(int) {
-            return offset = 857;
-        }
-
-        virtual unsigned int offset858(int) {
-            return offset = 858;
-        }
-
-        virtual unsigned int offset859(int) {
-            return offset = 859;
-        }
-
-        virtual unsigned int offset860(int) {
-            return offset = 860;
-        }
-
-        virtual unsigned int offset861(int) {
-            return offset = 861;
-        }
-
-        virtual unsigned int offset862(int) {
-            return offset = 862;
-        }
-
-        virtual unsigned int offset863(int) {
-            return offset = 863;
-        }
-
-        virtual unsigned int offset864(int) {
-            return offset = 864;
-        }
-
-        virtual unsigned int offset865(int) {
-            return offset = 865;
-        }
-
-        virtual unsigned int offset866(int) {
-            return offset = 866;
-        }
-
-        virtual unsigned int offset867(int) {
-            return offset = 867;
-        }
-
-        virtual unsigned int offset868(int) {
-            return offset = 868;
-        }
-
-        virtual unsigned int offset869(int) {
-            return offset = 869;
-        }
-
-        virtual unsigned int offset870(int) {
-            return offset = 870;
-        }
-
-        virtual unsigned int offset871(int) {
-            return offset = 871;
-        }
-
-        virtual unsigned int offset872(int) {
-            return offset = 872;
-        }
-
-        virtual unsigned int offset873(int) {
-            return offset = 873;
-        }
-
-        virtual unsigned int offset874(int) {
-            return offset = 874;
-        }
-
-        virtual unsigned int offset875(int) {
-            return offset = 875;
-        }
-
-        virtual unsigned int offset876(int) {
-            return offset = 876;
-        }
-
-        virtual unsigned int offset877(int) {
-            return offset = 877;
-        }
-
-        virtual unsigned int offset878(int) {
-            return offset = 878;
-        }
-
-        virtual unsigned int offset879(int) {
-            return offset = 879;
-        }
-
-        virtual unsigned int offset880(int) {
-            return offset = 880;
-        }
-
-        virtual unsigned int offset881(int) {
-            return offset = 881;
-        }
-
-        virtual unsigned int offset882(int) {
-            return offset = 882;
-        }
-
-        virtual unsigned int offset883(int) {
-            return offset = 883;
-        }
-
-        virtual unsigned int offset884(int) {
-            return offset = 884;
-        }
-
-        virtual unsigned int offset885(int) {
-            return offset = 885;
-        }
-
-        virtual unsigned int offset886(int) {
-            return offset = 886;
-        }
-
-        virtual unsigned int offset887(int) {
-            return offset = 887;
-        }
-
-        virtual unsigned int offset888(int) {
-            return offset = 888;
-        }
-
-        virtual unsigned int offset889(int) {
-            return offset = 889;
-        }
-
-        virtual unsigned int offset890(int) {
-            return offset = 890;
-        }
-
-        virtual unsigned int offset891(int) {
-            return offset = 891;
-        }
-
-        virtual unsigned int offset892(int) {
-            return offset = 892;
-        }
-
-        virtual unsigned int offset893(int) {
-            return offset = 893;
-        }
-
-        virtual unsigned int offset894(int) {
-            return offset = 894;
-        }
-
-        virtual unsigned int offset895(int) {
-            return offset = 895;
-        }
-
-        virtual unsigned int offset896(int) {
-            return offset = 896;
-        }
-
-        virtual unsigned int offset897(int) {
-            return offset = 897;
-        }
-
-        virtual unsigned int offset898(int) {
-            return offset = 898;
-        }
-
-        virtual unsigned int offset899(int) {
-            return offset = 899;
-        }
-
-
-        virtual unsigned int offset900(int) {
-            return offset = 900;
-        }
-
-        virtual unsigned int offset901(int) {
-            return offset = 901;
-        }
-
-        virtual unsigned int offset902(int) {
-            return offset = 902;
-        }
-
-        virtual unsigned int offset903(int) {
-            return offset = 903;
-        }
-
-        virtual unsigned int offset904(int) {
-            return offset = 904;
-        }
-
-        virtual unsigned int offset905(int) {
-            return offset = 905;
-        }
-
-        virtual unsigned int offset906(int) {
-            return offset = 906;
-        }
-
-        virtual unsigned int offset907(int) {
-            return offset = 907;
-        }
-
-        virtual unsigned int offset908(int) {
-            return offset = 908;
-        }
-
-        virtual unsigned int offset909(int) {
-            return offset = 909;
-        }
-
-        virtual unsigned int offset910(int) {
-            return offset = 910;
-        }
-
-        virtual unsigned int offset911(int) {
-            return offset = 911;
-        }
-
-        virtual unsigned int offset912(int) {
-            return offset = 912;
-        }
-
-        virtual unsigned int offset913(int) {
-            return offset = 913;
-        }
-
-        virtual unsigned int offset914(int) {
-            return offset = 914;
-        }
-
-        virtual unsigned int offset915(int) {
-            return offset = 915;
-        }
-
-        virtual unsigned int offset916(int) {
-            return offset = 916;
-        }
-
-        virtual unsigned int offset917(int) {
-            return offset = 917;
-        }
-
-        virtual unsigned int offset918(int) {
-            return offset = 918;
-        }
-
-        virtual unsigned int offset919(int) {
-            return offset = 919;
-        }
-
-        virtual unsigned int offset920(int) {
-            return offset = 920;
-        }
-
-        virtual unsigned int offset921(int) {
-            return offset = 921;
-        }
-
-        virtual unsigned int offset922(int) {
-            return offset = 922;
-        }
-
-        virtual unsigned int offset923(int) {
-            return offset = 923;
-        }
-
-        virtual unsigned int offset924(int) {
-            return offset = 924;
-        }
-
-        virtual unsigned int offset925(int) {
-            return offset = 925;
-        }
-
-        virtual unsigned int offset926(int) {
-            return offset = 926;
-        }
-
-        virtual unsigned int offset927(int) {
-            return offset = 927;
-        }
-
-        virtual unsigned int offset928(int) {
-            return offset = 928;
-        }
-
-        virtual unsigned int offset929(int) {
-            return offset = 929;
-        }
-
-        virtual unsigned int offset930(int) {
-            return offset = 930;
-        }
-
-        virtual unsigned int offset931(int) {
-            return offset = 931;
-        }
-
-        virtual unsigned int offset932(int) {
-            return offset = 932;
-        }
-
-        virtual unsigned int offset933(int) {
-            return offset = 933;
-        }
-
-        virtual unsigned int offset934(int) {
-            return offset = 934;
-        }
-
-        virtual unsigned int offset935(int) {
-            return offset = 935;
-        }
-
-        virtual unsigned int offset936(int) {
-            return offset = 936;
-        }
-
-        virtual unsigned int offset937(int) {
-            return offset = 937;
-        }
-
-        virtual unsigned int offset938(int) {
-            return offset = 938;
-        }
-
-        virtual unsigned int offset939(int) {
-            return offset = 939;
-        }
-
-        virtual unsigned int offset940(int) {
-            return offset = 940;
-        }
-
-        virtual unsigned int offset941(int) {
-            return offset = 941;
-        }
-
-        virtual unsigned int offset942(int) {
-            return offset = 942;
-        }
-
-        virtual unsigned int offset943(int) {
-            return offset = 943;
-        }
-
-        virtual unsigned int offset944(int) {
-            return offset = 944;
-        }
-
-        virtual unsigned int offset945(int) {
-            return offset = 945;
-        }
-
-        virtual unsigned int offset946(int) {
-            return offset = 946;
-        }
-
-        virtual unsigned int offset947(int) {
-            return offset = 947;
-        }
-
-        virtual unsigned int offset948(int) {
-            return offset = 948;
-        }
-
-        virtual unsigned int offset949(int) {
-            return offset = 949;
-        }
-
-        virtual unsigned int offset950(int) {
-            return offset = 950;
-        }
-
-        virtual unsigned int offset951(int) {
-            return offset = 951;
-        }
-
-        virtual unsigned int offset952(int) {
-            return offset = 952;
-        }
-
-        virtual unsigned int offset953(int) {
-            return offset = 953;
-        }
-
-        virtual unsigned int offset954(int) {
-            return offset = 954;
-        }
-
-        virtual unsigned int offset955(int) {
-            return offset = 955;
-        }
-
-        virtual unsigned int offset956(int) {
-            return offset = 956;
-        }
-
-        virtual unsigned int offset957(int) {
-            return offset = 957;
-        }
-
-        virtual unsigned int offset958(int) {
-            return offset = 958;
-        }
-
-        virtual unsigned int offset959(int) {
-            return offset = 959;
-        }
-
-        virtual unsigned int offset960(int) {
-            return offset = 960;
-        }
-
-        virtual unsigned int offset961(int) {
-            return offset = 961;
-        }
-
-        virtual unsigned int offset962(int) {
-            return offset = 962;
-        }
-
-        virtual unsigned int offset963(int) {
-            return offset = 963;
-        }
-
-        virtual unsigned int offset964(int) {
-            return offset = 964;
-        }
-
-        virtual unsigned int offset965(int) {
-            return offset = 965;
-        }
-
-        virtual unsigned int offset966(int) {
-            return offset = 966;
-        }
-
-        virtual unsigned int offset967(int) {
-            return offset = 967;
-        }
-
-        virtual unsigned int offset968(int) {
-            return offset = 968;
-        }
-
-        virtual unsigned int offset969(int) {
-            return offset = 969;
-        }
-
-        virtual unsigned int offset970(int) {
-            return offset = 970;
-        }
-
-        virtual unsigned int offset971(int) {
-            return offset = 971;
-        }
-
-        virtual unsigned int offset972(int) {
-            return offset = 972;
-        }
-
-        virtual unsigned int offset973(int) {
-            return offset = 973;
-        }
-
-        virtual unsigned int offset974(int) {
-            return offset = 974;
-        }
-
-        virtual unsigned int offset975(int) {
-            return offset = 975;
-        }
-
-        virtual unsigned int offset976(int) {
-            return offset = 976;
-        }
-
-        virtual unsigned int offset977(int) {
-            return offset = 977;
-        }
-
-        virtual unsigned int offset978(int) {
-            return offset = 978;
-        }
-
-        virtual unsigned int offset979(int) {
-            return offset = 979;
-        }
-
-        virtual unsigned int offset980(int) {
-            return offset = 980;
-        }
-
-        virtual unsigned int offset981(int) {
-            return offset = 981;
-        }
-
-        virtual unsigned int offset982(int) {
-            return offset = 982;
-        }
-
-        virtual unsigned int offset983(int) {
-            return offset = 983;
-        }
-
-        virtual unsigned int offset984(int) {
-            return offset = 984;
-        }
-
-        virtual unsigned int offset985(int) {
-            return offset = 985;
-        }
-
-        virtual unsigned int offset986(int) {
-            return offset = 986;
-        }
-
-        virtual unsigned int offset987(int) {
-            return offset = 987;
-        }
-
-        virtual unsigned int offset988(int) {
-            return offset = 988;
-        }
-
-        virtual unsigned int offset989(int) {
-            return offset = 989;
-        }
-
-        virtual unsigned int offset990(int) {
-            return offset = 990;
-        }
-
-        virtual unsigned int offset991(int) {
-            return offset = 991;
-        }
-
-        virtual unsigned int offset992(int) {
-            return offset = 992;
-        }
-
-        virtual unsigned int offset993(int) {
-            return offset = 993;
-        }
-
-        virtual unsigned int offset994(int) {
-            return offset = 994;
-        }
-
-        virtual unsigned int offset995(int) {
-            return offset = 995;
-        }
-
-        virtual unsigned int offset996(int) {
-            return offset = 996;
-        }
-
-        virtual unsigned int offset997(int) {
-            return offset = 997;
-        }
-
-        virtual unsigned int offset998(int) {
-            return offset = 998;
-        }
-
-        virtual unsigned int offset999(int) {
-            return offset = 999;
-        }
-
-        virtual unsigned int offset1000(int) {
-            return offset = 1000;
-        }
-
+    template<typename CONVENTION>
+	struct VirtualOffsetSelector{};
+
+// Creates a virtual offset selector specialization for a specific calling convention.
+#define FAKEIT_MAKE_SELECTOR( CONVENTION_TAG, CONVENTION_SPECIFIER ) \
+	template<> \
+    struct VirtualOffsetSelector<CONVENTION_TAG> { \
+ \
+        unsigned int offset; \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset0(int) { \
+            return offset = 0; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset1(int) { \
+            return offset = 1; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset2(int) { \
+            return offset = 2; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset3(int) { \
+            return offset = 3; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset4(int) { \
+            return offset = 4; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset5(int) { \
+            return offset = 5; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset6(int) { \
+            return offset = 6; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset7(int) { \
+            return offset = 7; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset8(int) { \
+            return offset = 8; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset9(int) { \
+            return offset = 9; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset10(int) { \
+            return offset = 10; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset11(int) { \
+            return offset = 11; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset12(int) { \
+            return offset = 12; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset13(int) { \
+            return offset = 13; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset14(int) { \
+            return offset = 14; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset15(int) { \
+            return offset = 15; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset16(int) { \
+            return offset = 16; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset17(int) { \
+            return offset = 17; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset18(int) { \
+            return offset = 18; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset19(int) { \
+            return offset = 19; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset20(int) { \
+            return offset = 20; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset21(int) { \
+            return offset = 21; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset22(int) { \
+            return offset = 22; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset23(int) { \
+            return offset = 23; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset24(int) { \
+            return offset = 24; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset25(int) { \
+            return offset = 25; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset26(int) { \
+            return offset = 26; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset27(int) { \
+            return offset = 27; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset28(int) { \
+            return offset = 28; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset29(int) { \
+            return offset = 29; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset30(int) { \
+            return offset = 30; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset31(int) { \
+            return offset = 31; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset32(int) { \
+            return offset = 32; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset33(int) { \
+            return offset = 33; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset34(int) { \
+            return offset = 34; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset35(int) { \
+            return offset = 35; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset36(int) { \
+            return offset = 36; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset37(int) { \
+            return offset = 37; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset38(int) { \
+            return offset = 38; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset39(int) { \
+            return offset = 39; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset40(int) { \
+            return offset = 40; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset41(int) { \
+            return offset = 41; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset42(int) { \
+            return offset = 42; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset43(int) { \
+            return offset = 43; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset44(int) { \
+            return offset = 44; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset45(int) { \
+            return offset = 45; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset46(int) { \
+            return offset = 46; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset47(int) { \
+            return offset = 47; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset48(int) { \
+            return offset = 48; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset49(int) { \
+            return offset = 49; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset50(int) { \
+            return offset = 50; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset51(int) { \
+            return offset = 51; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset52(int) { \
+            return offset = 52; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset53(int) { \
+            return offset = 53; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset54(int) { \
+            return offset = 54; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset55(int) { \
+            return offset = 55; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset56(int) { \
+            return offset = 56; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset57(int) { \
+            return offset = 57; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset58(int) { \
+            return offset = 58; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset59(int) { \
+            return offset = 59; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset60(int) { \
+            return offset = 60; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset61(int) { \
+            return offset = 61; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset62(int) { \
+            return offset = 62; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset63(int) { \
+            return offset = 63; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset64(int) { \
+            return offset = 64; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset65(int) { \
+            return offset = 65; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset66(int) { \
+            return offset = 66; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset67(int) { \
+            return offset = 67; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset68(int) { \
+            return offset = 68; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset69(int) { \
+            return offset = 69; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset70(int) { \
+            return offset = 70; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset71(int) { \
+            return offset = 71; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset72(int) { \
+            return offset = 72; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset73(int) { \
+            return offset = 73; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset74(int) { \
+            return offset = 74; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset75(int) { \
+            return offset = 75; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset76(int) { \
+            return offset = 76; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset77(int) { \
+            return offset = 77; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset78(int) { \
+            return offset = 78; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset79(int) { \
+            return offset = 79; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset80(int) { \
+            return offset = 80; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset81(int) { \
+            return offset = 81; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset82(int) { \
+            return offset = 82; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset83(int) { \
+            return offset = 83; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset84(int) { \
+            return offset = 84; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset85(int) { \
+            return offset = 85; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset86(int) { \
+            return offset = 86; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset87(int) { \
+            return offset = 87; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset88(int) { \
+            return offset = 88; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset89(int) { \
+            return offset = 89; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset90(int) { \
+            return offset = 90; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset91(int) { \
+            return offset = 91; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset92(int) { \
+            return offset = 92; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset93(int) { \
+            return offset = 93; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset94(int) { \
+            return offset = 94; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset95(int) { \
+            return offset = 95; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset96(int) { \
+            return offset = 96; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset97(int) { \
+            return offset = 97; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset98(int) { \
+            return offset = 98; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset99(int) { \
+            return offset = 99; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset100(int) { \
+            return offset = 100; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset101(int) { \
+            return offset = 101; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset102(int) { \
+            return offset = 102; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset103(int) { \
+            return offset = 103; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset104(int) { \
+            return offset = 104; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset105(int) { \
+            return offset = 105; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset106(int) { \
+            return offset = 106; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset107(int) { \
+            return offset = 107; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset108(int) { \
+            return offset = 108; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset109(int) { \
+            return offset = 109; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset110(int) { \
+            return offset = 110; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset111(int) { \
+            return offset = 111; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset112(int) { \
+            return offset = 112; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset113(int) { \
+            return offset = 113; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset114(int) { \
+            return offset = 114; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset115(int) { \
+            return offset = 115; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset116(int) { \
+            return offset = 116; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset117(int) { \
+            return offset = 117; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset118(int) { \
+            return offset = 118; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset119(int) { \
+            return offset = 119; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset120(int) { \
+            return offset = 120; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset121(int) { \
+            return offset = 121; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset122(int) { \
+            return offset = 122; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset123(int) { \
+            return offset = 123; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset124(int) { \
+            return offset = 124; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset125(int) { \
+            return offset = 125; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset126(int) { \
+            return offset = 126; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset127(int) { \
+            return offset = 127; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset128(int) { \
+            return offset = 128; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset129(int) { \
+            return offset = 129; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset130(int) { \
+            return offset = 130; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset131(int) { \
+            return offset = 131; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset132(int) { \
+            return offset = 132; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset133(int) { \
+            return offset = 133; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset134(int) { \
+            return offset = 134; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset135(int) { \
+            return offset = 135; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset136(int) { \
+            return offset = 136; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset137(int) { \
+            return offset = 137; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset138(int) { \
+            return offset = 138; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset139(int) { \
+            return offset = 139; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset140(int) { \
+            return offset = 140; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset141(int) { \
+            return offset = 141; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset142(int) { \
+            return offset = 142; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset143(int) { \
+            return offset = 143; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset144(int) { \
+            return offset = 144; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset145(int) { \
+            return offset = 145; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset146(int) { \
+            return offset = 146; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset147(int) { \
+            return offset = 147; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset148(int) { \
+            return offset = 148; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset149(int) { \
+            return offset = 149; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset150(int) { \
+            return offset = 150; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset151(int) { \
+            return offset = 151; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset152(int) { \
+            return offset = 152; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset153(int) { \
+            return offset = 153; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset154(int) { \
+            return offset = 154; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset155(int) { \
+            return offset = 155; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset156(int) { \
+            return offset = 156; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset157(int) { \
+            return offset = 157; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset158(int) { \
+            return offset = 158; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset159(int) { \
+            return offset = 159; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset160(int) { \
+            return offset = 160; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset161(int) { \
+            return offset = 161; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset162(int) { \
+            return offset = 162; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset163(int) { \
+            return offset = 163; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset164(int) { \
+            return offset = 164; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset165(int) { \
+            return offset = 165; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset166(int) { \
+            return offset = 166; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset167(int) { \
+            return offset = 167; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset168(int) { \
+            return offset = 168; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset169(int) { \
+            return offset = 169; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset170(int) { \
+            return offset = 170; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset171(int) { \
+            return offset = 171; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset172(int) { \
+            return offset = 172; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset173(int) { \
+            return offset = 173; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset174(int) { \
+            return offset = 174; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset175(int) { \
+            return offset = 175; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset176(int) { \
+            return offset = 176; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset177(int) { \
+            return offset = 177; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset178(int) { \
+            return offset = 178; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset179(int) { \
+            return offset = 179; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset180(int) { \
+            return offset = 180; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset181(int) { \
+            return offset = 181; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset182(int) { \
+            return offset = 182; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset183(int) { \
+            return offset = 183; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset184(int) { \
+            return offset = 184; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset185(int) { \
+            return offset = 185; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset186(int) { \
+            return offset = 186; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset187(int) { \
+            return offset = 187; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset188(int) { \
+            return offset = 188; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset189(int) { \
+            return offset = 189; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset190(int) { \
+            return offset = 190; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset191(int) { \
+            return offset = 191; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset192(int) { \
+            return offset = 192; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset193(int) { \
+            return offset = 193; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset194(int) { \
+            return offset = 194; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset195(int) { \
+            return offset = 195; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset196(int) { \
+            return offset = 196; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset197(int) { \
+            return offset = 197; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset198(int) { \
+            return offset = 198; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset199(int) { \
+            return offset = 199; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset200(int) { \
+            return offset = 200; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset201(int) { \
+            return offset = 201; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset202(int) { \
+            return offset = 202; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset203(int) { \
+            return offset = 203; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset204(int) { \
+            return offset = 204; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset205(int) { \
+            return offset = 205; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset206(int) { \
+            return offset = 206; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset207(int) { \
+            return offset = 207; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset208(int) { \
+            return offset = 208; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset209(int) { \
+            return offset = 209; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset210(int) { \
+            return offset = 210; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset211(int) { \
+            return offset = 211; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset212(int) { \
+            return offset = 212; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset213(int) { \
+            return offset = 213; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset214(int) { \
+            return offset = 214; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset215(int) { \
+            return offset = 215; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset216(int) { \
+            return offset = 216; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset217(int) { \
+            return offset = 217; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset218(int) { \
+            return offset = 218; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset219(int) { \
+            return offset = 219; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset220(int) { \
+            return offset = 220; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset221(int) { \
+            return offset = 221; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset222(int) { \
+            return offset = 222; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset223(int) { \
+            return offset = 223; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset224(int) { \
+            return offset = 224; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset225(int) { \
+            return offset = 225; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset226(int) { \
+            return offset = 226; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset227(int) { \
+            return offset = 227; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset228(int) { \
+            return offset = 228; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset229(int) { \
+            return offset = 229; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset230(int) { \
+            return offset = 230; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset231(int) { \
+            return offset = 231; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset232(int) { \
+            return offset = 232; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset233(int) { \
+            return offset = 233; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset234(int) { \
+            return offset = 234; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset235(int) { \
+            return offset = 235; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset236(int) { \
+            return offset = 236; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset237(int) { \
+            return offset = 237; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset238(int) { \
+            return offset = 238; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset239(int) { \
+            return offset = 239; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset240(int) { \
+            return offset = 240; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset241(int) { \
+            return offset = 241; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset242(int) { \
+            return offset = 242; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset243(int) { \
+            return offset = 243; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset244(int) { \
+            return offset = 244; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset245(int) { \
+            return offset = 245; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset246(int) { \
+            return offset = 246; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset247(int) { \
+            return offset = 247; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset248(int) { \
+            return offset = 248; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset249(int) { \
+            return offset = 249; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset250(int) { \
+            return offset = 250; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset251(int) { \
+            return offset = 251; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset252(int) { \
+            return offset = 252; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset253(int) { \
+            return offset = 253; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset254(int) { \
+            return offset = 254; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset255(int) { \
+            return offset = 255; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset256(int) { \
+            return offset = 256; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset257(int) { \
+            return offset = 257; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset258(int) { \
+            return offset = 258; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset259(int) { \
+            return offset = 259; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset260(int) { \
+            return offset = 260; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset261(int) { \
+            return offset = 261; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset262(int) { \
+            return offset = 262; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset263(int) { \
+            return offset = 263; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset264(int) { \
+            return offset = 264; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset265(int) { \
+            return offset = 265; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset266(int) { \
+            return offset = 266; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset267(int) { \
+            return offset = 267; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset268(int) { \
+            return offset = 268; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset269(int) { \
+            return offset = 269; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset270(int) { \
+            return offset = 270; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset271(int) { \
+            return offset = 271; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset272(int) { \
+            return offset = 272; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset273(int) { \
+            return offset = 273; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset274(int) { \
+            return offset = 274; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset275(int) { \
+            return offset = 275; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset276(int) { \
+            return offset = 276; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset277(int) { \
+            return offset = 277; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset278(int) { \
+            return offset = 278; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset279(int) { \
+            return offset = 279; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset280(int) { \
+            return offset = 280; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset281(int) { \
+            return offset = 281; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset282(int) { \
+            return offset = 282; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset283(int) { \
+            return offset = 283; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset284(int) { \
+            return offset = 284; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset285(int) { \
+            return offset = 285; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset286(int) { \
+            return offset = 286; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset287(int) { \
+            return offset = 287; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset288(int) { \
+            return offset = 288; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset289(int) { \
+            return offset = 289; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset290(int) { \
+            return offset = 290; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset291(int) { \
+            return offset = 291; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset292(int) { \
+            return offset = 292; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset293(int) { \
+            return offset = 293; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset294(int) { \
+            return offset = 294; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset295(int) { \
+            return offset = 295; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset296(int) { \
+            return offset = 296; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset297(int) { \
+            return offset = 297; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset298(int) { \
+            return offset = 298; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset299(int) { \
+            return offset = 299; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset300(int) { \
+            return offset = 300; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset301(int) { \
+            return offset = 301; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset302(int) { \
+            return offset = 302; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset303(int) { \
+            return offset = 303; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset304(int) { \
+            return offset = 304; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset305(int) { \
+            return offset = 305; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset306(int) { \
+            return offset = 306; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset307(int) { \
+            return offset = 307; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset308(int) { \
+            return offset = 308; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset309(int) { \
+            return offset = 309; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset310(int) { \
+            return offset = 310; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset311(int) { \
+            return offset = 311; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset312(int) { \
+            return offset = 312; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset313(int) { \
+            return offset = 313; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset314(int) { \
+            return offset = 314; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset315(int) { \
+            return offset = 315; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset316(int) { \
+            return offset = 316; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset317(int) { \
+            return offset = 317; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset318(int) { \
+            return offset = 318; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset319(int) { \
+            return offset = 319; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset320(int) { \
+            return offset = 320; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset321(int) { \
+            return offset = 321; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset322(int) { \
+            return offset = 322; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset323(int) { \
+            return offset = 323; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset324(int) { \
+            return offset = 324; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset325(int) { \
+            return offset = 325; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset326(int) { \
+            return offset = 326; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset327(int) { \
+            return offset = 327; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset328(int) { \
+            return offset = 328; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset329(int) { \
+            return offset = 329; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset330(int) { \
+            return offset = 330; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset331(int) { \
+            return offset = 331; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset332(int) { \
+            return offset = 332; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset333(int) { \
+            return offset = 333; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset334(int) { \
+            return offset = 334; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset335(int) { \
+            return offset = 335; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset336(int) { \
+            return offset = 336; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset337(int) { \
+            return offset = 337; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset338(int) { \
+            return offset = 338; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset339(int) { \
+            return offset = 339; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset340(int) { \
+            return offset = 340; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset341(int) { \
+            return offset = 341; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset342(int) { \
+            return offset = 342; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset343(int) { \
+            return offset = 343; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset344(int) { \
+            return offset = 344; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset345(int) { \
+            return offset = 345; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset346(int) { \
+            return offset = 346; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset347(int) { \
+            return offset = 347; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset348(int) { \
+            return offset = 348; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset349(int) { \
+            return offset = 349; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset350(int) { \
+            return offset = 350; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset351(int) { \
+            return offset = 351; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset352(int) { \
+            return offset = 352; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset353(int) { \
+            return offset = 353; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset354(int) { \
+            return offset = 354; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset355(int) { \
+            return offset = 355; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset356(int) { \
+            return offset = 356; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset357(int) { \
+            return offset = 357; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset358(int) { \
+            return offset = 358; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset359(int) { \
+            return offset = 359; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset360(int) { \
+            return offset = 360; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset361(int) { \
+            return offset = 361; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset362(int) { \
+            return offset = 362; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset363(int) { \
+            return offset = 363; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset364(int) { \
+            return offset = 364; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset365(int) { \
+            return offset = 365; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset366(int) { \
+            return offset = 366; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset367(int) { \
+            return offset = 367; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset368(int) { \
+            return offset = 368; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset369(int) { \
+            return offset = 369; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset370(int) { \
+            return offset = 370; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset371(int) { \
+            return offset = 371; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset372(int) { \
+            return offset = 372; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset373(int) { \
+            return offset = 373; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset374(int) { \
+            return offset = 374; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset375(int) { \
+            return offset = 375; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset376(int) { \
+            return offset = 376; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset377(int) { \
+            return offset = 377; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset378(int) { \
+            return offset = 378; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset379(int) { \
+            return offset = 379; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset380(int) { \
+            return offset = 380; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset381(int) { \
+            return offset = 381; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset382(int) { \
+            return offset = 382; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset383(int) { \
+            return offset = 383; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset384(int) { \
+            return offset = 384; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset385(int) { \
+            return offset = 385; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset386(int) { \
+            return offset = 386; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset387(int) { \
+            return offset = 387; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset388(int) { \
+            return offset = 388; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset389(int) { \
+            return offset = 389; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset390(int) { \
+            return offset = 390; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset391(int) { \
+            return offset = 391; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset392(int) { \
+            return offset = 392; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset393(int) { \
+            return offset = 393; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset394(int) { \
+            return offset = 394; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset395(int) { \
+            return offset = 395; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset396(int) { \
+            return offset = 396; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset397(int) { \
+            return offset = 397; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset398(int) { \
+            return offset = 398; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset399(int) { \
+            return offset = 399; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset400(int) { \
+            return offset = 400; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset401(int) { \
+            return offset = 401; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset402(int) { \
+            return offset = 402; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset403(int) { \
+            return offset = 403; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset404(int) { \
+            return offset = 404; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset405(int) { \
+            return offset = 405; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset406(int) { \
+            return offset = 406; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset407(int) { \
+            return offset = 407; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset408(int) { \
+            return offset = 408; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset409(int) { \
+            return offset = 409; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset410(int) { \
+            return offset = 410; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset411(int) { \
+            return offset = 411; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset412(int) { \
+            return offset = 412; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset413(int) { \
+            return offset = 413; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset414(int) { \
+            return offset = 414; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset415(int) { \
+            return offset = 415; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset416(int) { \
+            return offset = 416; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset417(int) { \
+            return offset = 417; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset418(int) { \
+            return offset = 418; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset419(int) { \
+            return offset = 419; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset420(int) { \
+            return offset = 420; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset421(int) { \
+            return offset = 421; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset422(int) { \
+            return offset = 422; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset423(int) { \
+            return offset = 423; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset424(int) { \
+            return offset = 424; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset425(int) { \
+            return offset = 425; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset426(int) { \
+            return offset = 426; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset427(int) { \
+            return offset = 427; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset428(int) { \
+            return offset = 428; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset429(int) { \
+            return offset = 429; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset430(int) { \
+            return offset = 430; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset431(int) { \
+            return offset = 431; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset432(int) { \
+            return offset = 432; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset433(int) { \
+            return offset = 433; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset434(int) { \
+            return offset = 434; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset435(int) { \
+            return offset = 435; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset436(int) { \
+            return offset = 436; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset437(int) { \
+            return offset = 437; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset438(int) { \
+            return offset = 438; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset439(int) { \
+            return offset = 439; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset440(int) { \
+            return offset = 440; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset441(int) { \
+            return offset = 441; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset442(int) { \
+            return offset = 442; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset443(int) { \
+            return offset = 443; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset444(int) { \
+            return offset = 444; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset445(int) { \
+            return offset = 445; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset446(int) { \
+            return offset = 446; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset447(int) { \
+            return offset = 447; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset448(int) { \
+            return offset = 448; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset449(int) { \
+            return offset = 449; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset450(int) { \
+            return offset = 450; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset451(int) { \
+            return offset = 451; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset452(int) { \
+            return offset = 452; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset453(int) { \
+            return offset = 453; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset454(int) { \
+            return offset = 454; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset455(int) { \
+            return offset = 455; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset456(int) { \
+            return offset = 456; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset457(int) { \
+            return offset = 457; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset458(int) { \
+            return offset = 458; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset459(int) { \
+            return offset = 459; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset460(int) { \
+            return offset = 460; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset461(int) { \
+            return offset = 461; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset462(int) { \
+            return offset = 462; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset463(int) { \
+            return offset = 463; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset464(int) { \
+            return offset = 464; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset465(int) { \
+            return offset = 465; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset466(int) { \
+            return offset = 466; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset467(int) { \
+            return offset = 467; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset468(int) { \
+            return offset = 468; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset469(int) { \
+            return offset = 469; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset470(int) { \
+            return offset = 470; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset471(int) { \
+            return offset = 471; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset472(int) { \
+            return offset = 472; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset473(int) { \
+            return offset = 473; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset474(int) { \
+            return offset = 474; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset475(int) { \
+            return offset = 475; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset476(int) { \
+            return offset = 476; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset477(int) { \
+            return offset = 477; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset478(int) { \
+            return offset = 478; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset479(int) { \
+            return offset = 479; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset480(int) { \
+            return offset = 480; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset481(int) { \
+            return offset = 481; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset482(int) { \
+            return offset = 482; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset483(int) { \
+            return offset = 483; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset484(int) { \
+            return offset = 484; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset485(int) { \
+            return offset = 485; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset486(int) { \
+            return offset = 486; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset487(int) { \
+            return offset = 487; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset488(int) { \
+            return offset = 488; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset489(int) { \
+            return offset = 489; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset490(int) { \
+            return offset = 490; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset491(int) { \
+            return offset = 491; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset492(int) { \
+            return offset = 492; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset493(int) { \
+            return offset = 493; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset494(int) { \
+            return offset = 494; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset495(int) { \
+            return offset = 495; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset496(int) { \
+            return offset = 496; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset497(int) { \
+            return offset = 497; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset498(int) { \
+            return offset = 498; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset499(int) { \
+            return offset = 499; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset500(int) { \
+            return offset = 500; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset501(int) { \
+            return offset = 501; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset502(int) { \
+            return offset = 502; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset503(int) { \
+            return offset = 503; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset504(int) { \
+            return offset = 504; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset505(int) { \
+            return offset = 505; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset506(int) { \
+            return offset = 506; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset507(int) { \
+            return offset = 507; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset508(int) { \
+            return offset = 508; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset509(int) { \
+            return offset = 509; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset510(int) { \
+            return offset = 510; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset511(int) { \
+            return offset = 511; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset512(int) { \
+            return offset = 512; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset513(int) { \
+            return offset = 513; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset514(int) { \
+            return offset = 514; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset515(int) { \
+            return offset = 515; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset516(int) { \
+            return offset = 516; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset517(int) { \
+            return offset = 517; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset518(int) { \
+            return offset = 518; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset519(int) { \
+            return offset = 519; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset520(int) { \
+            return offset = 520; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset521(int) { \
+            return offset = 521; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset522(int) { \
+            return offset = 522; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset523(int) { \
+            return offset = 523; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset524(int) { \
+            return offset = 524; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset525(int) { \
+            return offset = 525; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset526(int) { \
+            return offset = 526; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset527(int) { \
+            return offset = 527; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset528(int) { \
+            return offset = 528; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset529(int) { \
+            return offset = 529; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset530(int) { \
+            return offset = 530; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset531(int) { \
+            return offset = 531; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset532(int) { \
+            return offset = 532; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset533(int) { \
+            return offset = 533; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset534(int) { \
+            return offset = 534; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset535(int) { \
+            return offset = 535; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset536(int) { \
+            return offset = 536; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset537(int) { \
+            return offset = 537; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset538(int) { \
+            return offset = 538; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset539(int) { \
+            return offset = 539; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset540(int) { \
+            return offset = 540; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset541(int) { \
+            return offset = 541; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset542(int) { \
+            return offset = 542; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset543(int) { \
+            return offset = 543; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset544(int) { \
+            return offset = 544; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset545(int) { \
+            return offset = 545; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset546(int) { \
+            return offset = 546; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset547(int) { \
+            return offset = 547; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset548(int) { \
+            return offset = 548; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset549(int) { \
+            return offset = 549; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset550(int) { \
+            return offset = 550; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset551(int) { \
+            return offset = 551; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset552(int) { \
+            return offset = 552; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset553(int) { \
+            return offset = 553; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset554(int) { \
+            return offset = 554; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset555(int) { \
+            return offset = 555; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset556(int) { \
+            return offset = 556; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset557(int) { \
+            return offset = 557; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset558(int) { \
+            return offset = 558; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset559(int) { \
+            return offset = 559; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset560(int) { \
+            return offset = 560; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset561(int) { \
+            return offset = 561; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset562(int) { \
+            return offset = 562; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset563(int) { \
+            return offset = 563; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset564(int) { \
+            return offset = 564; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset565(int) { \
+            return offset = 565; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset566(int) { \
+            return offset = 566; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset567(int) { \
+            return offset = 567; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset568(int) { \
+            return offset = 568; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset569(int) { \
+            return offset = 569; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset570(int) { \
+            return offset = 570; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset571(int) { \
+            return offset = 571; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset572(int) { \
+            return offset = 572; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset573(int) { \
+            return offset = 573; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset574(int) { \
+            return offset = 574; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset575(int) { \
+            return offset = 575; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset576(int) { \
+            return offset = 576; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset577(int) { \
+            return offset = 577; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset578(int) { \
+            return offset = 578; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset579(int) { \
+            return offset = 579; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset580(int) { \
+            return offset = 580; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset581(int) { \
+            return offset = 581; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset582(int) { \
+            return offset = 582; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset583(int) { \
+            return offset = 583; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset584(int) { \
+            return offset = 584; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset585(int) { \
+            return offset = 585; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset586(int) { \
+            return offset = 586; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset587(int) { \
+            return offset = 587; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset588(int) { \
+            return offset = 588; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset589(int) { \
+            return offset = 589; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset590(int) { \
+            return offset = 590; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset591(int) { \
+            return offset = 591; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset592(int) { \
+            return offset = 592; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset593(int) { \
+            return offset = 593; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset594(int) { \
+            return offset = 594; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset595(int) { \
+            return offset = 595; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset596(int) { \
+            return offset = 596; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset597(int) { \
+            return offset = 597; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset598(int) { \
+            return offset = 598; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset599(int) { \
+            return offset = 599; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset600(int) { \
+            return offset = 600; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset601(int) { \
+            return offset = 601; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset602(int) { \
+            return offset = 602; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset603(int) { \
+            return offset = 603; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset604(int) { \
+            return offset = 604; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset605(int) { \
+            return offset = 605; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset606(int) { \
+            return offset = 606; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset607(int) { \
+            return offset = 607; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset608(int) { \
+            return offset = 608; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset609(int) { \
+            return offset = 609; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset610(int) { \
+            return offset = 610; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset611(int) { \
+            return offset = 611; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset612(int) { \
+            return offset = 612; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset613(int) { \
+            return offset = 613; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset614(int) { \
+            return offset = 614; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset615(int) { \
+            return offset = 615; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset616(int) { \
+            return offset = 616; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset617(int) { \
+            return offset = 617; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset618(int) { \
+            return offset = 618; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset619(int) { \
+            return offset = 619; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset620(int) { \
+            return offset = 620; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset621(int) { \
+            return offset = 621; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset622(int) { \
+            return offset = 622; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset623(int) { \
+            return offset = 623; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset624(int) { \
+            return offset = 624; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset625(int) { \
+            return offset = 625; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset626(int) { \
+            return offset = 626; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset627(int) { \
+            return offset = 627; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset628(int) { \
+            return offset = 628; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset629(int) { \
+            return offset = 629; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset630(int) { \
+            return offset = 630; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset631(int) { \
+            return offset = 631; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset632(int) { \
+            return offset = 632; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset633(int) { \
+            return offset = 633; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset634(int) { \
+            return offset = 634; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset635(int) { \
+            return offset = 635; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset636(int) { \
+            return offset = 636; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset637(int) { \
+            return offset = 637; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset638(int) { \
+            return offset = 638; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset639(int) { \
+            return offset = 639; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset640(int) { \
+            return offset = 640; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset641(int) { \
+            return offset = 641; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset642(int) { \
+            return offset = 642; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset643(int) { \
+            return offset = 643; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset644(int) { \
+            return offset = 644; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset645(int) { \
+            return offset = 645; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset646(int) { \
+            return offset = 646; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset647(int) { \
+            return offset = 647; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset648(int) { \
+            return offset = 648; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset649(int) { \
+            return offset = 649; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset650(int) { \
+            return offset = 650; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset651(int) { \
+            return offset = 651; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset652(int) { \
+            return offset = 652; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset653(int) { \
+            return offset = 653; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset654(int) { \
+            return offset = 654; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset655(int) { \
+            return offset = 655; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset656(int) { \
+            return offset = 656; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset657(int) { \
+            return offset = 657; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset658(int) { \
+            return offset = 658; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset659(int) { \
+            return offset = 659; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset660(int) { \
+            return offset = 660; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset661(int) { \
+            return offset = 661; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset662(int) { \
+            return offset = 662; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset663(int) { \
+            return offset = 663; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset664(int) { \
+            return offset = 664; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset665(int) { \
+            return offset = 665; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset666(int) { \
+            return offset = 666; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset667(int) { \
+            return offset = 667; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset668(int) { \
+            return offset = 668; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset669(int) { \
+            return offset = 669; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset670(int) { \
+            return offset = 670; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset671(int) { \
+            return offset = 671; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset672(int) { \
+            return offset = 672; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset673(int) { \
+            return offset = 673; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset674(int) { \
+            return offset = 674; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset675(int) { \
+            return offset = 675; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset676(int) { \
+            return offset = 676; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset677(int) { \
+            return offset = 677; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset678(int) { \
+            return offset = 678; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset679(int) { \
+            return offset = 679; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset680(int) { \
+            return offset = 680; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset681(int) { \
+            return offset = 681; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset682(int) { \
+            return offset = 682; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset683(int) { \
+            return offset = 683; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset684(int) { \
+            return offset = 684; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset685(int) { \
+            return offset = 685; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset686(int) { \
+            return offset = 686; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset687(int) { \
+            return offset = 687; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset688(int) { \
+            return offset = 688; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset689(int) { \
+            return offset = 689; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset690(int) { \
+            return offset = 690; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset691(int) { \
+            return offset = 691; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset692(int) { \
+            return offset = 692; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset693(int) { \
+            return offset = 693; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset694(int) { \
+            return offset = 694; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset695(int) { \
+            return offset = 695; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset696(int) { \
+            return offset = 696; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset697(int) { \
+            return offset = 697; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset698(int) { \
+            return offset = 698; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset699(int) { \
+            return offset = 699; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset700(int) { \
+            return offset = 700; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset701(int) { \
+            return offset = 701; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset702(int) { \
+            return offset = 702; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset703(int) { \
+            return offset = 703; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset704(int) { \
+            return offset = 704; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset705(int) { \
+            return offset = 705; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset706(int) { \
+            return offset = 706; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset707(int) { \
+            return offset = 707; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset708(int) { \
+            return offset = 708; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset709(int) { \
+            return offset = 709; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset710(int) { \
+            return offset = 710; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset711(int) { \
+            return offset = 711; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset712(int) { \
+            return offset = 712; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset713(int) { \
+            return offset = 713; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset714(int) { \
+            return offset = 714; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset715(int) { \
+            return offset = 715; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset716(int) { \
+            return offset = 716; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset717(int) { \
+            return offset = 717; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset718(int) { \
+            return offset = 718; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset719(int) { \
+            return offset = 719; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset720(int) { \
+            return offset = 720; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset721(int) { \
+            return offset = 721; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset722(int) { \
+            return offset = 722; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset723(int) { \
+            return offset = 723; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset724(int) { \
+            return offset = 724; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset725(int) { \
+            return offset = 725; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset726(int) { \
+            return offset = 726; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset727(int) { \
+            return offset = 727; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset728(int) { \
+            return offset = 728; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset729(int) { \
+            return offset = 729; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset730(int) { \
+            return offset = 730; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset731(int) { \
+            return offset = 731; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset732(int) { \
+            return offset = 732; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset733(int) { \
+            return offset = 733; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset734(int) { \
+            return offset = 734; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset735(int) { \
+            return offset = 735; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset736(int) { \
+            return offset = 736; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset737(int) { \
+            return offset = 737; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset738(int) { \
+            return offset = 738; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset739(int) { \
+            return offset = 739; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset740(int) { \
+            return offset = 740; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset741(int) { \
+            return offset = 741; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset742(int) { \
+            return offset = 742; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset743(int) { \
+            return offset = 743; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset744(int) { \
+            return offset = 744; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset745(int) { \
+            return offset = 745; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset746(int) { \
+            return offset = 746; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset747(int) { \
+            return offset = 747; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset748(int) { \
+            return offset = 748; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset749(int) { \
+            return offset = 749; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset750(int) { \
+            return offset = 750; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset751(int) { \
+            return offset = 751; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset752(int) { \
+            return offset = 752; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset753(int) { \
+            return offset = 753; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset754(int) { \
+            return offset = 754; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset755(int) { \
+            return offset = 755; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset756(int) { \
+            return offset = 756; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset757(int) { \
+            return offset = 757; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset758(int) { \
+            return offset = 758; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset759(int) { \
+            return offset = 759; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset760(int) { \
+            return offset = 760; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset761(int) { \
+            return offset = 761; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset762(int) { \
+            return offset = 762; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset763(int) { \
+            return offset = 763; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset764(int) { \
+            return offset = 764; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset765(int) { \
+            return offset = 765; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset766(int) { \
+            return offset = 766; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset767(int) { \
+            return offset = 767; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset768(int) { \
+            return offset = 768; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset769(int) { \
+            return offset = 769; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset770(int) { \
+            return offset = 770; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset771(int) { \
+            return offset = 771; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset772(int) { \
+            return offset = 772; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset773(int) { \
+            return offset = 773; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset774(int) { \
+            return offset = 774; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset775(int) { \
+            return offset = 775; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset776(int) { \
+            return offset = 776; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset777(int) { \
+            return offset = 777; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset778(int) { \
+            return offset = 778; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset779(int) { \
+            return offset = 779; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset780(int) { \
+            return offset = 780; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset781(int) { \
+            return offset = 781; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset782(int) { \
+            return offset = 782; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset783(int) { \
+            return offset = 783; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset784(int) { \
+            return offset = 784; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset785(int) { \
+            return offset = 785; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset786(int) { \
+            return offset = 786; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset787(int) { \
+            return offset = 787; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset788(int) { \
+            return offset = 788; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset789(int) { \
+            return offset = 789; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset790(int) { \
+            return offset = 790; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset791(int) { \
+            return offset = 791; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset792(int) { \
+            return offset = 792; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset793(int) { \
+            return offset = 793; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset794(int) { \
+            return offset = 794; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset795(int) { \
+            return offset = 795; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset796(int) { \
+            return offset = 796; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset797(int) { \
+            return offset = 797; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset798(int) { \
+            return offset = 798; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset799(int) { \
+            return offset = 799; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset800(int) { \
+            return offset = 800; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset801(int) { \
+            return offset = 801; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset802(int) { \
+            return offset = 802; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset803(int) { \
+            return offset = 803; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset804(int) { \
+            return offset = 804; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset805(int) { \
+            return offset = 805; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset806(int) { \
+            return offset = 806; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset807(int) { \
+            return offset = 807; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset808(int) { \
+            return offset = 808; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset809(int) { \
+            return offset = 809; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset810(int) { \
+            return offset = 810; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset811(int) { \
+            return offset = 811; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset812(int) { \
+            return offset = 812; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset813(int) { \
+            return offset = 813; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset814(int) { \
+            return offset = 814; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset815(int) { \
+            return offset = 815; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset816(int) { \
+            return offset = 816; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset817(int) { \
+            return offset = 817; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset818(int) { \
+            return offset = 818; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset819(int) { \
+            return offset = 819; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset820(int) { \
+            return offset = 820; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset821(int) { \
+            return offset = 821; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset822(int) { \
+            return offset = 822; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset823(int) { \
+            return offset = 823; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset824(int) { \
+            return offset = 824; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset825(int) { \
+            return offset = 825; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset826(int) { \
+            return offset = 826; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset827(int) { \
+            return offset = 827; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset828(int) { \
+            return offset = 828; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset829(int) { \
+            return offset = 829; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset830(int) { \
+            return offset = 830; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset831(int) { \
+            return offset = 831; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset832(int) { \
+            return offset = 832; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset833(int) { \
+            return offset = 833; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset834(int) { \
+            return offset = 834; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset835(int) { \
+            return offset = 835; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset836(int) { \
+            return offset = 836; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset837(int) { \
+            return offset = 837; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset838(int) { \
+            return offset = 838; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset839(int) { \
+            return offset = 839; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset840(int) { \
+            return offset = 840; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset841(int) { \
+            return offset = 841; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset842(int) { \
+            return offset = 842; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset843(int) { \
+            return offset = 843; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset844(int) { \
+            return offset = 844; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset845(int) { \
+            return offset = 845; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset846(int) { \
+            return offset = 846; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset847(int) { \
+            return offset = 847; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset848(int) { \
+            return offset = 848; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset849(int) { \
+            return offset = 849; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset850(int) { \
+            return offset = 850; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset851(int) { \
+            return offset = 851; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset852(int) { \
+            return offset = 852; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset853(int) { \
+            return offset = 853; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset854(int) { \
+            return offset = 854; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset855(int) { \
+            return offset = 855; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset856(int) { \
+            return offset = 856; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset857(int) { \
+            return offset = 857; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset858(int) { \
+            return offset = 858; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset859(int) { \
+            return offset = 859; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset860(int) { \
+            return offset = 860; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset861(int) { \
+            return offset = 861; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset862(int) { \
+            return offset = 862; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset863(int) { \
+            return offset = 863; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset864(int) { \
+            return offset = 864; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset865(int) { \
+            return offset = 865; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset866(int) { \
+            return offset = 866; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset867(int) { \
+            return offset = 867; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset868(int) { \
+            return offset = 868; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset869(int) { \
+            return offset = 869; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset870(int) { \
+            return offset = 870; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset871(int) { \
+            return offset = 871; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset872(int) { \
+            return offset = 872; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset873(int) { \
+            return offset = 873; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset874(int) { \
+            return offset = 874; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset875(int) { \
+            return offset = 875; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset876(int) { \
+            return offset = 876; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset877(int) { \
+            return offset = 877; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset878(int) { \
+            return offset = 878; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset879(int) { \
+            return offset = 879; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset880(int) { \
+            return offset = 880; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset881(int) { \
+            return offset = 881; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset882(int) { \
+            return offset = 882; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset883(int) { \
+            return offset = 883; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset884(int) { \
+            return offset = 884; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset885(int) { \
+            return offset = 885; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset886(int) { \
+            return offset = 886; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset887(int) { \
+            return offset = 887; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset888(int) { \
+            return offset = 888; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset889(int) { \
+            return offset = 889; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset890(int) { \
+            return offset = 890; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset891(int) { \
+            return offset = 891; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset892(int) { \
+            return offset = 892; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset893(int) { \
+            return offset = 893; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset894(int) { \
+            return offset = 894; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset895(int) { \
+            return offset = 895; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset896(int) { \
+            return offset = 896; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset897(int) { \
+            return offset = 897; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset898(int) { \
+            return offset = 898; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset899(int) { \
+            return offset = 899; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset900(int) { \
+            return offset = 900; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset901(int) { \
+            return offset = 901; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset902(int) { \
+            return offset = 902; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset903(int) { \
+            return offset = 903; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset904(int) { \
+            return offset = 904; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset905(int) { \
+            return offset = 905; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset906(int) { \
+            return offset = 906; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset907(int) { \
+            return offset = 907; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset908(int) { \
+            return offset = 908; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset909(int) { \
+            return offset = 909; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset910(int) { \
+            return offset = 910; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset911(int) { \
+            return offset = 911; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset912(int) { \
+            return offset = 912; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset913(int) { \
+            return offset = 913; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset914(int) { \
+            return offset = 914; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset915(int) { \
+            return offset = 915; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset916(int) { \
+            return offset = 916; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset917(int) { \
+            return offset = 917; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset918(int) { \
+            return offset = 918; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset919(int) { \
+            return offset = 919; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset920(int) { \
+            return offset = 920; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset921(int) { \
+            return offset = 921; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset922(int) { \
+            return offset = 922; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset923(int) { \
+            return offset = 923; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset924(int) { \
+            return offset = 924; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset925(int) { \
+            return offset = 925; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset926(int) { \
+            return offset = 926; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset927(int) { \
+            return offset = 927; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset928(int) { \
+            return offset = 928; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset929(int) { \
+            return offset = 929; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset930(int) { \
+            return offset = 930; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset931(int) { \
+            return offset = 931; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset932(int) { \
+            return offset = 932; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset933(int) { \
+            return offset = 933; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset934(int) { \
+            return offset = 934; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset935(int) { \
+            return offset = 935; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset936(int) { \
+            return offset = 936; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset937(int) { \
+            return offset = 937; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset938(int) { \
+            return offset = 938; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset939(int) { \
+            return offset = 939; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset940(int) { \
+            return offset = 940; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset941(int) { \
+            return offset = 941; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset942(int) { \
+            return offset = 942; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset943(int) { \
+            return offset = 943; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset944(int) { \
+            return offset = 944; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset945(int) { \
+            return offset = 945; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset946(int) { \
+            return offset = 946; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset947(int) { \
+            return offset = 947; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset948(int) { \
+            return offset = 948; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset949(int) { \
+            return offset = 949; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset950(int) { \
+            return offset = 950; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset951(int) { \
+            return offset = 951; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset952(int) { \
+            return offset = 952; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset953(int) { \
+            return offset = 953; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset954(int) { \
+            return offset = 954; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset955(int) { \
+            return offset = 955; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset956(int) { \
+            return offset = 956; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset957(int) { \
+            return offset = 957; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset958(int) { \
+            return offset = 958; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset959(int) { \
+            return offset = 959; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset960(int) { \
+            return offset = 960; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset961(int) { \
+            return offset = 961; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset962(int) { \
+            return offset = 962; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset963(int) { \
+            return offset = 963; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset964(int) { \
+            return offset = 964; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset965(int) { \
+            return offset = 965; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset966(int) { \
+            return offset = 966; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset967(int) { \
+            return offset = 967; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset968(int) { \
+            return offset = 968; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset969(int) { \
+            return offset = 969; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset970(int) { \
+            return offset = 970; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset971(int) { \
+            return offset = 971; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset972(int) { \
+            return offset = 972; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset973(int) { \
+            return offset = 973; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset974(int) { \
+            return offset = 974; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset975(int) { \
+            return offset = 975; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset976(int) { \
+            return offset = 976; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset977(int) { \
+            return offset = 977; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset978(int) { \
+            return offset = 978; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset979(int) { \
+            return offset = 979; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset980(int) { \
+            return offset = 980; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset981(int) { \
+            return offset = 981; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset982(int) { \
+            return offset = 982; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset983(int) { \
+            return offset = 983; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset984(int) { \
+            return offset = 984; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset985(int) { \
+            return offset = 985; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset986(int) { \
+            return offset = 986; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset987(int) { \
+            return offset = 987; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset988(int) { \
+            return offset = 988; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset989(int) { \
+            return offset = 989; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset990(int) { \
+            return offset = 990; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset991(int) { \
+            return offset = 991; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset992(int) { \
+            return offset = 992; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset993(int) { \
+            return offset = 993; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset994(int) { \
+            return offset = 994; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset995(int) { \
+            return offset = 995; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset996(int) { \
+            return offset = 996; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset997(int) { \
+            return offset = 997; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset998(int) { \
+            return offset = 998; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset999(int) { \
+            return offset = 999; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset1000(int) { \
+            return offset = 1000; \
+        } \
+ \
     };
+
+	FAKEIT_MAKE_SELECTOR( Thiscall, __thiscall)
+	FAKEIT_MAKE_SELECTOR( Stdcall, __stdcall )
+	FAKEIT_MAKE_SELECTOR( Cdecl, __cdecl )
 }

--- a/include/mockutils/mscpp/FunctionWithConvention.hpp
+++ b/include/mockutils/mscpp/FunctionWithConvention.hpp
@@ -1,0 +1,117 @@
+/// This file contains logic for dealing with the varying calling conventions of MSVC.
+#pragma once
+
+namespace fakeit {
+
+    // Taking the calling convention from a type parameter is not valid syntax,
+    // so we have to represent the calling conventions with marker types
+    // and specialize the relevant bits of codes for them.
+
+    // Marker type for __stdcall functions.
+    struct Stdcall {};
+
+    // Marker type for __thiscall functions.
+    struct Thiscall {};
+
+    // Marker type for __cdecl functions.
+    struct Cdecl {};
+
+    // Base case for a function pointer wrapper with the calling convention included.
+    template<typename C, typename R, typename CONVENTION, typename ... arglist>
+    class FuncWithConvention
+    {};
+
+    // Wrapper for a function pointer to a __thiscall function.
+    template<typename C, typename R, typename ... arglist>
+    class FuncWithConvention<C, R, Thiscall, arglist...>
+    {
+    public:
+            R (__thiscall C::*_vMethod)(arglist...);
+
+            FuncWithConvention( R (__thiscall C::*vMethod)(arglist...) ): _vMethod(vMethod)
+            {
+            };
+    };
+
+    // Wrapper for a function pointer to a __stdcall function.
+    template<typename C, typename R, typename ... arglist>
+    class FuncWithConvention<C, R, Stdcall, arglist...>
+    {
+    public:
+            R (__stdcall C::*_vMethod)(arglist...);
+
+            FuncWithConvention( R (__stdcall C::*vMethod)(arglist...) ): _vMethod(vMethod)
+            {
+            };
+    };
+
+    // Wrapper for a function pointer to a __cdecl function.
+    template<typename C, typename R, typename ... arglist>
+    class FuncWithConvention<C, R, Cdecl, arglist...>
+    {
+    public:
+            R (__cdecl C::*_vMethod)(arglist...);
+
+            FuncWithConvention( R (__cdecl C::*vMethod)(arglist...) ): _vMethod(vMethod)
+            {
+            };
+    };
+
+    class ConventionHelper
+    {
+    public:
+
+// __stdcall and __thiscall are the same in x64, so we get errors if we try to overload them there.
+#ifndef _WIN64
+            // GetConvention overload that recognizes __stdcall and maps it to the Stdcall marker.
+            template<typename C, typename R, typename ... arglist>
+            static Stdcall GetConvention( R (__stdcall C::*vMethod)(arglist...) )
+            {
+            }
+
+            // GetConvention overload that recognizes __stdcall and maps it to the Thiscall marker.
+            template<typename C, typename R, typename ... arglist>
+            static Thiscall GetConvention( R (__thiscall C::*vMethod)(arglist...) )
+            {
+            }
+#endif
+            // GetConvetion overload that recognizes __cdecl and maps it to the Cdecl marker.
+            template<typename C, typename R, typename ... arglist>
+            static Cdecl GetConvention( R (__cdecl C::*vMethod)(arglist...) )
+            {
+            }
+
+            // Member function with no calling convention defined, used to determine what is the default.
+            void MemberFunction(){};
+
+            // The marker type for the caling convention used for a member when no convention is explicitly defined.
+            typedef decltype(GetConvention(&MemberFunction)) DefaultConvention;
+
+            // Helper function to use type-deduction for constructing the appropriate wrapper type.
+            // This case is for __cdecl.
+            template<typename C, typename R, typename ... arglist>
+            static FuncWithConvention<C, R, Cdecl, arglist...> Make(R (__cdecl C::*vMethod)(arglist...))
+            {
+                    return FuncWithConvention<C, R, Cdecl, arglist...>( vMethod );
+            };
+
+// __stdcall and __thiscall are the same in x64, so we get errors if we try to overload them there.
+#ifndef _WIN64
+
+            template<typename C, typename R, typename ... arglist>
+            static FuncWithConvention<C, R, Thiscall, arglist...> Make(R (__thiscall C::*vMethod)(arglist...))
+            {
+                    return FuncWithConvention<C, R, Thiscall, arglist...>( vMethod );
+            };
+
+            // Helper function to use type-deduction for constructing the appropriate wrapper type.
+            // This case is for the __stdcall convention.
+            template<typename C, typename R, typename ... arglist>
+            static FuncWithConvention<C, R, Stdcall, arglist...> Make(R (__stdcall C::*vMethod)(arglist...))
+            {
+                    return FuncWithConvention<C, R, Stdcall, arglist...>( vMethod );
+            };
+#endif
+
+    };
+}

--- a/include/mockutils/mscpp/FunctionWithConvention.hpp
+++ b/include/mockutils/mscpp/FunctionWithConvention.hpp
@@ -90,7 +90,7 @@ namespace fakeit {
             // Helper function to use type-deduction for constructing the appropriate wrapper type.
             // This case is for __cdecl.
             template<typename C, typename R, typename ... arglist>
-            static FuncWithConvention<C, R, Cdecl, arglist...> Make(R (__cdecl C::*vMethod)(arglist...))
+            static FuncWithConvention<C, R, Cdecl, arglist...> Wrap(R (__cdecl C::*vMethod)(arglist...))
             {
                     return FuncWithConvention<C, R, Cdecl, arglist...>( vMethod );
             };
@@ -99,7 +99,7 @@ namespace fakeit {
 #ifndef _WIN64
 
             template<typename C, typename R, typename ... arglist>
-            static FuncWithConvention<C, R, Thiscall, arglist...> Make(R (__thiscall C::*vMethod)(arglist...))
+            static FuncWithConvention<C, R, Thiscall, arglist...> Wrap(R (__thiscall C::*vMethod)(arglist...))
             {
                     return FuncWithConvention<C, R, Thiscall, arglist...>( vMethod );
             };
@@ -107,7 +107,7 @@ namespace fakeit {
             // Helper function to use type-deduction for constructing the appropriate wrapper type.
             // This case is for the __stdcall convention.
             template<typename C, typename R, typename ... arglist>
-            static FuncWithConvention<C, R, Stdcall, arglist...> Make(R (__stdcall C::*vMethod)(arglist...))
+            static FuncWithConvention<C, R, Stdcall, arglist...> Wrap(R (__stdcall C::*vMethod)(arglist...))
             {
                     return FuncWithConvention<C, R, Stdcall, arglist...>( vMethod );
             };

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -107,6 +107,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature; //always zero ?

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -226,10 +226,10 @@ namespace fakeit {
             // store the user method in a cookie and put the
             // correct format method in the virtual table.
             // the method stored in the vt will call the method in the cookie when invoked.
-            void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
-            unsigned int index = VTUtils::getDestructorOffset<C>();
-            _firstMethod[index] = dtorPtr;
-            setCookie(numOfCookies - 1, method); // use the last cookie
+			void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
+			unsigned int index = VTUtils::getDestructorOffset<C>();
+			_firstMethod[index] = dtorPtr;
+			setCookie(numOfCookies - 1, method); // use the last cookie
         }
 
         unsigned int getSize() {

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -226,10 +226,10 @@ namespace fakeit {
             // store the user method in a cookie and put the
             // correct format method in the virtual table.
             // the method stored in the vt will call the method in the cookie when invoked.
-			void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
-			unsigned int index = VTUtils::getDestructorOffset<C>();
-			_firstMethod[index] = dtorPtr;
-			setCookie(numOfCookies - 1, method); // use the last cookie
+            void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
+            unsigned int index = VTUtils::getDestructorOffset<C>();
+            _firstMethod[index] = dtorPtr;
+            setCookie(numOfCookies - 1, method); // use the last cookie
         }
 
         unsigned int getSize() {

--- a/makefile
+++ b/makefile
@@ -1,5 +1,8 @@
 all:
-	@make -C build
+	@$(MAKE) -C build
 
 check:
-	@make -C build check
+	@$(MAKE) -C build check
+
+clean:
+	@$(MAKE) -C build clean

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:22:55.524797
+ *  Generated: 2019-06-01 12:14:40.033003
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -983,7 +983,19 @@ namespace fakeit {
         }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -5754,6 +5766,7 @@ namespace fakeit {
 
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif
@@ -8408,7 +8421,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8668,7 +8681,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -9030,7 +9043,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:14:27.622507
+ *  Generated: 2018-08-17 00:22:55.524797
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5248,7 +5248,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -7949,11 +7950,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8232,9 +8233,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-10-28 14:16:24.428377
+ *  Generated: 2018-07-27 08:18:37.353949
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -250,6 +250,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -873,6 +902,17 @@ namespace fakeit {
             return out.str();
         }
 
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
     private:
 
         static std::string formatSequence(const Sequence &val) {
@@ -904,8 +944,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -937,17 +977,6 @@ namespace fakeit {
 
             out << " * " << val.getTimes();
             return out.str();
-        }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
         }
     };
 }
@@ -1170,11 +1199,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::BoostTestFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5868,6 +5899,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -8797,7 +8832,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9052,8 +9087,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-07-27 08:18:37.353949
+ *  Generated: 2018-08-17 00:14:27.622507
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -771,6 +771,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -860,7 +863,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -897,7 +900,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -5245,7 +5248,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -5271,6 +5275,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -7868,21 +7884,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7897,8 +7904,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -7942,11 +7949,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -8054,11 +8084,15 @@ namespace fakeit {
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8074,8 +8108,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8113,10 +8150,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8126,7 +8159,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8200,7 +8232,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+
+		C &operator()() {
             return get();
         }
 
@@ -8721,12 +8757,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -5400,6 +5400,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-11-05 20:30:40.182814
+ *  Generated: 2018-01-22 14:00:12.367634
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -1170,12 +1170,13 @@ namespace fakeit {
                 std::string fomattedMessage,
                 Catch::ResultWas::OfType resultWas = Catch::ResultWas::OfType::ExpressionFailed ){
             Catch::AssertionHandler catchAssertionHandler( vetificationType, sourceLineInfo, failingExpression, Catch::ResultDisposition::Normal );
-            INTERNAL_CATCH_TRY( catchAssertionHandler ) { \
+            INTERNAL_CATCH_TRY { \
                 CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
-                catchAssertionHandler.handle( resultWas , fomattedMessage); \
+                catchAssertionHandler.handleMessage(resultWas, fomattedMessage); \
                 CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
-            } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
-            INTERNAL_CATCH_REACT( catchAssertionHandler )
+            } INTERNAL_CATCH_CATCH(catchAssertionHandler) { \
+                INTERNAL_CATCH_REACT(catchAssertionHandler) \
+            }
         }
 
         virtual void handle(const UnexpectedMethodCallEvent &evt) override {
@@ -8850,7 +8851,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9105,8 +9106,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-01-22 14:00:12.367634
+ *  Generated: 2018-07-27 08:18:01.123735
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -250,6 +250,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -915,8 +944,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -1238,11 +1267,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::CatchFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5936,6 +5967,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2019-06-01 12:14:44.281637
+ *  Generated: 2019-11-14 10:32:35.213146
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -9355,7 +9355,7 @@ namespace fakeit {
 #endif
 
 #define MOCK_TYPE(mock) \
-    std::remove_reference<decltype(mock.get())>::type
+    std::remove_reference<decltype((mock).get())>::type
 
 #define OVERLOADED_METHOD_PTR(mock, method, prototype) \
     fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
@@ -9364,16 +9364,16 @@ namespace fakeit {
     fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
 
 #define Dtor(mock) \
-    mock.dtor().setMethodDetails(#mock,"destructor")
+    (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-07-27 08:18:01.123735
+ *  Generated: 2018-08-17 00:14:36.031769
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -771,6 +771,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -860,7 +863,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -897,7 +900,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -5313,7 +5316,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -5339,6 +5343,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -7936,21 +7952,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7965,8 +7972,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -8010,11 +8017,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -8122,11 +8152,15 @@ namespace fakeit {
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8142,8 +8176,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8181,10 +8218,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8194,7 +8227,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8268,7 +8300,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+
+		C &operator()() {
             return get();
         }
 
@@ -8789,12 +8825,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2019-11-14 10:32:35.213146
+ *  Generated: 2019-11-15 14:29:24.405893
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -1297,4025 +1297,4154 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::CatchFakeit::getInstance();
 
 #include <functional>
 #include <type_traits>
+
 namespace fakeit {
 
-    struct VirtualOffsetSelector {
 
-        unsigned int offset;
 
-        virtual unsigned int offset0(int) {
-            return offset = 0;
-        }
 
-        virtual unsigned int offset1(int) {
-            return offset = 1;
-        }
 
-        virtual unsigned int offset2(int) {
-            return offset = 2;
-        }
 
-        virtual unsigned int offset3(int) {
-            return offset = 3;
-        }
+    struct Stdcall {};
 
-        virtual unsigned int offset4(int) {
-            return offset = 4;
-        }
 
-        virtual unsigned int offset5(int) {
-            return offset = 5;
-        }
+    struct Thiscall {};
 
-        virtual unsigned int offset6(int) {
-            return offset = 6;
-        }
 
-        virtual unsigned int offset7(int) {
-            return offset = 7;
-        }
+    struct Cdecl {};
 
-        virtual unsigned int offset8(int) {
-            return offset = 8;
-        }
 
-        virtual unsigned int offset9(int) {
-            return offset = 9;
-        }
+    template<typename C, typename R, typename CONVENTION, typename ... arglist>
+    class FuncWithConvention
+    {};
 
-        virtual unsigned int offset10(int) {
-            return offset = 10;
-        }
 
-        virtual unsigned int offset11(int) {
-            return offset = 11;
-        }
+    template<typename C, typename R, typename ... arglist>
+    class FuncWithConvention<C, R, Thiscall, arglist...>
+    {
+    public:
+            R (__thiscall C::*_vMethod)(arglist...);
 
-        virtual unsigned int offset12(int) {
-            return offset = 12;
-        }
+            FuncWithConvention( R (__thiscall C::*vMethod)(arglist...) ): _vMethod(vMethod)
+            {
+            };
+    };
 
-        virtual unsigned int offset13(int) {
-            return offset = 13;
-        }
 
-        virtual unsigned int offset14(int) {
-            return offset = 14;
-        }
+    template<typename C, typename R, typename ... arglist>
+    class FuncWithConvention<C, R, Stdcall, arglist...>
+    {
+    public:
+            R (__stdcall C::*_vMethod)(arglist...);
 
-        virtual unsigned int offset15(int) {
-            return offset = 15;
-        }
+            FuncWithConvention( R (__stdcall C::*vMethod)(arglist...) ): _vMethod(vMethod)
+            {
+            };
+    };
 
-        virtual unsigned int offset16(int) {
-            return offset = 16;
-        }
 
-        virtual unsigned int offset17(int) {
-            return offset = 17;
-        }
+    template<typename C, typename R, typename ... arglist>
+    class FuncWithConvention<C, R, Cdecl, arglist...>
+    {
+    public:
+            R (__cdecl C::*_vMethod)(arglist...);
 
-        virtual unsigned int offset18(int) {
-            return offset = 18;
-        }
+            FuncWithConvention( R (__cdecl C::*vMethod)(arglist...) ): _vMethod(vMethod)
+            {
+            };
+    };
 
-        virtual unsigned int offset19(int) {
-            return offset = 19;
-        }
+    class ConventionHelper
+    {
+    public:
 
-        virtual unsigned int offset20(int) {
-            return offset = 20;
-        }
 
-        virtual unsigned int offset21(int) {
-            return offset = 21;
-        }
+#ifndef _WIN64
 
-        virtual unsigned int offset22(int) {
-            return offset = 22;
-        }
+            template<typename C, typename R, typename ... arglist>
+            static Stdcall GetConvention( R (__stdcall C::*vMethod)(arglist...) )
+            {
+            }
 
-        virtual unsigned int offset23(int) {
-            return offset = 23;
-        }
 
-        virtual unsigned int offset24(int) {
-            return offset = 24;
-        }
+            template<typename C, typename R, typename ... arglist>
+            static Thiscall GetConvention( R (__thiscall C::*vMethod)(arglist...) )
+            {
+            }
+#endif
 
-        virtual unsigned int offset25(int) {
-            return offset = 25;
-        }
+            template<typename C, typename R, typename ... arglist>
+            static Cdecl GetConvention( R (__cdecl C::*vMethod)(arglist...) )
+            {
+            }
 
-        virtual unsigned int offset26(int) {
-            return offset = 26;
-        }
 
-        virtual unsigned int offset27(int) {
-            return offset = 27;
-        }
+            void MemberFunction(){};
 
-        virtual unsigned int offset28(int) {
-            return offset = 28;
-        }
 
-        virtual unsigned int offset29(int) {
-            return offset = 29;
-        }
+            typedef decltype(GetConvention(&MemberFunction)) DefaultConvention;
 
-        virtual unsigned int offset30(int) {
-            return offset = 30;
-        }
 
-        virtual unsigned int offset31(int) {
-            return offset = 31;
-        }
 
-        virtual unsigned int offset32(int) {
-            return offset = 32;
-        }
+            template<typename C, typename R, typename ... arglist>
+            static FuncWithConvention<C, R, Cdecl, arglist...> Wrap(R (__cdecl C::*vMethod)(arglist...))
+            {
+                    return FuncWithConvention<C, R, Cdecl, arglist...>( vMethod );
+            };
 
-        virtual unsigned int offset33(int) {
-            return offset = 33;
-        }
 
-        virtual unsigned int offset34(int) {
-            return offset = 34;
-        }
+#ifndef _WIN64
 
-        virtual unsigned int offset35(int) {
-            return offset = 35;
-        }
+            template<typename C, typename R, typename ... arglist>
+            static FuncWithConvention<C, R, Thiscall, arglist...> Wrap(R (__thiscall C::*vMethod)(arglist...))
+            {
+                    return FuncWithConvention<C, R, Thiscall, arglist...>( vMethod );
+            };
 
-        virtual unsigned int offset36(int) {
-            return offset = 36;
-        }
 
-        virtual unsigned int offset37(int) {
-            return offset = 37;
-        }
 
-        virtual unsigned int offset38(int) {
-            return offset = 38;
-        }
-
-        virtual unsigned int offset39(int) {
-            return offset = 39;
-        }
-
-        virtual unsigned int offset40(int) {
-            return offset = 40;
-        }
-
-        virtual unsigned int offset41(int) {
-            return offset = 41;
-        }
-
-        virtual unsigned int offset42(int) {
-            return offset = 42;
-        }
-
-        virtual unsigned int offset43(int) {
-            return offset = 43;
-        }
-
-        virtual unsigned int offset44(int) {
-            return offset = 44;
-        }
-
-        virtual unsigned int offset45(int) {
-            return offset = 45;
-        }
-
-        virtual unsigned int offset46(int) {
-            return offset = 46;
-        }
-
-        virtual unsigned int offset47(int) {
-            return offset = 47;
-        }
-
-        virtual unsigned int offset48(int) {
-            return offset = 48;
-        }
-
-        virtual unsigned int offset49(int) {
-            return offset = 49;
-        }
-
-        virtual unsigned int offset50(int) {
-            return offset = 50;
-        }
-
-        virtual unsigned int offset51(int) {
-            return offset = 51;
-        }
-
-        virtual unsigned int offset52(int) {
-            return offset = 52;
-        }
-
-        virtual unsigned int offset53(int) {
-            return offset = 53;
-        }
-
-        virtual unsigned int offset54(int) {
-            return offset = 54;
-        }
-
-        virtual unsigned int offset55(int) {
-            return offset = 55;
-        }
-
-        virtual unsigned int offset56(int) {
-            return offset = 56;
-        }
-
-        virtual unsigned int offset57(int) {
-            return offset = 57;
-        }
-
-        virtual unsigned int offset58(int) {
-            return offset = 58;
-        }
-
-        virtual unsigned int offset59(int) {
-            return offset = 59;
-        }
-
-        virtual unsigned int offset60(int) {
-            return offset = 60;
-        }
-
-        virtual unsigned int offset61(int) {
-            return offset = 61;
-        }
-
-        virtual unsigned int offset62(int) {
-            return offset = 62;
-        }
-
-        virtual unsigned int offset63(int) {
-            return offset = 63;
-        }
-
-        virtual unsigned int offset64(int) {
-            return offset = 64;
-        }
-
-        virtual unsigned int offset65(int) {
-            return offset = 65;
-        }
-
-        virtual unsigned int offset66(int) {
-            return offset = 66;
-        }
-
-        virtual unsigned int offset67(int) {
-            return offset = 67;
-        }
-
-        virtual unsigned int offset68(int) {
-            return offset = 68;
-        }
-
-        virtual unsigned int offset69(int) {
-            return offset = 69;
-        }
-
-        virtual unsigned int offset70(int) {
-            return offset = 70;
-        }
-
-        virtual unsigned int offset71(int) {
-            return offset = 71;
-        }
-
-        virtual unsigned int offset72(int) {
-            return offset = 72;
-        }
-
-        virtual unsigned int offset73(int) {
-            return offset = 73;
-        }
-
-        virtual unsigned int offset74(int) {
-            return offset = 74;
-        }
-
-        virtual unsigned int offset75(int) {
-            return offset = 75;
-        }
-
-        virtual unsigned int offset76(int) {
-            return offset = 76;
-        }
-
-        virtual unsigned int offset77(int) {
-            return offset = 77;
-        }
-
-        virtual unsigned int offset78(int) {
-            return offset = 78;
-        }
-
-        virtual unsigned int offset79(int) {
-            return offset = 79;
-        }
-
-        virtual unsigned int offset80(int) {
-            return offset = 80;
-        }
-
-        virtual unsigned int offset81(int) {
-            return offset = 81;
-        }
-
-        virtual unsigned int offset82(int) {
-            return offset = 82;
-        }
-
-        virtual unsigned int offset83(int) {
-            return offset = 83;
-        }
-
-        virtual unsigned int offset84(int) {
-            return offset = 84;
-        }
-
-        virtual unsigned int offset85(int) {
-            return offset = 85;
-        }
-
-        virtual unsigned int offset86(int) {
-            return offset = 86;
-        }
-
-        virtual unsigned int offset87(int) {
-            return offset = 87;
-        }
-
-        virtual unsigned int offset88(int) {
-            return offset = 88;
-        }
-
-        virtual unsigned int offset89(int) {
-            return offset = 89;
-        }
-
-        virtual unsigned int offset90(int) {
-            return offset = 90;
-        }
-
-        virtual unsigned int offset91(int) {
-            return offset = 91;
-        }
-
-        virtual unsigned int offset92(int) {
-            return offset = 92;
-        }
-
-        virtual unsigned int offset93(int) {
-            return offset = 93;
-        }
-
-        virtual unsigned int offset94(int) {
-            return offset = 94;
-        }
-
-        virtual unsigned int offset95(int) {
-            return offset = 95;
-        }
-
-        virtual unsigned int offset96(int) {
-            return offset = 96;
-        }
-
-        virtual unsigned int offset97(int) {
-            return offset = 97;
-        }
-
-        virtual unsigned int offset98(int) {
-            return offset = 98;
-        }
-
-        virtual unsigned int offset99(int) {
-            return offset = 99;
-        }
-
-        virtual unsigned int offset100(int) {
-            return offset = 100;
-        }
-
-        virtual unsigned int offset101(int) {
-            return offset = 101;
-        }
-
-        virtual unsigned int offset102(int) {
-            return offset = 102;
-        }
-
-        virtual unsigned int offset103(int) {
-            return offset = 103;
-        }
-
-        virtual unsigned int offset104(int) {
-            return offset = 104;
-        }
-
-        virtual unsigned int offset105(int) {
-            return offset = 105;
-        }
-
-        virtual unsigned int offset106(int) {
-            return offset = 106;
-        }
-
-        virtual unsigned int offset107(int) {
-            return offset = 107;
-        }
-
-        virtual unsigned int offset108(int) {
-            return offset = 108;
-        }
-
-        virtual unsigned int offset109(int) {
-            return offset = 109;
-        }
-
-        virtual unsigned int offset110(int) {
-            return offset = 110;
-        }
-
-        virtual unsigned int offset111(int) {
-            return offset = 111;
-        }
-
-        virtual unsigned int offset112(int) {
-            return offset = 112;
-        }
-
-        virtual unsigned int offset113(int) {
-            return offset = 113;
-        }
-
-        virtual unsigned int offset114(int) {
-            return offset = 114;
-        }
-
-        virtual unsigned int offset115(int) {
-            return offset = 115;
-        }
-
-        virtual unsigned int offset116(int) {
-            return offset = 116;
-        }
-
-        virtual unsigned int offset117(int) {
-            return offset = 117;
-        }
-
-        virtual unsigned int offset118(int) {
-            return offset = 118;
-        }
-
-        virtual unsigned int offset119(int) {
-            return offset = 119;
-        }
-
-        virtual unsigned int offset120(int) {
-            return offset = 120;
-        }
-
-        virtual unsigned int offset121(int) {
-            return offset = 121;
-        }
-
-        virtual unsigned int offset122(int) {
-            return offset = 122;
-        }
-
-        virtual unsigned int offset123(int) {
-            return offset = 123;
-        }
-
-        virtual unsigned int offset124(int) {
-            return offset = 124;
-        }
-
-        virtual unsigned int offset125(int) {
-            return offset = 125;
-        }
-
-        virtual unsigned int offset126(int) {
-            return offset = 126;
-        }
-
-        virtual unsigned int offset127(int) {
-            return offset = 127;
-        }
-
-        virtual unsigned int offset128(int) {
-            return offset = 128;
-        }
-
-        virtual unsigned int offset129(int) {
-            return offset = 129;
-        }
-
-        virtual unsigned int offset130(int) {
-            return offset = 130;
-        }
-
-        virtual unsigned int offset131(int) {
-            return offset = 131;
-        }
-
-        virtual unsigned int offset132(int) {
-            return offset = 132;
-        }
-
-        virtual unsigned int offset133(int) {
-            return offset = 133;
-        }
-
-        virtual unsigned int offset134(int) {
-            return offset = 134;
-        }
-
-        virtual unsigned int offset135(int) {
-            return offset = 135;
-        }
-
-        virtual unsigned int offset136(int) {
-            return offset = 136;
-        }
-
-        virtual unsigned int offset137(int) {
-            return offset = 137;
-        }
-
-        virtual unsigned int offset138(int) {
-            return offset = 138;
-        }
-
-        virtual unsigned int offset139(int) {
-            return offset = 139;
-        }
-
-        virtual unsigned int offset140(int) {
-            return offset = 140;
-        }
-
-        virtual unsigned int offset141(int) {
-            return offset = 141;
-        }
-
-        virtual unsigned int offset142(int) {
-            return offset = 142;
-        }
-
-        virtual unsigned int offset143(int) {
-            return offset = 143;
-        }
-
-        virtual unsigned int offset144(int) {
-            return offset = 144;
-        }
-
-        virtual unsigned int offset145(int) {
-            return offset = 145;
-        }
-
-        virtual unsigned int offset146(int) {
-            return offset = 146;
-        }
-
-        virtual unsigned int offset147(int) {
-            return offset = 147;
-        }
-
-        virtual unsigned int offset148(int) {
-            return offset = 148;
-        }
-
-        virtual unsigned int offset149(int) {
-            return offset = 149;
-        }
-
-        virtual unsigned int offset150(int) {
-            return offset = 150;
-        }
-
-        virtual unsigned int offset151(int) {
-            return offset = 151;
-        }
-
-        virtual unsigned int offset152(int) {
-            return offset = 152;
-        }
-
-        virtual unsigned int offset153(int) {
-            return offset = 153;
-        }
-
-        virtual unsigned int offset154(int) {
-            return offset = 154;
-        }
-
-        virtual unsigned int offset155(int) {
-            return offset = 155;
-        }
-
-        virtual unsigned int offset156(int) {
-            return offset = 156;
-        }
-
-        virtual unsigned int offset157(int) {
-            return offset = 157;
-        }
-
-        virtual unsigned int offset158(int) {
-            return offset = 158;
-        }
-
-        virtual unsigned int offset159(int) {
-            return offset = 159;
-        }
-
-        virtual unsigned int offset160(int) {
-            return offset = 160;
-        }
-
-        virtual unsigned int offset161(int) {
-            return offset = 161;
-        }
-
-        virtual unsigned int offset162(int) {
-            return offset = 162;
-        }
-
-        virtual unsigned int offset163(int) {
-            return offset = 163;
-        }
-
-        virtual unsigned int offset164(int) {
-            return offset = 164;
-        }
-
-        virtual unsigned int offset165(int) {
-            return offset = 165;
-        }
-
-        virtual unsigned int offset166(int) {
-            return offset = 166;
-        }
-
-        virtual unsigned int offset167(int) {
-            return offset = 167;
-        }
-
-        virtual unsigned int offset168(int) {
-            return offset = 168;
-        }
-
-        virtual unsigned int offset169(int) {
-            return offset = 169;
-        }
-
-        virtual unsigned int offset170(int) {
-            return offset = 170;
-        }
-
-        virtual unsigned int offset171(int) {
-            return offset = 171;
-        }
-
-        virtual unsigned int offset172(int) {
-            return offset = 172;
-        }
-
-        virtual unsigned int offset173(int) {
-            return offset = 173;
-        }
-
-        virtual unsigned int offset174(int) {
-            return offset = 174;
-        }
-
-        virtual unsigned int offset175(int) {
-            return offset = 175;
-        }
-
-        virtual unsigned int offset176(int) {
-            return offset = 176;
-        }
-
-        virtual unsigned int offset177(int) {
-            return offset = 177;
-        }
-
-        virtual unsigned int offset178(int) {
-            return offset = 178;
-        }
-
-        virtual unsigned int offset179(int) {
-            return offset = 179;
-        }
-
-        virtual unsigned int offset180(int) {
-            return offset = 180;
-        }
-
-        virtual unsigned int offset181(int) {
-            return offset = 181;
-        }
-
-        virtual unsigned int offset182(int) {
-            return offset = 182;
-        }
-
-        virtual unsigned int offset183(int) {
-            return offset = 183;
-        }
-
-        virtual unsigned int offset184(int) {
-            return offset = 184;
-        }
-
-        virtual unsigned int offset185(int) {
-            return offset = 185;
-        }
-
-        virtual unsigned int offset186(int) {
-            return offset = 186;
-        }
-
-        virtual unsigned int offset187(int) {
-            return offset = 187;
-        }
-
-        virtual unsigned int offset188(int) {
-            return offset = 188;
-        }
-
-        virtual unsigned int offset189(int) {
-            return offset = 189;
-        }
-
-        virtual unsigned int offset190(int) {
-            return offset = 190;
-        }
-
-        virtual unsigned int offset191(int) {
-            return offset = 191;
-        }
-
-        virtual unsigned int offset192(int) {
-            return offset = 192;
-        }
-
-        virtual unsigned int offset193(int) {
-            return offset = 193;
-        }
-
-        virtual unsigned int offset194(int) {
-            return offset = 194;
-        }
-
-        virtual unsigned int offset195(int) {
-            return offset = 195;
-        }
-
-        virtual unsigned int offset196(int) {
-            return offset = 196;
-        }
-
-        virtual unsigned int offset197(int) {
-            return offset = 197;
-        }
-
-        virtual unsigned int offset198(int) {
-            return offset = 198;
-        }
-
-        virtual unsigned int offset199(int) {
-            return offset = 199;
-        }
-
-
-        virtual unsigned int offset200(int) {
-            return offset = 200;
-        }
-
-        virtual unsigned int offset201(int) {
-            return offset = 201;
-        }
-
-        virtual unsigned int offset202(int) {
-            return offset = 202;
-        }
-
-        virtual unsigned int offset203(int) {
-            return offset = 203;
-        }
-
-        virtual unsigned int offset204(int) {
-            return offset = 204;
-        }
-
-        virtual unsigned int offset205(int) {
-            return offset = 205;
-        }
-
-        virtual unsigned int offset206(int) {
-            return offset = 206;
-        }
-
-        virtual unsigned int offset207(int) {
-            return offset = 207;
-        }
-
-        virtual unsigned int offset208(int) {
-            return offset = 208;
-        }
-
-        virtual unsigned int offset209(int) {
-            return offset = 209;
-        }
-
-        virtual unsigned int offset210(int) {
-            return offset = 210;
-        }
-
-        virtual unsigned int offset211(int) {
-            return offset = 211;
-        }
-
-        virtual unsigned int offset212(int) {
-            return offset = 212;
-        }
-
-        virtual unsigned int offset213(int) {
-            return offset = 213;
-        }
-
-        virtual unsigned int offset214(int) {
-            return offset = 214;
-        }
-
-        virtual unsigned int offset215(int) {
-            return offset = 215;
-        }
-
-        virtual unsigned int offset216(int) {
-            return offset = 216;
-        }
-
-        virtual unsigned int offset217(int) {
-            return offset = 217;
-        }
-
-        virtual unsigned int offset218(int) {
-            return offset = 218;
-        }
-
-        virtual unsigned int offset219(int) {
-            return offset = 219;
-        }
-
-        virtual unsigned int offset220(int) {
-            return offset = 220;
-        }
-
-        virtual unsigned int offset221(int) {
-            return offset = 221;
-        }
-
-        virtual unsigned int offset222(int) {
-            return offset = 222;
-        }
-
-        virtual unsigned int offset223(int) {
-            return offset = 223;
-        }
-
-        virtual unsigned int offset224(int) {
-            return offset = 224;
-        }
-
-        virtual unsigned int offset225(int) {
-            return offset = 225;
-        }
-
-        virtual unsigned int offset226(int) {
-            return offset = 226;
-        }
-
-        virtual unsigned int offset227(int) {
-            return offset = 227;
-        }
-
-        virtual unsigned int offset228(int) {
-            return offset = 228;
-        }
-
-        virtual unsigned int offset229(int) {
-            return offset = 229;
-        }
-
-        virtual unsigned int offset230(int) {
-            return offset = 230;
-        }
-
-        virtual unsigned int offset231(int) {
-            return offset = 231;
-        }
-
-        virtual unsigned int offset232(int) {
-            return offset = 232;
-        }
-
-        virtual unsigned int offset233(int) {
-            return offset = 233;
-        }
-
-        virtual unsigned int offset234(int) {
-            return offset = 234;
-        }
-
-        virtual unsigned int offset235(int) {
-            return offset = 235;
-        }
-
-        virtual unsigned int offset236(int) {
-            return offset = 236;
-        }
-
-        virtual unsigned int offset237(int) {
-            return offset = 237;
-        }
-
-        virtual unsigned int offset238(int) {
-            return offset = 238;
-        }
-
-        virtual unsigned int offset239(int) {
-            return offset = 239;
-        }
-
-        virtual unsigned int offset240(int) {
-            return offset = 240;
-        }
-
-        virtual unsigned int offset241(int) {
-            return offset = 241;
-        }
-
-        virtual unsigned int offset242(int) {
-            return offset = 242;
-        }
-
-        virtual unsigned int offset243(int) {
-            return offset = 243;
-        }
-
-        virtual unsigned int offset244(int) {
-            return offset = 244;
-        }
-
-        virtual unsigned int offset245(int) {
-            return offset = 245;
-        }
-
-        virtual unsigned int offset246(int) {
-            return offset = 246;
-        }
-
-        virtual unsigned int offset247(int) {
-            return offset = 247;
-        }
-
-        virtual unsigned int offset248(int) {
-            return offset = 248;
-        }
-
-        virtual unsigned int offset249(int) {
-            return offset = 249;
-        }
-
-        virtual unsigned int offset250(int) {
-            return offset = 250;
-        }
-
-        virtual unsigned int offset251(int) {
-            return offset = 251;
-        }
-
-        virtual unsigned int offset252(int) {
-            return offset = 252;
-        }
-
-        virtual unsigned int offset253(int) {
-            return offset = 253;
-        }
-
-        virtual unsigned int offset254(int) {
-            return offset = 254;
-        }
-
-        virtual unsigned int offset255(int) {
-            return offset = 255;
-        }
-
-        virtual unsigned int offset256(int) {
-            return offset = 256;
-        }
-
-        virtual unsigned int offset257(int) {
-            return offset = 257;
-        }
-
-        virtual unsigned int offset258(int) {
-            return offset = 258;
-        }
-
-        virtual unsigned int offset259(int) {
-            return offset = 259;
-        }
-
-        virtual unsigned int offset260(int) {
-            return offset = 260;
-        }
-
-        virtual unsigned int offset261(int) {
-            return offset = 261;
-        }
-
-        virtual unsigned int offset262(int) {
-            return offset = 262;
-        }
-
-        virtual unsigned int offset263(int) {
-            return offset = 263;
-        }
-
-        virtual unsigned int offset264(int) {
-            return offset = 264;
-        }
-
-        virtual unsigned int offset265(int) {
-            return offset = 265;
-        }
-
-        virtual unsigned int offset266(int) {
-            return offset = 266;
-        }
-
-        virtual unsigned int offset267(int) {
-            return offset = 267;
-        }
-
-        virtual unsigned int offset268(int) {
-            return offset = 268;
-        }
-
-        virtual unsigned int offset269(int) {
-            return offset = 269;
-        }
-
-        virtual unsigned int offset270(int) {
-            return offset = 270;
-        }
-
-        virtual unsigned int offset271(int) {
-            return offset = 271;
-        }
-
-        virtual unsigned int offset272(int) {
-            return offset = 272;
-        }
-
-        virtual unsigned int offset273(int) {
-            return offset = 273;
-        }
-
-        virtual unsigned int offset274(int) {
-            return offset = 274;
-        }
-
-        virtual unsigned int offset275(int) {
-            return offset = 275;
-        }
-
-        virtual unsigned int offset276(int) {
-            return offset = 276;
-        }
-
-        virtual unsigned int offset277(int) {
-            return offset = 277;
-        }
-
-        virtual unsigned int offset278(int) {
-            return offset = 278;
-        }
-
-        virtual unsigned int offset279(int) {
-            return offset = 279;
-        }
-
-        virtual unsigned int offset280(int) {
-            return offset = 280;
-        }
-
-        virtual unsigned int offset281(int) {
-            return offset = 281;
-        }
-
-        virtual unsigned int offset282(int) {
-            return offset = 282;
-        }
-
-        virtual unsigned int offset283(int) {
-            return offset = 283;
-        }
-
-        virtual unsigned int offset284(int) {
-            return offset = 284;
-        }
-
-        virtual unsigned int offset285(int) {
-            return offset = 285;
-        }
-
-        virtual unsigned int offset286(int) {
-            return offset = 286;
-        }
-
-        virtual unsigned int offset287(int) {
-            return offset = 287;
-        }
-
-        virtual unsigned int offset288(int) {
-            return offset = 288;
-        }
-
-        virtual unsigned int offset289(int) {
-            return offset = 289;
-        }
-
-        virtual unsigned int offset290(int) {
-            return offset = 290;
-        }
-
-        virtual unsigned int offset291(int) {
-            return offset = 291;
-        }
-
-        virtual unsigned int offset292(int) {
-            return offset = 292;
-        }
-
-        virtual unsigned int offset293(int) {
-            return offset = 293;
-        }
-
-        virtual unsigned int offset294(int) {
-            return offset = 294;
-        }
-
-        virtual unsigned int offset295(int) {
-            return offset = 295;
-        }
-
-        virtual unsigned int offset296(int) {
-            return offset = 296;
-        }
-
-        virtual unsigned int offset297(int) {
-            return offset = 297;
-        }
-
-        virtual unsigned int offset298(int) {
-            return offset = 298;
-        }
-
-        virtual unsigned int offset299(int) {
-            return offset = 299;
-        }
-
-
-        virtual unsigned int offset300(int) {
-            return offset = 300;
-        }
-
-        virtual unsigned int offset301(int) {
-            return offset = 301;
-        }
-
-        virtual unsigned int offset302(int) {
-            return offset = 302;
-        }
-
-        virtual unsigned int offset303(int) {
-            return offset = 303;
-        }
-
-        virtual unsigned int offset304(int) {
-            return offset = 304;
-        }
-
-        virtual unsigned int offset305(int) {
-            return offset = 305;
-        }
-
-        virtual unsigned int offset306(int) {
-            return offset = 306;
-        }
-
-        virtual unsigned int offset307(int) {
-            return offset = 307;
-        }
-
-        virtual unsigned int offset308(int) {
-            return offset = 308;
-        }
-
-        virtual unsigned int offset309(int) {
-            return offset = 309;
-        }
-
-        virtual unsigned int offset310(int) {
-            return offset = 310;
-        }
-
-        virtual unsigned int offset311(int) {
-            return offset = 311;
-        }
-
-        virtual unsigned int offset312(int) {
-            return offset = 312;
-        }
-
-        virtual unsigned int offset313(int) {
-            return offset = 313;
-        }
-
-        virtual unsigned int offset314(int) {
-            return offset = 314;
-        }
-
-        virtual unsigned int offset315(int) {
-            return offset = 315;
-        }
-
-        virtual unsigned int offset316(int) {
-            return offset = 316;
-        }
-
-        virtual unsigned int offset317(int) {
-            return offset = 317;
-        }
-
-        virtual unsigned int offset318(int) {
-            return offset = 318;
-        }
-
-        virtual unsigned int offset319(int) {
-            return offset = 319;
-        }
-
-        virtual unsigned int offset320(int) {
-            return offset = 320;
-        }
-
-        virtual unsigned int offset321(int) {
-            return offset = 321;
-        }
-
-        virtual unsigned int offset322(int) {
-            return offset = 322;
-        }
-
-        virtual unsigned int offset323(int) {
-            return offset = 323;
-        }
-
-        virtual unsigned int offset324(int) {
-            return offset = 324;
-        }
-
-        virtual unsigned int offset325(int) {
-            return offset = 325;
-        }
-
-        virtual unsigned int offset326(int) {
-            return offset = 326;
-        }
-
-        virtual unsigned int offset327(int) {
-            return offset = 327;
-        }
-
-        virtual unsigned int offset328(int) {
-            return offset = 328;
-        }
-
-        virtual unsigned int offset329(int) {
-            return offset = 329;
-        }
-
-        virtual unsigned int offset330(int) {
-            return offset = 330;
-        }
-
-        virtual unsigned int offset331(int) {
-            return offset = 331;
-        }
-
-        virtual unsigned int offset332(int) {
-            return offset = 332;
-        }
-
-        virtual unsigned int offset333(int) {
-            return offset = 333;
-        }
-
-        virtual unsigned int offset334(int) {
-            return offset = 334;
-        }
-
-        virtual unsigned int offset335(int) {
-            return offset = 335;
-        }
-
-        virtual unsigned int offset336(int) {
-            return offset = 336;
-        }
-
-        virtual unsigned int offset337(int) {
-            return offset = 337;
-        }
-
-        virtual unsigned int offset338(int) {
-            return offset = 338;
-        }
-
-        virtual unsigned int offset339(int) {
-            return offset = 339;
-        }
-
-        virtual unsigned int offset340(int) {
-            return offset = 340;
-        }
-
-        virtual unsigned int offset341(int) {
-            return offset = 341;
-        }
-
-        virtual unsigned int offset342(int) {
-            return offset = 342;
-        }
-
-        virtual unsigned int offset343(int) {
-            return offset = 343;
-        }
-
-        virtual unsigned int offset344(int) {
-            return offset = 344;
-        }
-
-        virtual unsigned int offset345(int) {
-            return offset = 345;
-        }
-
-        virtual unsigned int offset346(int) {
-            return offset = 346;
-        }
-
-        virtual unsigned int offset347(int) {
-            return offset = 347;
-        }
-
-        virtual unsigned int offset348(int) {
-            return offset = 348;
-        }
-
-        virtual unsigned int offset349(int) {
-            return offset = 349;
-        }
-
-        virtual unsigned int offset350(int) {
-            return offset = 350;
-        }
-
-        virtual unsigned int offset351(int) {
-            return offset = 351;
-        }
-
-        virtual unsigned int offset352(int) {
-            return offset = 352;
-        }
-
-        virtual unsigned int offset353(int) {
-            return offset = 353;
-        }
-
-        virtual unsigned int offset354(int) {
-            return offset = 354;
-        }
-
-        virtual unsigned int offset355(int) {
-            return offset = 355;
-        }
-
-        virtual unsigned int offset356(int) {
-            return offset = 356;
-        }
-
-        virtual unsigned int offset357(int) {
-            return offset = 357;
-        }
-
-        virtual unsigned int offset358(int) {
-            return offset = 358;
-        }
-
-        virtual unsigned int offset359(int) {
-            return offset = 359;
-        }
-
-        virtual unsigned int offset360(int) {
-            return offset = 360;
-        }
-
-        virtual unsigned int offset361(int) {
-            return offset = 361;
-        }
-
-        virtual unsigned int offset362(int) {
-            return offset = 362;
-        }
-
-        virtual unsigned int offset363(int) {
-            return offset = 363;
-        }
-
-        virtual unsigned int offset364(int) {
-            return offset = 364;
-        }
-
-        virtual unsigned int offset365(int) {
-            return offset = 365;
-        }
-
-        virtual unsigned int offset366(int) {
-            return offset = 366;
-        }
-
-        virtual unsigned int offset367(int) {
-            return offset = 367;
-        }
-
-        virtual unsigned int offset368(int) {
-            return offset = 368;
-        }
-
-        virtual unsigned int offset369(int) {
-            return offset = 369;
-        }
-
-        virtual unsigned int offset370(int) {
-            return offset = 370;
-        }
-
-        virtual unsigned int offset371(int) {
-            return offset = 371;
-        }
-
-        virtual unsigned int offset372(int) {
-            return offset = 372;
-        }
-
-        virtual unsigned int offset373(int) {
-            return offset = 373;
-        }
-
-        virtual unsigned int offset374(int) {
-            return offset = 374;
-        }
-
-        virtual unsigned int offset375(int) {
-            return offset = 375;
-        }
-
-        virtual unsigned int offset376(int) {
-            return offset = 376;
-        }
-
-        virtual unsigned int offset377(int) {
-            return offset = 377;
-        }
-
-        virtual unsigned int offset378(int) {
-            return offset = 378;
-        }
-
-        virtual unsigned int offset379(int) {
-            return offset = 379;
-        }
-
-        virtual unsigned int offset380(int) {
-            return offset = 380;
-        }
-
-        virtual unsigned int offset381(int) {
-            return offset = 381;
-        }
-
-        virtual unsigned int offset382(int) {
-            return offset = 382;
-        }
-
-        virtual unsigned int offset383(int) {
-            return offset = 383;
-        }
-
-        virtual unsigned int offset384(int) {
-            return offset = 384;
-        }
-
-        virtual unsigned int offset385(int) {
-            return offset = 385;
-        }
-
-        virtual unsigned int offset386(int) {
-            return offset = 386;
-        }
-
-        virtual unsigned int offset387(int) {
-            return offset = 387;
-        }
-
-        virtual unsigned int offset388(int) {
-            return offset = 388;
-        }
-
-        virtual unsigned int offset389(int) {
-            return offset = 389;
-        }
-
-        virtual unsigned int offset390(int) {
-            return offset = 390;
-        }
-
-        virtual unsigned int offset391(int) {
-            return offset = 391;
-        }
-
-        virtual unsigned int offset392(int) {
-            return offset = 392;
-        }
-
-        virtual unsigned int offset393(int) {
-            return offset = 393;
-        }
-
-        virtual unsigned int offset394(int) {
-            return offset = 394;
-        }
-
-        virtual unsigned int offset395(int) {
-            return offset = 395;
-        }
-
-        virtual unsigned int offset396(int) {
-            return offset = 396;
-        }
-
-        virtual unsigned int offset397(int) {
-            return offset = 397;
-        }
-
-        virtual unsigned int offset398(int) {
-            return offset = 398;
-        }
-
-        virtual unsigned int offset399(int) {
-            return offset = 399;
-        }
-
-
-        virtual unsigned int offset400(int) {
-            return offset = 400;
-        }
-
-        virtual unsigned int offset401(int) {
-            return offset = 401;
-        }
-
-        virtual unsigned int offset402(int) {
-            return offset = 402;
-        }
-
-        virtual unsigned int offset403(int) {
-            return offset = 403;
-        }
-
-        virtual unsigned int offset404(int) {
-            return offset = 404;
-        }
-
-        virtual unsigned int offset405(int) {
-            return offset = 405;
-        }
-
-        virtual unsigned int offset406(int) {
-            return offset = 406;
-        }
-
-        virtual unsigned int offset407(int) {
-            return offset = 407;
-        }
-
-        virtual unsigned int offset408(int) {
-            return offset = 408;
-        }
-
-        virtual unsigned int offset409(int) {
-            return offset = 409;
-        }
-
-        virtual unsigned int offset410(int) {
-            return offset = 410;
-        }
-
-        virtual unsigned int offset411(int) {
-            return offset = 411;
-        }
-
-        virtual unsigned int offset412(int) {
-            return offset = 412;
-        }
-
-        virtual unsigned int offset413(int) {
-            return offset = 413;
-        }
-
-        virtual unsigned int offset414(int) {
-            return offset = 414;
-        }
-
-        virtual unsigned int offset415(int) {
-            return offset = 415;
-        }
-
-        virtual unsigned int offset416(int) {
-            return offset = 416;
-        }
-
-        virtual unsigned int offset417(int) {
-            return offset = 417;
-        }
-
-        virtual unsigned int offset418(int) {
-            return offset = 418;
-        }
-
-        virtual unsigned int offset419(int) {
-            return offset = 419;
-        }
-
-        virtual unsigned int offset420(int) {
-            return offset = 420;
-        }
-
-        virtual unsigned int offset421(int) {
-            return offset = 421;
-        }
-
-        virtual unsigned int offset422(int) {
-            return offset = 422;
-        }
-
-        virtual unsigned int offset423(int) {
-            return offset = 423;
-        }
-
-        virtual unsigned int offset424(int) {
-            return offset = 424;
-        }
-
-        virtual unsigned int offset425(int) {
-            return offset = 425;
-        }
-
-        virtual unsigned int offset426(int) {
-            return offset = 426;
-        }
-
-        virtual unsigned int offset427(int) {
-            return offset = 427;
-        }
-
-        virtual unsigned int offset428(int) {
-            return offset = 428;
-        }
-
-        virtual unsigned int offset429(int) {
-            return offset = 429;
-        }
-
-        virtual unsigned int offset430(int) {
-            return offset = 430;
-        }
-
-        virtual unsigned int offset431(int) {
-            return offset = 431;
-        }
-
-        virtual unsigned int offset432(int) {
-            return offset = 432;
-        }
-
-        virtual unsigned int offset433(int) {
-            return offset = 433;
-        }
-
-        virtual unsigned int offset434(int) {
-            return offset = 434;
-        }
-
-        virtual unsigned int offset435(int) {
-            return offset = 435;
-        }
-
-        virtual unsigned int offset436(int) {
-            return offset = 436;
-        }
-
-        virtual unsigned int offset437(int) {
-            return offset = 437;
-        }
-
-        virtual unsigned int offset438(int) {
-            return offset = 438;
-        }
-
-        virtual unsigned int offset439(int) {
-            return offset = 439;
-        }
-
-        virtual unsigned int offset440(int) {
-            return offset = 440;
-        }
-
-        virtual unsigned int offset441(int) {
-            return offset = 441;
-        }
-
-        virtual unsigned int offset442(int) {
-            return offset = 442;
-        }
-
-        virtual unsigned int offset443(int) {
-            return offset = 443;
-        }
-
-        virtual unsigned int offset444(int) {
-            return offset = 444;
-        }
-
-        virtual unsigned int offset445(int) {
-            return offset = 445;
-        }
-
-        virtual unsigned int offset446(int) {
-            return offset = 446;
-        }
-
-        virtual unsigned int offset447(int) {
-            return offset = 447;
-        }
-
-        virtual unsigned int offset448(int) {
-            return offset = 448;
-        }
-
-        virtual unsigned int offset449(int) {
-            return offset = 449;
-        }
-
-        virtual unsigned int offset450(int) {
-            return offset = 450;
-        }
-
-        virtual unsigned int offset451(int) {
-            return offset = 451;
-        }
-
-        virtual unsigned int offset452(int) {
-            return offset = 452;
-        }
-
-        virtual unsigned int offset453(int) {
-            return offset = 453;
-        }
-
-        virtual unsigned int offset454(int) {
-            return offset = 454;
-        }
-
-        virtual unsigned int offset455(int) {
-            return offset = 455;
-        }
-
-        virtual unsigned int offset456(int) {
-            return offset = 456;
-        }
-
-        virtual unsigned int offset457(int) {
-            return offset = 457;
-        }
-
-        virtual unsigned int offset458(int) {
-            return offset = 458;
-        }
-
-        virtual unsigned int offset459(int) {
-            return offset = 459;
-        }
-
-        virtual unsigned int offset460(int) {
-            return offset = 460;
-        }
-
-        virtual unsigned int offset461(int) {
-            return offset = 461;
-        }
-
-        virtual unsigned int offset462(int) {
-            return offset = 462;
-        }
-
-        virtual unsigned int offset463(int) {
-            return offset = 463;
-        }
-
-        virtual unsigned int offset464(int) {
-            return offset = 464;
-        }
-
-        virtual unsigned int offset465(int) {
-            return offset = 465;
-        }
-
-        virtual unsigned int offset466(int) {
-            return offset = 466;
-        }
-
-        virtual unsigned int offset467(int) {
-            return offset = 467;
-        }
-
-        virtual unsigned int offset468(int) {
-            return offset = 468;
-        }
-
-        virtual unsigned int offset469(int) {
-            return offset = 469;
-        }
-
-        virtual unsigned int offset470(int) {
-            return offset = 470;
-        }
-
-        virtual unsigned int offset471(int) {
-            return offset = 471;
-        }
-
-        virtual unsigned int offset472(int) {
-            return offset = 472;
-        }
-
-        virtual unsigned int offset473(int) {
-            return offset = 473;
-        }
-
-        virtual unsigned int offset474(int) {
-            return offset = 474;
-        }
-
-        virtual unsigned int offset475(int) {
-            return offset = 475;
-        }
-
-        virtual unsigned int offset476(int) {
-            return offset = 476;
-        }
-
-        virtual unsigned int offset477(int) {
-            return offset = 477;
-        }
-
-        virtual unsigned int offset478(int) {
-            return offset = 478;
-        }
-
-        virtual unsigned int offset479(int) {
-            return offset = 479;
-        }
-
-        virtual unsigned int offset480(int) {
-            return offset = 480;
-        }
-
-        virtual unsigned int offset481(int) {
-            return offset = 481;
-        }
-
-        virtual unsigned int offset482(int) {
-            return offset = 482;
-        }
-
-        virtual unsigned int offset483(int) {
-            return offset = 483;
-        }
-
-        virtual unsigned int offset484(int) {
-            return offset = 484;
-        }
-
-        virtual unsigned int offset485(int) {
-            return offset = 485;
-        }
-
-        virtual unsigned int offset486(int) {
-            return offset = 486;
-        }
-
-        virtual unsigned int offset487(int) {
-            return offset = 487;
-        }
-
-        virtual unsigned int offset488(int) {
-            return offset = 488;
-        }
-
-        virtual unsigned int offset489(int) {
-            return offset = 489;
-        }
-
-        virtual unsigned int offset490(int) {
-            return offset = 490;
-        }
-
-        virtual unsigned int offset491(int) {
-            return offset = 491;
-        }
-
-        virtual unsigned int offset492(int) {
-            return offset = 492;
-        }
-
-        virtual unsigned int offset493(int) {
-            return offset = 493;
-        }
-
-        virtual unsigned int offset494(int) {
-            return offset = 494;
-        }
-
-        virtual unsigned int offset495(int) {
-            return offset = 495;
-        }
-
-        virtual unsigned int offset496(int) {
-            return offset = 496;
-        }
-
-        virtual unsigned int offset497(int) {
-            return offset = 497;
-        }
-
-        virtual unsigned int offset498(int) {
-            return offset = 498;
-        }
-
-        virtual unsigned int offset499(int) {
-            return offset = 499;
-        }
-
-
-        virtual unsigned int offset500(int) {
-            return offset = 500;
-        }
-
-        virtual unsigned int offset501(int) {
-            return offset = 501;
-        }
-
-        virtual unsigned int offset502(int) {
-            return offset = 502;
-        }
-
-        virtual unsigned int offset503(int) {
-            return offset = 503;
-        }
-
-        virtual unsigned int offset504(int) {
-            return offset = 504;
-        }
-
-        virtual unsigned int offset505(int) {
-            return offset = 505;
-        }
-
-        virtual unsigned int offset506(int) {
-            return offset = 506;
-        }
-
-        virtual unsigned int offset507(int) {
-            return offset = 507;
-        }
-
-        virtual unsigned int offset508(int) {
-            return offset = 508;
-        }
-
-        virtual unsigned int offset509(int) {
-            return offset = 509;
-        }
-
-        virtual unsigned int offset510(int) {
-            return offset = 510;
-        }
-
-        virtual unsigned int offset511(int) {
-            return offset = 511;
-        }
-
-        virtual unsigned int offset512(int) {
-            return offset = 512;
-        }
-
-        virtual unsigned int offset513(int) {
-            return offset = 513;
-        }
-
-        virtual unsigned int offset514(int) {
-            return offset = 514;
-        }
-
-        virtual unsigned int offset515(int) {
-            return offset = 515;
-        }
-
-        virtual unsigned int offset516(int) {
-            return offset = 516;
-        }
-
-        virtual unsigned int offset517(int) {
-            return offset = 517;
-        }
-
-        virtual unsigned int offset518(int) {
-            return offset = 518;
-        }
-
-        virtual unsigned int offset519(int) {
-            return offset = 519;
-        }
-
-        virtual unsigned int offset520(int) {
-            return offset = 520;
-        }
-
-        virtual unsigned int offset521(int) {
-            return offset = 521;
-        }
-
-        virtual unsigned int offset522(int) {
-            return offset = 522;
-        }
-
-        virtual unsigned int offset523(int) {
-            return offset = 523;
-        }
-
-        virtual unsigned int offset524(int) {
-            return offset = 524;
-        }
-
-        virtual unsigned int offset525(int) {
-            return offset = 525;
-        }
-
-        virtual unsigned int offset526(int) {
-            return offset = 526;
-        }
-
-        virtual unsigned int offset527(int) {
-            return offset = 527;
-        }
-
-        virtual unsigned int offset528(int) {
-            return offset = 528;
-        }
-
-        virtual unsigned int offset529(int) {
-            return offset = 529;
-        }
-
-        virtual unsigned int offset530(int) {
-            return offset = 530;
-        }
-
-        virtual unsigned int offset531(int) {
-            return offset = 531;
-        }
-
-        virtual unsigned int offset532(int) {
-            return offset = 532;
-        }
-
-        virtual unsigned int offset533(int) {
-            return offset = 533;
-        }
-
-        virtual unsigned int offset534(int) {
-            return offset = 534;
-        }
-
-        virtual unsigned int offset535(int) {
-            return offset = 535;
-        }
-
-        virtual unsigned int offset536(int) {
-            return offset = 536;
-        }
-
-        virtual unsigned int offset537(int) {
-            return offset = 537;
-        }
-
-        virtual unsigned int offset538(int) {
-            return offset = 538;
-        }
-
-        virtual unsigned int offset539(int) {
-            return offset = 539;
-        }
-
-        virtual unsigned int offset540(int) {
-            return offset = 540;
-        }
-
-        virtual unsigned int offset541(int) {
-            return offset = 541;
-        }
-
-        virtual unsigned int offset542(int) {
-            return offset = 542;
-        }
-
-        virtual unsigned int offset543(int) {
-            return offset = 543;
-        }
-
-        virtual unsigned int offset544(int) {
-            return offset = 544;
-        }
-
-        virtual unsigned int offset545(int) {
-            return offset = 545;
-        }
-
-        virtual unsigned int offset546(int) {
-            return offset = 546;
-        }
-
-        virtual unsigned int offset547(int) {
-            return offset = 547;
-        }
-
-        virtual unsigned int offset548(int) {
-            return offset = 548;
-        }
-
-        virtual unsigned int offset549(int) {
-            return offset = 549;
-        }
-
-        virtual unsigned int offset550(int) {
-            return offset = 550;
-        }
-
-        virtual unsigned int offset551(int) {
-            return offset = 551;
-        }
-
-        virtual unsigned int offset552(int) {
-            return offset = 552;
-        }
-
-        virtual unsigned int offset553(int) {
-            return offset = 553;
-        }
-
-        virtual unsigned int offset554(int) {
-            return offset = 554;
-        }
-
-        virtual unsigned int offset555(int) {
-            return offset = 555;
-        }
-
-        virtual unsigned int offset556(int) {
-            return offset = 556;
-        }
-
-        virtual unsigned int offset557(int) {
-            return offset = 557;
-        }
-
-        virtual unsigned int offset558(int) {
-            return offset = 558;
-        }
-
-        virtual unsigned int offset559(int) {
-            return offset = 559;
-        }
-
-        virtual unsigned int offset560(int) {
-            return offset = 560;
-        }
-
-        virtual unsigned int offset561(int) {
-            return offset = 561;
-        }
-
-        virtual unsigned int offset562(int) {
-            return offset = 562;
-        }
-
-        virtual unsigned int offset563(int) {
-            return offset = 563;
-        }
-
-        virtual unsigned int offset564(int) {
-            return offset = 564;
-        }
-
-        virtual unsigned int offset565(int) {
-            return offset = 565;
-        }
-
-        virtual unsigned int offset566(int) {
-            return offset = 566;
-        }
-
-        virtual unsigned int offset567(int) {
-            return offset = 567;
-        }
-
-        virtual unsigned int offset568(int) {
-            return offset = 568;
-        }
-
-        virtual unsigned int offset569(int) {
-            return offset = 569;
-        }
-
-        virtual unsigned int offset570(int) {
-            return offset = 570;
-        }
-
-        virtual unsigned int offset571(int) {
-            return offset = 571;
-        }
-
-        virtual unsigned int offset572(int) {
-            return offset = 572;
-        }
-
-        virtual unsigned int offset573(int) {
-            return offset = 573;
-        }
-
-        virtual unsigned int offset574(int) {
-            return offset = 574;
-        }
-
-        virtual unsigned int offset575(int) {
-            return offset = 575;
-        }
-
-        virtual unsigned int offset576(int) {
-            return offset = 576;
-        }
-
-        virtual unsigned int offset577(int) {
-            return offset = 577;
-        }
-
-        virtual unsigned int offset578(int) {
-            return offset = 578;
-        }
-
-        virtual unsigned int offset579(int) {
-            return offset = 579;
-        }
-
-        virtual unsigned int offset580(int) {
-            return offset = 580;
-        }
-
-        virtual unsigned int offset581(int) {
-            return offset = 581;
-        }
-
-        virtual unsigned int offset582(int) {
-            return offset = 582;
-        }
-
-        virtual unsigned int offset583(int) {
-            return offset = 583;
-        }
-
-        virtual unsigned int offset584(int) {
-            return offset = 584;
-        }
-
-        virtual unsigned int offset585(int) {
-            return offset = 585;
-        }
-
-        virtual unsigned int offset586(int) {
-            return offset = 586;
-        }
-
-        virtual unsigned int offset587(int) {
-            return offset = 587;
-        }
-
-        virtual unsigned int offset588(int) {
-            return offset = 588;
-        }
-
-        virtual unsigned int offset589(int) {
-            return offset = 589;
-        }
-
-        virtual unsigned int offset590(int) {
-            return offset = 590;
-        }
-
-        virtual unsigned int offset591(int) {
-            return offset = 591;
-        }
-
-        virtual unsigned int offset592(int) {
-            return offset = 592;
-        }
-
-        virtual unsigned int offset593(int) {
-            return offset = 593;
-        }
-
-        virtual unsigned int offset594(int) {
-            return offset = 594;
-        }
-
-        virtual unsigned int offset595(int) {
-            return offset = 595;
-        }
-
-        virtual unsigned int offset596(int) {
-            return offset = 596;
-        }
-
-        virtual unsigned int offset597(int) {
-            return offset = 597;
-        }
-
-        virtual unsigned int offset598(int) {
-            return offset = 598;
-        }
-
-        virtual unsigned int offset599(int) {
-            return offset = 599;
-        }
-
-
-        virtual unsigned int offset600(int) {
-            return offset = 600;
-        }
-
-        virtual unsigned int offset601(int) {
-            return offset = 601;
-        }
-
-        virtual unsigned int offset602(int) {
-            return offset = 602;
-        }
-
-        virtual unsigned int offset603(int) {
-            return offset = 603;
-        }
-
-        virtual unsigned int offset604(int) {
-            return offset = 604;
-        }
-
-        virtual unsigned int offset605(int) {
-            return offset = 605;
-        }
-
-        virtual unsigned int offset606(int) {
-            return offset = 606;
-        }
-
-        virtual unsigned int offset607(int) {
-            return offset = 607;
-        }
-
-        virtual unsigned int offset608(int) {
-            return offset = 608;
-        }
-
-        virtual unsigned int offset609(int) {
-            return offset = 609;
-        }
-
-        virtual unsigned int offset610(int) {
-            return offset = 610;
-        }
-
-        virtual unsigned int offset611(int) {
-            return offset = 611;
-        }
-
-        virtual unsigned int offset612(int) {
-            return offset = 612;
-        }
-
-        virtual unsigned int offset613(int) {
-            return offset = 613;
-        }
-
-        virtual unsigned int offset614(int) {
-            return offset = 614;
-        }
-
-        virtual unsigned int offset615(int) {
-            return offset = 615;
-        }
-
-        virtual unsigned int offset616(int) {
-            return offset = 616;
-        }
-
-        virtual unsigned int offset617(int) {
-            return offset = 617;
-        }
-
-        virtual unsigned int offset618(int) {
-            return offset = 618;
-        }
-
-        virtual unsigned int offset619(int) {
-            return offset = 619;
-        }
-
-        virtual unsigned int offset620(int) {
-            return offset = 620;
-        }
-
-        virtual unsigned int offset621(int) {
-            return offset = 621;
-        }
-
-        virtual unsigned int offset622(int) {
-            return offset = 622;
-        }
-
-        virtual unsigned int offset623(int) {
-            return offset = 623;
-        }
-
-        virtual unsigned int offset624(int) {
-            return offset = 624;
-        }
-
-        virtual unsigned int offset625(int) {
-            return offset = 625;
-        }
-
-        virtual unsigned int offset626(int) {
-            return offset = 626;
-        }
-
-        virtual unsigned int offset627(int) {
-            return offset = 627;
-        }
-
-        virtual unsigned int offset628(int) {
-            return offset = 628;
-        }
-
-        virtual unsigned int offset629(int) {
-            return offset = 629;
-        }
-
-        virtual unsigned int offset630(int) {
-            return offset = 630;
-        }
-
-        virtual unsigned int offset631(int) {
-            return offset = 631;
-        }
-
-        virtual unsigned int offset632(int) {
-            return offset = 632;
-        }
-
-        virtual unsigned int offset633(int) {
-            return offset = 633;
-        }
-
-        virtual unsigned int offset634(int) {
-            return offset = 634;
-        }
-
-        virtual unsigned int offset635(int) {
-            return offset = 635;
-        }
-
-        virtual unsigned int offset636(int) {
-            return offset = 636;
-        }
-
-        virtual unsigned int offset637(int) {
-            return offset = 637;
-        }
-
-        virtual unsigned int offset638(int) {
-            return offset = 638;
-        }
-
-        virtual unsigned int offset639(int) {
-            return offset = 639;
-        }
-
-        virtual unsigned int offset640(int) {
-            return offset = 640;
-        }
-
-        virtual unsigned int offset641(int) {
-            return offset = 641;
-        }
-
-        virtual unsigned int offset642(int) {
-            return offset = 642;
-        }
-
-        virtual unsigned int offset643(int) {
-            return offset = 643;
-        }
-
-        virtual unsigned int offset644(int) {
-            return offset = 644;
-        }
-
-        virtual unsigned int offset645(int) {
-            return offset = 645;
-        }
-
-        virtual unsigned int offset646(int) {
-            return offset = 646;
-        }
-
-        virtual unsigned int offset647(int) {
-            return offset = 647;
-        }
-
-        virtual unsigned int offset648(int) {
-            return offset = 648;
-        }
-
-        virtual unsigned int offset649(int) {
-            return offset = 649;
-        }
-
-        virtual unsigned int offset650(int) {
-            return offset = 650;
-        }
-
-        virtual unsigned int offset651(int) {
-            return offset = 651;
-        }
-
-        virtual unsigned int offset652(int) {
-            return offset = 652;
-        }
-
-        virtual unsigned int offset653(int) {
-            return offset = 653;
-        }
-
-        virtual unsigned int offset654(int) {
-            return offset = 654;
-        }
-
-        virtual unsigned int offset655(int) {
-            return offset = 655;
-        }
-
-        virtual unsigned int offset656(int) {
-            return offset = 656;
-        }
-
-        virtual unsigned int offset657(int) {
-            return offset = 657;
-        }
-
-        virtual unsigned int offset658(int) {
-            return offset = 658;
-        }
-
-        virtual unsigned int offset659(int) {
-            return offset = 659;
-        }
-
-        virtual unsigned int offset660(int) {
-            return offset = 660;
-        }
-
-        virtual unsigned int offset661(int) {
-            return offset = 661;
-        }
-
-        virtual unsigned int offset662(int) {
-            return offset = 662;
-        }
-
-        virtual unsigned int offset663(int) {
-            return offset = 663;
-        }
-
-        virtual unsigned int offset664(int) {
-            return offset = 664;
-        }
-
-        virtual unsigned int offset665(int) {
-            return offset = 665;
-        }
-
-        virtual unsigned int offset666(int) {
-            return offset = 666;
-        }
-
-        virtual unsigned int offset667(int) {
-            return offset = 667;
-        }
-
-        virtual unsigned int offset668(int) {
-            return offset = 668;
-        }
-
-        virtual unsigned int offset669(int) {
-            return offset = 669;
-        }
-
-        virtual unsigned int offset670(int) {
-            return offset = 670;
-        }
-
-        virtual unsigned int offset671(int) {
-            return offset = 671;
-        }
-
-        virtual unsigned int offset672(int) {
-            return offset = 672;
-        }
-
-        virtual unsigned int offset673(int) {
-            return offset = 673;
-        }
-
-        virtual unsigned int offset674(int) {
-            return offset = 674;
-        }
-
-        virtual unsigned int offset675(int) {
-            return offset = 675;
-        }
-
-        virtual unsigned int offset676(int) {
-            return offset = 676;
-        }
-
-        virtual unsigned int offset677(int) {
-            return offset = 677;
-        }
-
-        virtual unsigned int offset678(int) {
-            return offset = 678;
-        }
-
-        virtual unsigned int offset679(int) {
-            return offset = 679;
-        }
-
-        virtual unsigned int offset680(int) {
-            return offset = 680;
-        }
-
-        virtual unsigned int offset681(int) {
-            return offset = 681;
-        }
-
-        virtual unsigned int offset682(int) {
-            return offset = 682;
-        }
-
-        virtual unsigned int offset683(int) {
-            return offset = 683;
-        }
-
-        virtual unsigned int offset684(int) {
-            return offset = 684;
-        }
-
-        virtual unsigned int offset685(int) {
-            return offset = 685;
-        }
-
-        virtual unsigned int offset686(int) {
-            return offset = 686;
-        }
-
-        virtual unsigned int offset687(int) {
-            return offset = 687;
-        }
-
-        virtual unsigned int offset688(int) {
-            return offset = 688;
-        }
-
-        virtual unsigned int offset689(int) {
-            return offset = 689;
-        }
-
-        virtual unsigned int offset690(int) {
-            return offset = 690;
-        }
-
-        virtual unsigned int offset691(int) {
-            return offset = 691;
-        }
-
-        virtual unsigned int offset692(int) {
-            return offset = 692;
-        }
-
-        virtual unsigned int offset693(int) {
-            return offset = 693;
-        }
-
-        virtual unsigned int offset694(int) {
-            return offset = 694;
-        }
-
-        virtual unsigned int offset695(int) {
-            return offset = 695;
-        }
-
-        virtual unsigned int offset696(int) {
-            return offset = 696;
-        }
-
-        virtual unsigned int offset697(int) {
-            return offset = 697;
-        }
-
-        virtual unsigned int offset698(int) {
-            return offset = 698;
-        }
-
-        virtual unsigned int offset699(int) {
-            return offset = 699;
-        }
-
-
-        virtual unsigned int offset700(int) {
-            return offset = 700;
-        }
-
-        virtual unsigned int offset701(int) {
-            return offset = 701;
-        }
-
-        virtual unsigned int offset702(int) {
-            return offset = 702;
-        }
-
-        virtual unsigned int offset703(int) {
-            return offset = 703;
-        }
-
-        virtual unsigned int offset704(int) {
-            return offset = 704;
-        }
-
-        virtual unsigned int offset705(int) {
-            return offset = 705;
-        }
-
-        virtual unsigned int offset706(int) {
-            return offset = 706;
-        }
-
-        virtual unsigned int offset707(int) {
-            return offset = 707;
-        }
-
-        virtual unsigned int offset708(int) {
-            return offset = 708;
-        }
-
-        virtual unsigned int offset709(int) {
-            return offset = 709;
-        }
-
-        virtual unsigned int offset710(int) {
-            return offset = 710;
-        }
-
-        virtual unsigned int offset711(int) {
-            return offset = 711;
-        }
-
-        virtual unsigned int offset712(int) {
-            return offset = 712;
-        }
-
-        virtual unsigned int offset713(int) {
-            return offset = 713;
-        }
-
-        virtual unsigned int offset714(int) {
-            return offset = 714;
-        }
-
-        virtual unsigned int offset715(int) {
-            return offset = 715;
-        }
-
-        virtual unsigned int offset716(int) {
-            return offset = 716;
-        }
-
-        virtual unsigned int offset717(int) {
-            return offset = 717;
-        }
-
-        virtual unsigned int offset718(int) {
-            return offset = 718;
-        }
-
-        virtual unsigned int offset719(int) {
-            return offset = 719;
-        }
-
-        virtual unsigned int offset720(int) {
-            return offset = 720;
-        }
-
-        virtual unsigned int offset721(int) {
-            return offset = 721;
-        }
-
-        virtual unsigned int offset722(int) {
-            return offset = 722;
-        }
-
-        virtual unsigned int offset723(int) {
-            return offset = 723;
-        }
-
-        virtual unsigned int offset724(int) {
-            return offset = 724;
-        }
-
-        virtual unsigned int offset725(int) {
-            return offset = 725;
-        }
-
-        virtual unsigned int offset726(int) {
-            return offset = 726;
-        }
-
-        virtual unsigned int offset727(int) {
-            return offset = 727;
-        }
-
-        virtual unsigned int offset728(int) {
-            return offset = 728;
-        }
-
-        virtual unsigned int offset729(int) {
-            return offset = 729;
-        }
-
-        virtual unsigned int offset730(int) {
-            return offset = 730;
-        }
-
-        virtual unsigned int offset731(int) {
-            return offset = 731;
-        }
-
-        virtual unsigned int offset732(int) {
-            return offset = 732;
-        }
-
-        virtual unsigned int offset733(int) {
-            return offset = 733;
-        }
-
-        virtual unsigned int offset734(int) {
-            return offset = 734;
-        }
-
-        virtual unsigned int offset735(int) {
-            return offset = 735;
-        }
-
-        virtual unsigned int offset736(int) {
-            return offset = 736;
-        }
-
-        virtual unsigned int offset737(int) {
-            return offset = 737;
-        }
-
-        virtual unsigned int offset738(int) {
-            return offset = 738;
-        }
-
-        virtual unsigned int offset739(int) {
-            return offset = 739;
-        }
-
-        virtual unsigned int offset740(int) {
-            return offset = 740;
-        }
-
-        virtual unsigned int offset741(int) {
-            return offset = 741;
-        }
-
-        virtual unsigned int offset742(int) {
-            return offset = 742;
-        }
-
-        virtual unsigned int offset743(int) {
-            return offset = 743;
-        }
-
-        virtual unsigned int offset744(int) {
-            return offset = 744;
-        }
-
-        virtual unsigned int offset745(int) {
-            return offset = 745;
-        }
-
-        virtual unsigned int offset746(int) {
-            return offset = 746;
-        }
-
-        virtual unsigned int offset747(int) {
-            return offset = 747;
-        }
-
-        virtual unsigned int offset748(int) {
-            return offset = 748;
-        }
-
-        virtual unsigned int offset749(int) {
-            return offset = 749;
-        }
-
-        virtual unsigned int offset750(int) {
-            return offset = 750;
-        }
-
-        virtual unsigned int offset751(int) {
-            return offset = 751;
-        }
-
-        virtual unsigned int offset752(int) {
-            return offset = 752;
-        }
-
-        virtual unsigned int offset753(int) {
-            return offset = 753;
-        }
-
-        virtual unsigned int offset754(int) {
-            return offset = 754;
-        }
-
-        virtual unsigned int offset755(int) {
-            return offset = 755;
-        }
-
-        virtual unsigned int offset756(int) {
-            return offset = 756;
-        }
-
-        virtual unsigned int offset757(int) {
-            return offset = 757;
-        }
-
-        virtual unsigned int offset758(int) {
-            return offset = 758;
-        }
-
-        virtual unsigned int offset759(int) {
-            return offset = 759;
-        }
-
-        virtual unsigned int offset760(int) {
-            return offset = 760;
-        }
-
-        virtual unsigned int offset761(int) {
-            return offset = 761;
-        }
-
-        virtual unsigned int offset762(int) {
-            return offset = 762;
-        }
-
-        virtual unsigned int offset763(int) {
-            return offset = 763;
-        }
-
-        virtual unsigned int offset764(int) {
-            return offset = 764;
-        }
-
-        virtual unsigned int offset765(int) {
-            return offset = 765;
-        }
-
-        virtual unsigned int offset766(int) {
-            return offset = 766;
-        }
-
-        virtual unsigned int offset767(int) {
-            return offset = 767;
-        }
-
-        virtual unsigned int offset768(int) {
-            return offset = 768;
-        }
-
-        virtual unsigned int offset769(int) {
-            return offset = 769;
-        }
-
-        virtual unsigned int offset770(int) {
-            return offset = 770;
-        }
-
-        virtual unsigned int offset771(int) {
-            return offset = 771;
-        }
-
-        virtual unsigned int offset772(int) {
-            return offset = 772;
-        }
-
-        virtual unsigned int offset773(int) {
-            return offset = 773;
-        }
-
-        virtual unsigned int offset774(int) {
-            return offset = 774;
-        }
-
-        virtual unsigned int offset775(int) {
-            return offset = 775;
-        }
-
-        virtual unsigned int offset776(int) {
-            return offset = 776;
-        }
-
-        virtual unsigned int offset777(int) {
-            return offset = 777;
-        }
-
-        virtual unsigned int offset778(int) {
-            return offset = 778;
-        }
-
-        virtual unsigned int offset779(int) {
-            return offset = 779;
-        }
-
-        virtual unsigned int offset780(int) {
-            return offset = 780;
-        }
-
-        virtual unsigned int offset781(int) {
-            return offset = 781;
-        }
-
-        virtual unsigned int offset782(int) {
-            return offset = 782;
-        }
-
-        virtual unsigned int offset783(int) {
-            return offset = 783;
-        }
-
-        virtual unsigned int offset784(int) {
-            return offset = 784;
-        }
-
-        virtual unsigned int offset785(int) {
-            return offset = 785;
-        }
-
-        virtual unsigned int offset786(int) {
-            return offset = 786;
-        }
-
-        virtual unsigned int offset787(int) {
-            return offset = 787;
-        }
-
-        virtual unsigned int offset788(int) {
-            return offset = 788;
-        }
-
-        virtual unsigned int offset789(int) {
-            return offset = 789;
-        }
-
-        virtual unsigned int offset790(int) {
-            return offset = 790;
-        }
-
-        virtual unsigned int offset791(int) {
-            return offset = 791;
-        }
-
-        virtual unsigned int offset792(int) {
-            return offset = 792;
-        }
-
-        virtual unsigned int offset793(int) {
-            return offset = 793;
-        }
-
-        virtual unsigned int offset794(int) {
-            return offset = 794;
-        }
-
-        virtual unsigned int offset795(int) {
-            return offset = 795;
-        }
-
-        virtual unsigned int offset796(int) {
-            return offset = 796;
-        }
-
-        virtual unsigned int offset797(int) {
-            return offset = 797;
-        }
-
-        virtual unsigned int offset798(int) {
-            return offset = 798;
-        }
-
-        virtual unsigned int offset799(int) {
-            return offset = 799;
-        }
-
-
-        virtual unsigned int offset800(int) {
-            return offset = 800;
-        }
-
-        virtual unsigned int offset801(int) {
-            return offset = 801;
-        }
-
-        virtual unsigned int offset802(int) {
-            return offset = 802;
-        }
-
-        virtual unsigned int offset803(int) {
-            return offset = 803;
-        }
-
-        virtual unsigned int offset804(int) {
-            return offset = 804;
-        }
-
-        virtual unsigned int offset805(int) {
-            return offset = 805;
-        }
-
-        virtual unsigned int offset806(int) {
-            return offset = 806;
-        }
-
-        virtual unsigned int offset807(int) {
-            return offset = 807;
-        }
-
-        virtual unsigned int offset808(int) {
-            return offset = 808;
-        }
-
-        virtual unsigned int offset809(int) {
-            return offset = 809;
-        }
-
-        virtual unsigned int offset810(int) {
-            return offset = 810;
-        }
-
-        virtual unsigned int offset811(int) {
-            return offset = 811;
-        }
-
-        virtual unsigned int offset812(int) {
-            return offset = 812;
-        }
-
-        virtual unsigned int offset813(int) {
-            return offset = 813;
-        }
-
-        virtual unsigned int offset814(int) {
-            return offset = 814;
-        }
-
-        virtual unsigned int offset815(int) {
-            return offset = 815;
-        }
-
-        virtual unsigned int offset816(int) {
-            return offset = 816;
-        }
-
-        virtual unsigned int offset817(int) {
-            return offset = 817;
-        }
-
-        virtual unsigned int offset818(int) {
-            return offset = 818;
-        }
-
-        virtual unsigned int offset819(int) {
-            return offset = 819;
-        }
-
-        virtual unsigned int offset820(int) {
-            return offset = 820;
-        }
-
-        virtual unsigned int offset821(int) {
-            return offset = 821;
-        }
-
-        virtual unsigned int offset822(int) {
-            return offset = 822;
-        }
-
-        virtual unsigned int offset823(int) {
-            return offset = 823;
-        }
-
-        virtual unsigned int offset824(int) {
-            return offset = 824;
-        }
-
-        virtual unsigned int offset825(int) {
-            return offset = 825;
-        }
-
-        virtual unsigned int offset826(int) {
-            return offset = 826;
-        }
-
-        virtual unsigned int offset827(int) {
-            return offset = 827;
-        }
-
-        virtual unsigned int offset828(int) {
-            return offset = 828;
-        }
-
-        virtual unsigned int offset829(int) {
-            return offset = 829;
-        }
-
-        virtual unsigned int offset830(int) {
-            return offset = 830;
-        }
-
-        virtual unsigned int offset831(int) {
-            return offset = 831;
-        }
-
-        virtual unsigned int offset832(int) {
-            return offset = 832;
-        }
-
-        virtual unsigned int offset833(int) {
-            return offset = 833;
-        }
-
-        virtual unsigned int offset834(int) {
-            return offset = 834;
-        }
-
-        virtual unsigned int offset835(int) {
-            return offset = 835;
-        }
-
-        virtual unsigned int offset836(int) {
-            return offset = 836;
-        }
-
-        virtual unsigned int offset837(int) {
-            return offset = 837;
-        }
-
-        virtual unsigned int offset838(int) {
-            return offset = 838;
-        }
-
-        virtual unsigned int offset839(int) {
-            return offset = 839;
-        }
-
-        virtual unsigned int offset840(int) {
-            return offset = 840;
-        }
-
-        virtual unsigned int offset841(int) {
-            return offset = 841;
-        }
-
-        virtual unsigned int offset842(int) {
-            return offset = 842;
-        }
-
-        virtual unsigned int offset843(int) {
-            return offset = 843;
-        }
-
-        virtual unsigned int offset844(int) {
-            return offset = 844;
-        }
-
-        virtual unsigned int offset845(int) {
-            return offset = 845;
-        }
-
-        virtual unsigned int offset846(int) {
-            return offset = 846;
-        }
-
-        virtual unsigned int offset847(int) {
-            return offset = 847;
-        }
-
-        virtual unsigned int offset848(int) {
-            return offset = 848;
-        }
-
-        virtual unsigned int offset849(int) {
-            return offset = 849;
-        }
-
-        virtual unsigned int offset850(int) {
-            return offset = 850;
-        }
-
-        virtual unsigned int offset851(int) {
-            return offset = 851;
-        }
-
-        virtual unsigned int offset852(int) {
-            return offset = 852;
-        }
-
-        virtual unsigned int offset853(int) {
-            return offset = 853;
-        }
-
-        virtual unsigned int offset854(int) {
-            return offset = 854;
-        }
-
-        virtual unsigned int offset855(int) {
-            return offset = 855;
-        }
-
-        virtual unsigned int offset856(int) {
-            return offset = 856;
-        }
-
-        virtual unsigned int offset857(int) {
-            return offset = 857;
-        }
-
-        virtual unsigned int offset858(int) {
-            return offset = 858;
-        }
-
-        virtual unsigned int offset859(int) {
-            return offset = 859;
-        }
-
-        virtual unsigned int offset860(int) {
-            return offset = 860;
-        }
-
-        virtual unsigned int offset861(int) {
-            return offset = 861;
-        }
-
-        virtual unsigned int offset862(int) {
-            return offset = 862;
-        }
-
-        virtual unsigned int offset863(int) {
-            return offset = 863;
-        }
-
-        virtual unsigned int offset864(int) {
-            return offset = 864;
-        }
-
-        virtual unsigned int offset865(int) {
-            return offset = 865;
-        }
-
-        virtual unsigned int offset866(int) {
-            return offset = 866;
-        }
-
-        virtual unsigned int offset867(int) {
-            return offset = 867;
-        }
-
-        virtual unsigned int offset868(int) {
-            return offset = 868;
-        }
-
-        virtual unsigned int offset869(int) {
-            return offset = 869;
-        }
-
-        virtual unsigned int offset870(int) {
-            return offset = 870;
-        }
-
-        virtual unsigned int offset871(int) {
-            return offset = 871;
-        }
-
-        virtual unsigned int offset872(int) {
-            return offset = 872;
-        }
-
-        virtual unsigned int offset873(int) {
-            return offset = 873;
-        }
-
-        virtual unsigned int offset874(int) {
-            return offset = 874;
-        }
-
-        virtual unsigned int offset875(int) {
-            return offset = 875;
-        }
-
-        virtual unsigned int offset876(int) {
-            return offset = 876;
-        }
-
-        virtual unsigned int offset877(int) {
-            return offset = 877;
-        }
-
-        virtual unsigned int offset878(int) {
-            return offset = 878;
-        }
-
-        virtual unsigned int offset879(int) {
-            return offset = 879;
-        }
-
-        virtual unsigned int offset880(int) {
-            return offset = 880;
-        }
-
-        virtual unsigned int offset881(int) {
-            return offset = 881;
-        }
-
-        virtual unsigned int offset882(int) {
-            return offset = 882;
-        }
-
-        virtual unsigned int offset883(int) {
-            return offset = 883;
-        }
-
-        virtual unsigned int offset884(int) {
-            return offset = 884;
-        }
-
-        virtual unsigned int offset885(int) {
-            return offset = 885;
-        }
-
-        virtual unsigned int offset886(int) {
-            return offset = 886;
-        }
-
-        virtual unsigned int offset887(int) {
-            return offset = 887;
-        }
-
-        virtual unsigned int offset888(int) {
-            return offset = 888;
-        }
-
-        virtual unsigned int offset889(int) {
-            return offset = 889;
-        }
-
-        virtual unsigned int offset890(int) {
-            return offset = 890;
-        }
-
-        virtual unsigned int offset891(int) {
-            return offset = 891;
-        }
-
-        virtual unsigned int offset892(int) {
-            return offset = 892;
-        }
-
-        virtual unsigned int offset893(int) {
-            return offset = 893;
-        }
-
-        virtual unsigned int offset894(int) {
-            return offset = 894;
-        }
-
-        virtual unsigned int offset895(int) {
-            return offset = 895;
-        }
-
-        virtual unsigned int offset896(int) {
-            return offset = 896;
-        }
-
-        virtual unsigned int offset897(int) {
-            return offset = 897;
-        }
-
-        virtual unsigned int offset898(int) {
-            return offset = 898;
-        }
-
-        virtual unsigned int offset899(int) {
-            return offset = 899;
-        }
-
-
-        virtual unsigned int offset900(int) {
-            return offset = 900;
-        }
-
-        virtual unsigned int offset901(int) {
-            return offset = 901;
-        }
-
-        virtual unsigned int offset902(int) {
-            return offset = 902;
-        }
-
-        virtual unsigned int offset903(int) {
-            return offset = 903;
-        }
-
-        virtual unsigned int offset904(int) {
-            return offset = 904;
-        }
-
-        virtual unsigned int offset905(int) {
-            return offset = 905;
-        }
-
-        virtual unsigned int offset906(int) {
-            return offset = 906;
-        }
-
-        virtual unsigned int offset907(int) {
-            return offset = 907;
-        }
-
-        virtual unsigned int offset908(int) {
-            return offset = 908;
-        }
-
-        virtual unsigned int offset909(int) {
-            return offset = 909;
-        }
-
-        virtual unsigned int offset910(int) {
-            return offset = 910;
-        }
-
-        virtual unsigned int offset911(int) {
-            return offset = 911;
-        }
-
-        virtual unsigned int offset912(int) {
-            return offset = 912;
-        }
-
-        virtual unsigned int offset913(int) {
-            return offset = 913;
-        }
-
-        virtual unsigned int offset914(int) {
-            return offset = 914;
-        }
-
-        virtual unsigned int offset915(int) {
-            return offset = 915;
-        }
-
-        virtual unsigned int offset916(int) {
-            return offset = 916;
-        }
-
-        virtual unsigned int offset917(int) {
-            return offset = 917;
-        }
-
-        virtual unsigned int offset918(int) {
-            return offset = 918;
-        }
-
-        virtual unsigned int offset919(int) {
-            return offset = 919;
-        }
-
-        virtual unsigned int offset920(int) {
-            return offset = 920;
-        }
-
-        virtual unsigned int offset921(int) {
-            return offset = 921;
-        }
-
-        virtual unsigned int offset922(int) {
-            return offset = 922;
-        }
-
-        virtual unsigned int offset923(int) {
-            return offset = 923;
-        }
-
-        virtual unsigned int offset924(int) {
-            return offset = 924;
-        }
-
-        virtual unsigned int offset925(int) {
-            return offset = 925;
-        }
-
-        virtual unsigned int offset926(int) {
-            return offset = 926;
-        }
-
-        virtual unsigned int offset927(int) {
-            return offset = 927;
-        }
-
-        virtual unsigned int offset928(int) {
-            return offset = 928;
-        }
-
-        virtual unsigned int offset929(int) {
-            return offset = 929;
-        }
-
-        virtual unsigned int offset930(int) {
-            return offset = 930;
-        }
-
-        virtual unsigned int offset931(int) {
-            return offset = 931;
-        }
-
-        virtual unsigned int offset932(int) {
-            return offset = 932;
-        }
-
-        virtual unsigned int offset933(int) {
-            return offset = 933;
-        }
-
-        virtual unsigned int offset934(int) {
-            return offset = 934;
-        }
-
-        virtual unsigned int offset935(int) {
-            return offset = 935;
-        }
-
-        virtual unsigned int offset936(int) {
-            return offset = 936;
-        }
-
-        virtual unsigned int offset937(int) {
-            return offset = 937;
-        }
-
-        virtual unsigned int offset938(int) {
-            return offset = 938;
-        }
-
-        virtual unsigned int offset939(int) {
-            return offset = 939;
-        }
-
-        virtual unsigned int offset940(int) {
-            return offset = 940;
-        }
-
-        virtual unsigned int offset941(int) {
-            return offset = 941;
-        }
-
-        virtual unsigned int offset942(int) {
-            return offset = 942;
-        }
-
-        virtual unsigned int offset943(int) {
-            return offset = 943;
-        }
-
-        virtual unsigned int offset944(int) {
-            return offset = 944;
-        }
-
-        virtual unsigned int offset945(int) {
-            return offset = 945;
-        }
-
-        virtual unsigned int offset946(int) {
-            return offset = 946;
-        }
-
-        virtual unsigned int offset947(int) {
-            return offset = 947;
-        }
-
-        virtual unsigned int offset948(int) {
-            return offset = 948;
-        }
-
-        virtual unsigned int offset949(int) {
-            return offset = 949;
-        }
-
-        virtual unsigned int offset950(int) {
-            return offset = 950;
-        }
-
-        virtual unsigned int offset951(int) {
-            return offset = 951;
-        }
-
-        virtual unsigned int offset952(int) {
-            return offset = 952;
-        }
-
-        virtual unsigned int offset953(int) {
-            return offset = 953;
-        }
-
-        virtual unsigned int offset954(int) {
-            return offset = 954;
-        }
-
-        virtual unsigned int offset955(int) {
-            return offset = 955;
-        }
-
-        virtual unsigned int offset956(int) {
-            return offset = 956;
-        }
-
-        virtual unsigned int offset957(int) {
-            return offset = 957;
-        }
-
-        virtual unsigned int offset958(int) {
-            return offset = 958;
-        }
-
-        virtual unsigned int offset959(int) {
-            return offset = 959;
-        }
-
-        virtual unsigned int offset960(int) {
-            return offset = 960;
-        }
-
-        virtual unsigned int offset961(int) {
-            return offset = 961;
-        }
-
-        virtual unsigned int offset962(int) {
-            return offset = 962;
-        }
-
-        virtual unsigned int offset963(int) {
-            return offset = 963;
-        }
-
-        virtual unsigned int offset964(int) {
-            return offset = 964;
-        }
-
-        virtual unsigned int offset965(int) {
-            return offset = 965;
-        }
-
-        virtual unsigned int offset966(int) {
-            return offset = 966;
-        }
-
-        virtual unsigned int offset967(int) {
-            return offset = 967;
-        }
-
-        virtual unsigned int offset968(int) {
-            return offset = 968;
-        }
-
-        virtual unsigned int offset969(int) {
-            return offset = 969;
-        }
-
-        virtual unsigned int offset970(int) {
-            return offset = 970;
-        }
-
-        virtual unsigned int offset971(int) {
-            return offset = 971;
-        }
-
-        virtual unsigned int offset972(int) {
-            return offset = 972;
-        }
-
-        virtual unsigned int offset973(int) {
-            return offset = 973;
-        }
-
-        virtual unsigned int offset974(int) {
-            return offset = 974;
-        }
-
-        virtual unsigned int offset975(int) {
-            return offset = 975;
-        }
-
-        virtual unsigned int offset976(int) {
-            return offset = 976;
-        }
-
-        virtual unsigned int offset977(int) {
-            return offset = 977;
-        }
-
-        virtual unsigned int offset978(int) {
-            return offset = 978;
-        }
-
-        virtual unsigned int offset979(int) {
-            return offset = 979;
-        }
-
-        virtual unsigned int offset980(int) {
-            return offset = 980;
-        }
-
-        virtual unsigned int offset981(int) {
-            return offset = 981;
-        }
-
-        virtual unsigned int offset982(int) {
-            return offset = 982;
-        }
-
-        virtual unsigned int offset983(int) {
-            return offset = 983;
-        }
-
-        virtual unsigned int offset984(int) {
-            return offset = 984;
-        }
-
-        virtual unsigned int offset985(int) {
-            return offset = 985;
-        }
-
-        virtual unsigned int offset986(int) {
-            return offset = 986;
-        }
-
-        virtual unsigned int offset987(int) {
-            return offset = 987;
-        }
-
-        virtual unsigned int offset988(int) {
-            return offset = 988;
-        }
-
-        virtual unsigned int offset989(int) {
-            return offset = 989;
-        }
-
-        virtual unsigned int offset990(int) {
-            return offset = 990;
-        }
-
-        virtual unsigned int offset991(int) {
-            return offset = 991;
-        }
-
-        virtual unsigned int offset992(int) {
-            return offset = 992;
-        }
-
-        virtual unsigned int offset993(int) {
-            return offset = 993;
-        }
-
-        virtual unsigned int offset994(int) {
-            return offset = 994;
-        }
-
-        virtual unsigned int offset995(int) {
-            return offset = 995;
-        }
-
-        virtual unsigned int offset996(int) {
-            return offset = 996;
-        }
-
-        virtual unsigned int offset997(int) {
-            return offset = 997;
-        }
-
-        virtual unsigned int offset998(int) {
-            return offset = 998;
-        }
-
-        virtual unsigned int offset999(int) {
-            return offset = 999;
-        }
-
-        virtual unsigned int offset1000(int) {
-            return offset = 1000;
-        }
+            template<typename C, typename R, typename ... arglist>
+            static FuncWithConvention<C, R, Stdcall, arglist...> Wrap(R (__stdcall C::*vMethod)(arglist...))
+            {
+                    return FuncWithConvention<C, R, Stdcall, arglist...>( vMethod );
+            };
+#endif
 
     };
+}
+
+namespace fakeit {
+
+
+
+
+    template<typename CONVENTION>
+	struct VirtualOffsetSelector{};
+
+
+#define FAKEIT_MAKE_SELECTOR( CONVENTION_TAG, CONVENTION_SPECIFIER ) \
+	template<> \
+    struct VirtualOffsetSelector<CONVENTION_TAG> { \
+ \
+        unsigned int offset; \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset0(int) { \
+            return offset = 0; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset1(int) { \
+            return offset = 1; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset2(int) { \
+            return offset = 2; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset3(int) { \
+            return offset = 3; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset4(int) { \
+            return offset = 4; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset5(int) { \
+            return offset = 5; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset6(int) { \
+            return offset = 6; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset7(int) { \
+            return offset = 7; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset8(int) { \
+            return offset = 8; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset9(int) { \
+            return offset = 9; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset10(int) { \
+            return offset = 10; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset11(int) { \
+            return offset = 11; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset12(int) { \
+            return offset = 12; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset13(int) { \
+            return offset = 13; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset14(int) { \
+            return offset = 14; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset15(int) { \
+            return offset = 15; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset16(int) { \
+            return offset = 16; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset17(int) { \
+            return offset = 17; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset18(int) { \
+            return offset = 18; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset19(int) { \
+            return offset = 19; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset20(int) { \
+            return offset = 20; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset21(int) { \
+            return offset = 21; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset22(int) { \
+            return offset = 22; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset23(int) { \
+            return offset = 23; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset24(int) { \
+            return offset = 24; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset25(int) { \
+            return offset = 25; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset26(int) { \
+            return offset = 26; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset27(int) { \
+            return offset = 27; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset28(int) { \
+            return offset = 28; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset29(int) { \
+            return offset = 29; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset30(int) { \
+            return offset = 30; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset31(int) { \
+            return offset = 31; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset32(int) { \
+            return offset = 32; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset33(int) { \
+            return offset = 33; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset34(int) { \
+            return offset = 34; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset35(int) { \
+            return offset = 35; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset36(int) { \
+            return offset = 36; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset37(int) { \
+            return offset = 37; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset38(int) { \
+            return offset = 38; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset39(int) { \
+            return offset = 39; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset40(int) { \
+            return offset = 40; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset41(int) { \
+            return offset = 41; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset42(int) { \
+            return offset = 42; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset43(int) { \
+            return offset = 43; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset44(int) { \
+            return offset = 44; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset45(int) { \
+            return offset = 45; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset46(int) { \
+            return offset = 46; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset47(int) { \
+            return offset = 47; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset48(int) { \
+            return offset = 48; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset49(int) { \
+            return offset = 49; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset50(int) { \
+            return offset = 50; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset51(int) { \
+            return offset = 51; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset52(int) { \
+            return offset = 52; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset53(int) { \
+            return offset = 53; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset54(int) { \
+            return offset = 54; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset55(int) { \
+            return offset = 55; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset56(int) { \
+            return offset = 56; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset57(int) { \
+            return offset = 57; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset58(int) { \
+            return offset = 58; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset59(int) { \
+            return offset = 59; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset60(int) { \
+            return offset = 60; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset61(int) { \
+            return offset = 61; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset62(int) { \
+            return offset = 62; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset63(int) { \
+            return offset = 63; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset64(int) { \
+            return offset = 64; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset65(int) { \
+            return offset = 65; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset66(int) { \
+            return offset = 66; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset67(int) { \
+            return offset = 67; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset68(int) { \
+            return offset = 68; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset69(int) { \
+            return offset = 69; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset70(int) { \
+            return offset = 70; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset71(int) { \
+            return offset = 71; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset72(int) { \
+            return offset = 72; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset73(int) { \
+            return offset = 73; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset74(int) { \
+            return offset = 74; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset75(int) { \
+            return offset = 75; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset76(int) { \
+            return offset = 76; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset77(int) { \
+            return offset = 77; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset78(int) { \
+            return offset = 78; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset79(int) { \
+            return offset = 79; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset80(int) { \
+            return offset = 80; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset81(int) { \
+            return offset = 81; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset82(int) { \
+            return offset = 82; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset83(int) { \
+            return offset = 83; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset84(int) { \
+            return offset = 84; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset85(int) { \
+            return offset = 85; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset86(int) { \
+            return offset = 86; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset87(int) { \
+            return offset = 87; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset88(int) { \
+            return offset = 88; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset89(int) { \
+            return offset = 89; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset90(int) { \
+            return offset = 90; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset91(int) { \
+            return offset = 91; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset92(int) { \
+            return offset = 92; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset93(int) { \
+            return offset = 93; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset94(int) { \
+            return offset = 94; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset95(int) { \
+            return offset = 95; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset96(int) { \
+            return offset = 96; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset97(int) { \
+            return offset = 97; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset98(int) { \
+            return offset = 98; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset99(int) { \
+            return offset = 99; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset100(int) { \
+            return offset = 100; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset101(int) { \
+            return offset = 101; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset102(int) { \
+            return offset = 102; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset103(int) { \
+            return offset = 103; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset104(int) { \
+            return offset = 104; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset105(int) { \
+            return offset = 105; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset106(int) { \
+            return offset = 106; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset107(int) { \
+            return offset = 107; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset108(int) { \
+            return offset = 108; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset109(int) { \
+            return offset = 109; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset110(int) { \
+            return offset = 110; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset111(int) { \
+            return offset = 111; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset112(int) { \
+            return offset = 112; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset113(int) { \
+            return offset = 113; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset114(int) { \
+            return offset = 114; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset115(int) { \
+            return offset = 115; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset116(int) { \
+            return offset = 116; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset117(int) { \
+            return offset = 117; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset118(int) { \
+            return offset = 118; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset119(int) { \
+            return offset = 119; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset120(int) { \
+            return offset = 120; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset121(int) { \
+            return offset = 121; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset122(int) { \
+            return offset = 122; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset123(int) { \
+            return offset = 123; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset124(int) { \
+            return offset = 124; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset125(int) { \
+            return offset = 125; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset126(int) { \
+            return offset = 126; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset127(int) { \
+            return offset = 127; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset128(int) { \
+            return offset = 128; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset129(int) { \
+            return offset = 129; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset130(int) { \
+            return offset = 130; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset131(int) { \
+            return offset = 131; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset132(int) { \
+            return offset = 132; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset133(int) { \
+            return offset = 133; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset134(int) { \
+            return offset = 134; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset135(int) { \
+            return offset = 135; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset136(int) { \
+            return offset = 136; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset137(int) { \
+            return offset = 137; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset138(int) { \
+            return offset = 138; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset139(int) { \
+            return offset = 139; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset140(int) { \
+            return offset = 140; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset141(int) { \
+            return offset = 141; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset142(int) { \
+            return offset = 142; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset143(int) { \
+            return offset = 143; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset144(int) { \
+            return offset = 144; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset145(int) { \
+            return offset = 145; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset146(int) { \
+            return offset = 146; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset147(int) { \
+            return offset = 147; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset148(int) { \
+            return offset = 148; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset149(int) { \
+            return offset = 149; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset150(int) { \
+            return offset = 150; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset151(int) { \
+            return offset = 151; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset152(int) { \
+            return offset = 152; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset153(int) { \
+            return offset = 153; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset154(int) { \
+            return offset = 154; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset155(int) { \
+            return offset = 155; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset156(int) { \
+            return offset = 156; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset157(int) { \
+            return offset = 157; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset158(int) { \
+            return offset = 158; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset159(int) { \
+            return offset = 159; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset160(int) { \
+            return offset = 160; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset161(int) { \
+            return offset = 161; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset162(int) { \
+            return offset = 162; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset163(int) { \
+            return offset = 163; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset164(int) { \
+            return offset = 164; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset165(int) { \
+            return offset = 165; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset166(int) { \
+            return offset = 166; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset167(int) { \
+            return offset = 167; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset168(int) { \
+            return offset = 168; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset169(int) { \
+            return offset = 169; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset170(int) { \
+            return offset = 170; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset171(int) { \
+            return offset = 171; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset172(int) { \
+            return offset = 172; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset173(int) { \
+            return offset = 173; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset174(int) { \
+            return offset = 174; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset175(int) { \
+            return offset = 175; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset176(int) { \
+            return offset = 176; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset177(int) { \
+            return offset = 177; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset178(int) { \
+            return offset = 178; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset179(int) { \
+            return offset = 179; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset180(int) { \
+            return offset = 180; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset181(int) { \
+            return offset = 181; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset182(int) { \
+            return offset = 182; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset183(int) { \
+            return offset = 183; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset184(int) { \
+            return offset = 184; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset185(int) { \
+            return offset = 185; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset186(int) { \
+            return offset = 186; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset187(int) { \
+            return offset = 187; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset188(int) { \
+            return offset = 188; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset189(int) { \
+            return offset = 189; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset190(int) { \
+            return offset = 190; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset191(int) { \
+            return offset = 191; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset192(int) { \
+            return offset = 192; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset193(int) { \
+            return offset = 193; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset194(int) { \
+            return offset = 194; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset195(int) { \
+            return offset = 195; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset196(int) { \
+            return offset = 196; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset197(int) { \
+            return offset = 197; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset198(int) { \
+            return offset = 198; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset199(int) { \
+            return offset = 199; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset200(int) { \
+            return offset = 200; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset201(int) { \
+            return offset = 201; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset202(int) { \
+            return offset = 202; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset203(int) { \
+            return offset = 203; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset204(int) { \
+            return offset = 204; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset205(int) { \
+            return offset = 205; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset206(int) { \
+            return offset = 206; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset207(int) { \
+            return offset = 207; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset208(int) { \
+            return offset = 208; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset209(int) { \
+            return offset = 209; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset210(int) { \
+            return offset = 210; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset211(int) { \
+            return offset = 211; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset212(int) { \
+            return offset = 212; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset213(int) { \
+            return offset = 213; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset214(int) { \
+            return offset = 214; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset215(int) { \
+            return offset = 215; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset216(int) { \
+            return offset = 216; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset217(int) { \
+            return offset = 217; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset218(int) { \
+            return offset = 218; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset219(int) { \
+            return offset = 219; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset220(int) { \
+            return offset = 220; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset221(int) { \
+            return offset = 221; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset222(int) { \
+            return offset = 222; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset223(int) { \
+            return offset = 223; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset224(int) { \
+            return offset = 224; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset225(int) { \
+            return offset = 225; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset226(int) { \
+            return offset = 226; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset227(int) { \
+            return offset = 227; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset228(int) { \
+            return offset = 228; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset229(int) { \
+            return offset = 229; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset230(int) { \
+            return offset = 230; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset231(int) { \
+            return offset = 231; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset232(int) { \
+            return offset = 232; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset233(int) { \
+            return offset = 233; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset234(int) { \
+            return offset = 234; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset235(int) { \
+            return offset = 235; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset236(int) { \
+            return offset = 236; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset237(int) { \
+            return offset = 237; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset238(int) { \
+            return offset = 238; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset239(int) { \
+            return offset = 239; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset240(int) { \
+            return offset = 240; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset241(int) { \
+            return offset = 241; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset242(int) { \
+            return offset = 242; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset243(int) { \
+            return offset = 243; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset244(int) { \
+            return offset = 244; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset245(int) { \
+            return offset = 245; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset246(int) { \
+            return offset = 246; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset247(int) { \
+            return offset = 247; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset248(int) { \
+            return offset = 248; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset249(int) { \
+            return offset = 249; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset250(int) { \
+            return offset = 250; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset251(int) { \
+            return offset = 251; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset252(int) { \
+            return offset = 252; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset253(int) { \
+            return offset = 253; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset254(int) { \
+            return offset = 254; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset255(int) { \
+            return offset = 255; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset256(int) { \
+            return offset = 256; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset257(int) { \
+            return offset = 257; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset258(int) { \
+            return offset = 258; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset259(int) { \
+            return offset = 259; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset260(int) { \
+            return offset = 260; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset261(int) { \
+            return offset = 261; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset262(int) { \
+            return offset = 262; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset263(int) { \
+            return offset = 263; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset264(int) { \
+            return offset = 264; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset265(int) { \
+            return offset = 265; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset266(int) { \
+            return offset = 266; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset267(int) { \
+            return offset = 267; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset268(int) { \
+            return offset = 268; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset269(int) { \
+            return offset = 269; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset270(int) { \
+            return offset = 270; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset271(int) { \
+            return offset = 271; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset272(int) { \
+            return offset = 272; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset273(int) { \
+            return offset = 273; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset274(int) { \
+            return offset = 274; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset275(int) { \
+            return offset = 275; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset276(int) { \
+            return offset = 276; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset277(int) { \
+            return offset = 277; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset278(int) { \
+            return offset = 278; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset279(int) { \
+            return offset = 279; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset280(int) { \
+            return offset = 280; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset281(int) { \
+            return offset = 281; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset282(int) { \
+            return offset = 282; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset283(int) { \
+            return offset = 283; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset284(int) { \
+            return offset = 284; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset285(int) { \
+            return offset = 285; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset286(int) { \
+            return offset = 286; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset287(int) { \
+            return offset = 287; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset288(int) { \
+            return offset = 288; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset289(int) { \
+            return offset = 289; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset290(int) { \
+            return offset = 290; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset291(int) { \
+            return offset = 291; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset292(int) { \
+            return offset = 292; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset293(int) { \
+            return offset = 293; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset294(int) { \
+            return offset = 294; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset295(int) { \
+            return offset = 295; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset296(int) { \
+            return offset = 296; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset297(int) { \
+            return offset = 297; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset298(int) { \
+            return offset = 298; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset299(int) { \
+            return offset = 299; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset300(int) { \
+            return offset = 300; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset301(int) { \
+            return offset = 301; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset302(int) { \
+            return offset = 302; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset303(int) { \
+            return offset = 303; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset304(int) { \
+            return offset = 304; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset305(int) { \
+            return offset = 305; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset306(int) { \
+            return offset = 306; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset307(int) { \
+            return offset = 307; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset308(int) { \
+            return offset = 308; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset309(int) { \
+            return offset = 309; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset310(int) { \
+            return offset = 310; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset311(int) { \
+            return offset = 311; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset312(int) { \
+            return offset = 312; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset313(int) { \
+            return offset = 313; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset314(int) { \
+            return offset = 314; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset315(int) { \
+            return offset = 315; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset316(int) { \
+            return offset = 316; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset317(int) { \
+            return offset = 317; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset318(int) { \
+            return offset = 318; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset319(int) { \
+            return offset = 319; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset320(int) { \
+            return offset = 320; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset321(int) { \
+            return offset = 321; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset322(int) { \
+            return offset = 322; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset323(int) { \
+            return offset = 323; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset324(int) { \
+            return offset = 324; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset325(int) { \
+            return offset = 325; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset326(int) { \
+            return offset = 326; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset327(int) { \
+            return offset = 327; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset328(int) { \
+            return offset = 328; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset329(int) { \
+            return offset = 329; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset330(int) { \
+            return offset = 330; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset331(int) { \
+            return offset = 331; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset332(int) { \
+            return offset = 332; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset333(int) { \
+            return offset = 333; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset334(int) { \
+            return offset = 334; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset335(int) { \
+            return offset = 335; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset336(int) { \
+            return offset = 336; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset337(int) { \
+            return offset = 337; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset338(int) { \
+            return offset = 338; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset339(int) { \
+            return offset = 339; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset340(int) { \
+            return offset = 340; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset341(int) { \
+            return offset = 341; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset342(int) { \
+            return offset = 342; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset343(int) { \
+            return offset = 343; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset344(int) { \
+            return offset = 344; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset345(int) { \
+            return offset = 345; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset346(int) { \
+            return offset = 346; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset347(int) { \
+            return offset = 347; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset348(int) { \
+            return offset = 348; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset349(int) { \
+            return offset = 349; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset350(int) { \
+            return offset = 350; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset351(int) { \
+            return offset = 351; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset352(int) { \
+            return offset = 352; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset353(int) { \
+            return offset = 353; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset354(int) { \
+            return offset = 354; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset355(int) { \
+            return offset = 355; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset356(int) { \
+            return offset = 356; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset357(int) { \
+            return offset = 357; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset358(int) { \
+            return offset = 358; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset359(int) { \
+            return offset = 359; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset360(int) { \
+            return offset = 360; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset361(int) { \
+            return offset = 361; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset362(int) { \
+            return offset = 362; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset363(int) { \
+            return offset = 363; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset364(int) { \
+            return offset = 364; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset365(int) { \
+            return offset = 365; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset366(int) { \
+            return offset = 366; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset367(int) { \
+            return offset = 367; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset368(int) { \
+            return offset = 368; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset369(int) { \
+            return offset = 369; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset370(int) { \
+            return offset = 370; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset371(int) { \
+            return offset = 371; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset372(int) { \
+            return offset = 372; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset373(int) { \
+            return offset = 373; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset374(int) { \
+            return offset = 374; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset375(int) { \
+            return offset = 375; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset376(int) { \
+            return offset = 376; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset377(int) { \
+            return offset = 377; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset378(int) { \
+            return offset = 378; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset379(int) { \
+            return offset = 379; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset380(int) { \
+            return offset = 380; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset381(int) { \
+            return offset = 381; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset382(int) { \
+            return offset = 382; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset383(int) { \
+            return offset = 383; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset384(int) { \
+            return offset = 384; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset385(int) { \
+            return offset = 385; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset386(int) { \
+            return offset = 386; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset387(int) { \
+            return offset = 387; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset388(int) { \
+            return offset = 388; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset389(int) { \
+            return offset = 389; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset390(int) { \
+            return offset = 390; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset391(int) { \
+            return offset = 391; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset392(int) { \
+            return offset = 392; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset393(int) { \
+            return offset = 393; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset394(int) { \
+            return offset = 394; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset395(int) { \
+            return offset = 395; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset396(int) { \
+            return offset = 396; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset397(int) { \
+            return offset = 397; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset398(int) { \
+            return offset = 398; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset399(int) { \
+            return offset = 399; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset400(int) { \
+            return offset = 400; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset401(int) { \
+            return offset = 401; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset402(int) { \
+            return offset = 402; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset403(int) { \
+            return offset = 403; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset404(int) { \
+            return offset = 404; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset405(int) { \
+            return offset = 405; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset406(int) { \
+            return offset = 406; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset407(int) { \
+            return offset = 407; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset408(int) { \
+            return offset = 408; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset409(int) { \
+            return offset = 409; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset410(int) { \
+            return offset = 410; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset411(int) { \
+            return offset = 411; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset412(int) { \
+            return offset = 412; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset413(int) { \
+            return offset = 413; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset414(int) { \
+            return offset = 414; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset415(int) { \
+            return offset = 415; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset416(int) { \
+            return offset = 416; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset417(int) { \
+            return offset = 417; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset418(int) { \
+            return offset = 418; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset419(int) { \
+            return offset = 419; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset420(int) { \
+            return offset = 420; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset421(int) { \
+            return offset = 421; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset422(int) { \
+            return offset = 422; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset423(int) { \
+            return offset = 423; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset424(int) { \
+            return offset = 424; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset425(int) { \
+            return offset = 425; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset426(int) { \
+            return offset = 426; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset427(int) { \
+            return offset = 427; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset428(int) { \
+            return offset = 428; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset429(int) { \
+            return offset = 429; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset430(int) { \
+            return offset = 430; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset431(int) { \
+            return offset = 431; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset432(int) { \
+            return offset = 432; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset433(int) { \
+            return offset = 433; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset434(int) { \
+            return offset = 434; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset435(int) { \
+            return offset = 435; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset436(int) { \
+            return offset = 436; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset437(int) { \
+            return offset = 437; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset438(int) { \
+            return offset = 438; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset439(int) { \
+            return offset = 439; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset440(int) { \
+            return offset = 440; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset441(int) { \
+            return offset = 441; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset442(int) { \
+            return offset = 442; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset443(int) { \
+            return offset = 443; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset444(int) { \
+            return offset = 444; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset445(int) { \
+            return offset = 445; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset446(int) { \
+            return offset = 446; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset447(int) { \
+            return offset = 447; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset448(int) { \
+            return offset = 448; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset449(int) { \
+            return offset = 449; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset450(int) { \
+            return offset = 450; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset451(int) { \
+            return offset = 451; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset452(int) { \
+            return offset = 452; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset453(int) { \
+            return offset = 453; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset454(int) { \
+            return offset = 454; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset455(int) { \
+            return offset = 455; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset456(int) { \
+            return offset = 456; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset457(int) { \
+            return offset = 457; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset458(int) { \
+            return offset = 458; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset459(int) { \
+            return offset = 459; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset460(int) { \
+            return offset = 460; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset461(int) { \
+            return offset = 461; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset462(int) { \
+            return offset = 462; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset463(int) { \
+            return offset = 463; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset464(int) { \
+            return offset = 464; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset465(int) { \
+            return offset = 465; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset466(int) { \
+            return offset = 466; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset467(int) { \
+            return offset = 467; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset468(int) { \
+            return offset = 468; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset469(int) { \
+            return offset = 469; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset470(int) { \
+            return offset = 470; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset471(int) { \
+            return offset = 471; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset472(int) { \
+            return offset = 472; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset473(int) { \
+            return offset = 473; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset474(int) { \
+            return offset = 474; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset475(int) { \
+            return offset = 475; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset476(int) { \
+            return offset = 476; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset477(int) { \
+            return offset = 477; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset478(int) { \
+            return offset = 478; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset479(int) { \
+            return offset = 479; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset480(int) { \
+            return offset = 480; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset481(int) { \
+            return offset = 481; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset482(int) { \
+            return offset = 482; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset483(int) { \
+            return offset = 483; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset484(int) { \
+            return offset = 484; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset485(int) { \
+            return offset = 485; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset486(int) { \
+            return offset = 486; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset487(int) { \
+            return offset = 487; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset488(int) { \
+            return offset = 488; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset489(int) { \
+            return offset = 489; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset490(int) { \
+            return offset = 490; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset491(int) { \
+            return offset = 491; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset492(int) { \
+            return offset = 492; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset493(int) { \
+            return offset = 493; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset494(int) { \
+            return offset = 494; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset495(int) { \
+            return offset = 495; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset496(int) { \
+            return offset = 496; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset497(int) { \
+            return offset = 497; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset498(int) { \
+            return offset = 498; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset499(int) { \
+            return offset = 499; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset500(int) { \
+            return offset = 500; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset501(int) { \
+            return offset = 501; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset502(int) { \
+            return offset = 502; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset503(int) { \
+            return offset = 503; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset504(int) { \
+            return offset = 504; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset505(int) { \
+            return offset = 505; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset506(int) { \
+            return offset = 506; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset507(int) { \
+            return offset = 507; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset508(int) { \
+            return offset = 508; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset509(int) { \
+            return offset = 509; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset510(int) { \
+            return offset = 510; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset511(int) { \
+            return offset = 511; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset512(int) { \
+            return offset = 512; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset513(int) { \
+            return offset = 513; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset514(int) { \
+            return offset = 514; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset515(int) { \
+            return offset = 515; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset516(int) { \
+            return offset = 516; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset517(int) { \
+            return offset = 517; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset518(int) { \
+            return offset = 518; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset519(int) { \
+            return offset = 519; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset520(int) { \
+            return offset = 520; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset521(int) { \
+            return offset = 521; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset522(int) { \
+            return offset = 522; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset523(int) { \
+            return offset = 523; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset524(int) { \
+            return offset = 524; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset525(int) { \
+            return offset = 525; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset526(int) { \
+            return offset = 526; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset527(int) { \
+            return offset = 527; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset528(int) { \
+            return offset = 528; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset529(int) { \
+            return offset = 529; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset530(int) { \
+            return offset = 530; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset531(int) { \
+            return offset = 531; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset532(int) { \
+            return offset = 532; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset533(int) { \
+            return offset = 533; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset534(int) { \
+            return offset = 534; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset535(int) { \
+            return offset = 535; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset536(int) { \
+            return offset = 536; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset537(int) { \
+            return offset = 537; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset538(int) { \
+            return offset = 538; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset539(int) { \
+            return offset = 539; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset540(int) { \
+            return offset = 540; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset541(int) { \
+            return offset = 541; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset542(int) { \
+            return offset = 542; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset543(int) { \
+            return offset = 543; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset544(int) { \
+            return offset = 544; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset545(int) { \
+            return offset = 545; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset546(int) { \
+            return offset = 546; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset547(int) { \
+            return offset = 547; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset548(int) { \
+            return offset = 548; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset549(int) { \
+            return offset = 549; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset550(int) { \
+            return offset = 550; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset551(int) { \
+            return offset = 551; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset552(int) { \
+            return offset = 552; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset553(int) { \
+            return offset = 553; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset554(int) { \
+            return offset = 554; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset555(int) { \
+            return offset = 555; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset556(int) { \
+            return offset = 556; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset557(int) { \
+            return offset = 557; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset558(int) { \
+            return offset = 558; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset559(int) { \
+            return offset = 559; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset560(int) { \
+            return offset = 560; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset561(int) { \
+            return offset = 561; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset562(int) { \
+            return offset = 562; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset563(int) { \
+            return offset = 563; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset564(int) { \
+            return offset = 564; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset565(int) { \
+            return offset = 565; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset566(int) { \
+            return offset = 566; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset567(int) { \
+            return offset = 567; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset568(int) { \
+            return offset = 568; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset569(int) { \
+            return offset = 569; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset570(int) { \
+            return offset = 570; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset571(int) { \
+            return offset = 571; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset572(int) { \
+            return offset = 572; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset573(int) { \
+            return offset = 573; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset574(int) { \
+            return offset = 574; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset575(int) { \
+            return offset = 575; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset576(int) { \
+            return offset = 576; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset577(int) { \
+            return offset = 577; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset578(int) { \
+            return offset = 578; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset579(int) { \
+            return offset = 579; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset580(int) { \
+            return offset = 580; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset581(int) { \
+            return offset = 581; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset582(int) { \
+            return offset = 582; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset583(int) { \
+            return offset = 583; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset584(int) { \
+            return offset = 584; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset585(int) { \
+            return offset = 585; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset586(int) { \
+            return offset = 586; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset587(int) { \
+            return offset = 587; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset588(int) { \
+            return offset = 588; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset589(int) { \
+            return offset = 589; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset590(int) { \
+            return offset = 590; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset591(int) { \
+            return offset = 591; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset592(int) { \
+            return offset = 592; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset593(int) { \
+            return offset = 593; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset594(int) { \
+            return offset = 594; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset595(int) { \
+            return offset = 595; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset596(int) { \
+            return offset = 596; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset597(int) { \
+            return offset = 597; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset598(int) { \
+            return offset = 598; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset599(int) { \
+            return offset = 599; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset600(int) { \
+            return offset = 600; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset601(int) { \
+            return offset = 601; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset602(int) { \
+            return offset = 602; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset603(int) { \
+            return offset = 603; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset604(int) { \
+            return offset = 604; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset605(int) { \
+            return offset = 605; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset606(int) { \
+            return offset = 606; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset607(int) { \
+            return offset = 607; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset608(int) { \
+            return offset = 608; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset609(int) { \
+            return offset = 609; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset610(int) { \
+            return offset = 610; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset611(int) { \
+            return offset = 611; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset612(int) { \
+            return offset = 612; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset613(int) { \
+            return offset = 613; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset614(int) { \
+            return offset = 614; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset615(int) { \
+            return offset = 615; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset616(int) { \
+            return offset = 616; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset617(int) { \
+            return offset = 617; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset618(int) { \
+            return offset = 618; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset619(int) { \
+            return offset = 619; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset620(int) { \
+            return offset = 620; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset621(int) { \
+            return offset = 621; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset622(int) { \
+            return offset = 622; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset623(int) { \
+            return offset = 623; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset624(int) { \
+            return offset = 624; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset625(int) { \
+            return offset = 625; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset626(int) { \
+            return offset = 626; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset627(int) { \
+            return offset = 627; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset628(int) { \
+            return offset = 628; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset629(int) { \
+            return offset = 629; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset630(int) { \
+            return offset = 630; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset631(int) { \
+            return offset = 631; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset632(int) { \
+            return offset = 632; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset633(int) { \
+            return offset = 633; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset634(int) { \
+            return offset = 634; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset635(int) { \
+            return offset = 635; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset636(int) { \
+            return offset = 636; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset637(int) { \
+            return offset = 637; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset638(int) { \
+            return offset = 638; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset639(int) { \
+            return offset = 639; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset640(int) { \
+            return offset = 640; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset641(int) { \
+            return offset = 641; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset642(int) { \
+            return offset = 642; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset643(int) { \
+            return offset = 643; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset644(int) { \
+            return offset = 644; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset645(int) { \
+            return offset = 645; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset646(int) { \
+            return offset = 646; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset647(int) { \
+            return offset = 647; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset648(int) { \
+            return offset = 648; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset649(int) { \
+            return offset = 649; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset650(int) { \
+            return offset = 650; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset651(int) { \
+            return offset = 651; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset652(int) { \
+            return offset = 652; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset653(int) { \
+            return offset = 653; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset654(int) { \
+            return offset = 654; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset655(int) { \
+            return offset = 655; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset656(int) { \
+            return offset = 656; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset657(int) { \
+            return offset = 657; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset658(int) { \
+            return offset = 658; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset659(int) { \
+            return offset = 659; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset660(int) { \
+            return offset = 660; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset661(int) { \
+            return offset = 661; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset662(int) { \
+            return offset = 662; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset663(int) { \
+            return offset = 663; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset664(int) { \
+            return offset = 664; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset665(int) { \
+            return offset = 665; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset666(int) { \
+            return offset = 666; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset667(int) { \
+            return offset = 667; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset668(int) { \
+            return offset = 668; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset669(int) { \
+            return offset = 669; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset670(int) { \
+            return offset = 670; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset671(int) { \
+            return offset = 671; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset672(int) { \
+            return offset = 672; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset673(int) { \
+            return offset = 673; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset674(int) { \
+            return offset = 674; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset675(int) { \
+            return offset = 675; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset676(int) { \
+            return offset = 676; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset677(int) { \
+            return offset = 677; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset678(int) { \
+            return offset = 678; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset679(int) { \
+            return offset = 679; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset680(int) { \
+            return offset = 680; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset681(int) { \
+            return offset = 681; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset682(int) { \
+            return offset = 682; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset683(int) { \
+            return offset = 683; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset684(int) { \
+            return offset = 684; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset685(int) { \
+            return offset = 685; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset686(int) { \
+            return offset = 686; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset687(int) { \
+            return offset = 687; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset688(int) { \
+            return offset = 688; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset689(int) { \
+            return offset = 689; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset690(int) { \
+            return offset = 690; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset691(int) { \
+            return offset = 691; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset692(int) { \
+            return offset = 692; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset693(int) { \
+            return offset = 693; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset694(int) { \
+            return offset = 694; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset695(int) { \
+            return offset = 695; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset696(int) { \
+            return offset = 696; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset697(int) { \
+            return offset = 697; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset698(int) { \
+            return offset = 698; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset699(int) { \
+            return offset = 699; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset700(int) { \
+            return offset = 700; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset701(int) { \
+            return offset = 701; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset702(int) { \
+            return offset = 702; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset703(int) { \
+            return offset = 703; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset704(int) { \
+            return offset = 704; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset705(int) { \
+            return offset = 705; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset706(int) { \
+            return offset = 706; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset707(int) { \
+            return offset = 707; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset708(int) { \
+            return offset = 708; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset709(int) { \
+            return offset = 709; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset710(int) { \
+            return offset = 710; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset711(int) { \
+            return offset = 711; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset712(int) { \
+            return offset = 712; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset713(int) { \
+            return offset = 713; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset714(int) { \
+            return offset = 714; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset715(int) { \
+            return offset = 715; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset716(int) { \
+            return offset = 716; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset717(int) { \
+            return offset = 717; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset718(int) { \
+            return offset = 718; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset719(int) { \
+            return offset = 719; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset720(int) { \
+            return offset = 720; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset721(int) { \
+            return offset = 721; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset722(int) { \
+            return offset = 722; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset723(int) { \
+            return offset = 723; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset724(int) { \
+            return offset = 724; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset725(int) { \
+            return offset = 725; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset726(int) { \
+            return offset = 726; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset727(int) { \
+            return offset = 727; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset728(int) { \
+            return offset = 728; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset729(int) { \
+            return offset = 729; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset730(int) { \
+            return offset = 730; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset731(int) { \
+            return offset = 731; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset732(int) { \
+            return offset = 732; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset733(int) { \
+            return offset = 733; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset734(int) { \
+            return offset = 734; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset735(int) { \
+            return offset = 735; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset736(int) { \
+            return offset = 736; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset737(int) { \
+            return offset = 737; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset738(int) { \
+            return offset = 738; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset739(int) { \
+            return offset = 739; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset740(int) { \
+            return offset = 740; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset741(int) { \
+            return offset = 741; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset742(int) { \
+            return offset = 742; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset743(int) { \
+            return offset = 743; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset744(int) { \
+            return offset = 744; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset745(int) { \
+            return offset = 745; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset746(int) { \
+            return offset = 746; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset747(int) { \
+            return offset = 747; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset748(int) { \
+            return offset = 748; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset749(int) { \
+            return offset = 749; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset750(int) { \
+            return offset = 750; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset751(int) { \
+            return offset = 751; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset752(int) { \
+            return offset = 752; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset753(int) { \
+            return offset = 753; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset754(int) { \
+            return offset = 754; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset755(int) { \
+            return offset = 755; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset756(int) { \
+            return offset = 756; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset757(int) { \
+            return offset = 757; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset758(int) { \
+            return offset = 758; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset759(int) { \
+            return offset = 759; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset760(int) { \
+            return offset = 760; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset761(int) { \
+            return offset = 761; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset762(int) { \
+            return offset = 762; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset763(int) { \
+            return offset = 763; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset764(int) { \
+            return offset = 764; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset765(int) { \
+            return offset = 765; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset766(int) { \
+            return offset = 766; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset767(int) { \
+            return offset = 767; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset768(int) { \
+            return offset = 768; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset769(int) { \
+            return offset = 769; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset770(int) { \
+            return offset = 770; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset771(int) { \
+            return offset = 771; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset772(int) { \
+            return offset = 772; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset773(int) { \
+            return offset = 773; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset774(int) { \
+            return offset = 774; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset775(int) { \
+            return offset = 775; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset776(int) { \
+            return offset = 776; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset777(int) { \
+            return offset = 777; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset778(int) { \
+            return offset = 778; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset779(int) { \
+            return offset = 779; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset780(int) { \
+            return offset = 780; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset781(int) { \
+            return offset = 781; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset782(int) { \
+            return offset = 782; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset783(int) { \
+            return offset = 783; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset784(int) { \
+            return offset = 784; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset785(int) { \
+            return offset = 785; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset786(int) { \
+            return offset = 786; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset787(int) { \
+            return offset = 787; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset788(int) { \
+            return offset = 788; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset789(int) { \
+            return offset = 789; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset790(int) { \
+            return offset = 790; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset791(int) { \
+            return offset = 791; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset792(int) { \
+            return offset = 792; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset793(int) { \
+            return offset = 793; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset794(int) { \
+            return offset = 794; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset795(int) { \
+            return offset = 795; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset796(int) { \
+            return offset = 796; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset797(int) { \
+            return offset = 797; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset798(int) { \
+            return offset = 798; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset799(int) { \
+            return offset = 799; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset800(int) { \
+            return offset = 800; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset801(int) { \
+            return offset = 801; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset802(int) { \
+            return offset = 802; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset803(int) { \
+            return offset = 803; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset804(int) { \
+            return offset = 804; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset805(int) { \
+            return offset = 805; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset806(int) { \
+            return offset = 806; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset807(int) { \
+            return offset = 807; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset808(int) { \
+            return offset = 808; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset809(int) { \
+            return offset = 809; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset810(int) { \
+            return offset = 810; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset811(int) { \
+            return offset = 811; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset812(int) { \
+            return offset = 812; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset813(int) { \
+            return offset = 813; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset814(int) { \
+            return offset = 814; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset815(int) { \
+            return offset = 815; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset816(int) { \
+            return offset = 816; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset817(int) { \
+            return offset = 817; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset818(int) { \
+            return offset = 818; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset819(int) { \
+            return offset = 819; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset820(int) { \
+            return offset = 820; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset821(int) { \
+            return offset = 821; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset822(int) { \
+            return offset = 822; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset823(int) { \
+            return offset = 823; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset824(int) { \
+            return offset = 824; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset825(int) { \
+            return offset = 825; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset826(int) { \
+            return offset = 826; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset827(int) { \
+            return offset = 827; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset828(int) { \
+            return offset = 828; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset829(int) { \
+            return offset = 829; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset830(int) { \
+            return offset = 830; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset831(int) { \
+            return offset = 831; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset832(int) { \
+            return offset = 832; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset833(int) { \
+            return offset = 833; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset834(int) { \
+            return offset = 834; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset835(int) { \
+            return offset = 835; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset836(int) { \
+            return offset = 836; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset837(int) { \
+            return offset = 837; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset838(int) { \
+            return offset = 838; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset839(int) { \
+            return offset = 839; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset840(int) { \
+            return offset = 840; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset841(int) { \
+            return offset = 841; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset842(int) { \
+            return offset = 842; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset843(int) { \
+            return offset = 843; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset844(int) { \
+            return offset = 844; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset845(int) { \
+            return offset = 845; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset846(int) { \
+            return offset = 846; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset847(int) { \
+            return offset = 847; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset848(int) { \
+            return offset = 848; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset849(int) { \
+            return offset = 849; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset850(int) { \
+            return offset = 850; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset851(int) { \
+            return offset = 851; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset852(int) { \
+            return offset = 852; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset853(int) { \
+            return offset = 853; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset854(int) { \
+            return offset = 854; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset855(int) { \
+            return offset = 855; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset856(int) { \
+            return offset = 856; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset857(int) { \
+            return offset = 857; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset858(int) { \
+            return offset = 858; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset859(int) { \
+            return offset = 859; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset860(int) { \
+            return offset = 860; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset861(int) { \
+            return offset = 861; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset862(int) { \
+            return offset = 862; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset863(int) { \
+            return offset = 863; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset864(int) { \
+            return offset = 864; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset865(int) { \
+            return offset = 865; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset866(int) { \
+            return offset = 866; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset867(int) { \
+            return offset = 867; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset868(int) { \
+            return offset = 868; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset869(int) { \
+            return offset = 869; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset870(int) { \
+            return offset = 870; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset871(int) { \
+            return offset = 871; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset872(int) { \
+            return offset = 872; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset873(int) { \
+            return offset = 873; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset874(int) { \
+            return offset = 874; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset875(int) { \
+            return offset = 875; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset876(int) { \
+            return offset = 876; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset877(int) { \
+            return offset = 877; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset878(int) { \
+            return offset = 878; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset879(int) { \
+            return offset = 879; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset880(int) { \
+            return offset = 880; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset881(int) { \
+            return offset = 881; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset882(int) { \
+            return offset = 882; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset883(int) { \
+            return offset = 883; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset884(int) { \
+            return offset = 884; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset885(int) { \
+            return offset = 885; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset886(int) { \
+            return offset = 886; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset887(int) { \
+            return offset = 887; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset888(int) { \
+            return offset = 888; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset889(int) { \
+            return offset = 889; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset890(int) { \
+            return offset = 890; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset891(int) { \
+            return offset = 891; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset892(int) { \
+            return offset = 892; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset893(int) { \
+            return offset = 893; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset894(int) { \
+            return offset = 894; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset895(int) { \
+            return offset = 895; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset896(int) { \
+            return offset = 896; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset897(int) { \
+            return offset = 897; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset898(int) { \
+            return offset = 898; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset899(int) { \
+            return offset = 899; \
+        } \
+ \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset900(int) { \
+            return offset = 900; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset901(int) { \
+            return offset = 901; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset902(int) { \
+            return offset = 902; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset903(int) { \
+            return offset = 903; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset904(int) { \
+            return offset = 904; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset905(int) { \
+            return offset = 905; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset906(int) { \
+            return offset = 906; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset907(int) { \
+            return offset = 907; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset908(int) { \
+            return offset = 908; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset909(int) { \
+            return offset = 909; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset910(int) { \
+            return offset = 910; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset911(int) { \
+            return offset = 911; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset912(int) { \
+            return offset = 912; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset913(int) { \
+            return offset = 913; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset914(int) { \
+            return offset = 914; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset915(int) { \
+            return offset = 915; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset916(int) { \
+            return offset = 916; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset917(int) { \
+            return offset = 917; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset918(int) { \
+            return offset = 918; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset919(int) { \
+            return offset = 919; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset920(int) { \
+            return offset = 920; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset921(int) { \
+            return offset = 921; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset922(int) { \
+            return offset = 922; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset923(int) { \
+            return offset = 923; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset924(int) { \
+            return offset = 924; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset925(int) { \
+            return offset = 925; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset926(int) { \
+            return offset = 926; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset927(int) { \
+            return offset = 927; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset928(int) { \
+            return offset = 928; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset929(int) { \
+            return offset = 929; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset930(int) { \
+            return offset = 930; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset931(int) { \
+            return offset = 931; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset932(int) { \
+            return offset = 932; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset933(int) { \
+            return offset = 933; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset934(int) { \
+            return offset = 934; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset935(int) { \
+            return offset = 935; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset936(int) { \
+            return offset = 936; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset937(int) { \
+            return offset = 937; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset938(int) { \
+            return offset = 938; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset939(int) { \
+            return offset = 939; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset940(int) { \
+            return offset = 940; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset941(int) { \
+            return offset = 941; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset942(int) { \
+            return offset = 942; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset943(int) { \
+            return offset = 943; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset944(int) { \
+            return offset = 944; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset945(int) { \
+            return offset = 945; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset946(int) { \
+            return offset = 946; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset947(int) { \
+            return offset = 947; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset948(int) { \
+            return offset = 948; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset949(int) { \
+            return offset = 949; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset950(int) { \
+            return offset = 950; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset951(int) { \
+            return offset = 951; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset952(int) { \
+            return offset = 952; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset953(int) { \
+            return offset = 953; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset954(int) { \
+            return offset = 954; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset955(int) { \
+            return offset = 955; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset956(int) { \
+            return offset = 956; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset957(int) { \
+            return offset = 957; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset958(int) { \
+            return offset = 958; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset959(int) { \
+            return offset = 959; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset960(int) { \
+            return offset = 960; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset961(int) { \
+            return offset = 961; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset962(int) { \
+            return offset = 962; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset963(int) { \
+            return offset = 963; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset964(int) { \
+            return offset = 964; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset965(int) { \
+            return offset = 965; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset966(int) { \
+            return offset = 966; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset967(int) { \
+            return offset = 967; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset968(int) { \
+            return offset = 968; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset969(int) { \
+            return offset = 969; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset970(int) { \
+            return offset = 970; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset971(int) { \
+            return offset = 971; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset972(int) { \
+            return offset = 972; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset973(int) { \
+            return offset = 973; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset974(int) { \
+            return offset = 974; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset975(int) { \
+            return offset = 975; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset976(int) { \
+            return offset = 976; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset977(int) { \
+            return offset = 977; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset978(int) { \
+            return offset = 978; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset979(int) { \
+            return offset = 979; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset980(int) { \
+            return offset = 980; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset981(int) { \
+            return offset = 981; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset982(int) { \
+            return offset = 982; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset983(int) { \
+            return offset = 983; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset984(int) { \
+            return offset = 984; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset985(int) { \
+            return offset = 985; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset986(int) { \
+            return offset = 986; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset987(int) { \
+            return offset = 987; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset988(int) { \
+            return offset = 988; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset989(int) { \
+            return offset = 989; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset990(int) { \
+            return offset = 990; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset991(int) { \
+            return offset = 991; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset992(int) { \
+            return offset = 992; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset993(int) { \
+            return offset = 993; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset994(int) { \
+            return offset = 994; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset995(int) { \
+            return offset = 995; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset996(int) { \
+            return offset = 996; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset997(int) { \
+            return offset = 997; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset998(int) { \
+            return offset = 998; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset999(int) { \
+            return offset = 999; \
+        } \
+ \
+        virtual unsigned int CONVENTION_SPECIFIER offset1000(int) { \
+            return offset = 1000; \
+        } \
+ \
+    };
+
+	FAKEIT_MAKE_SELECTOR( Thiscall, __thiscall)
+	FAKEIT_MAKE_SELECTOR( Stdcall, __stdcall )
+	FAKEIT_MAKE_SELECTOR( Cdecl, __cdecl )
 }
 namespace fakeit {
 
@@ -5341,17 +5470,32 @@ namespace fakeit {
     class VTUtils {
     public:
 
+        template<typename C, typename R,  typename ... arglist>
+        static unsigned int getOffset(FuncWithConvention<C, R, Thiscall, arglist...> vMethod) {
+            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector<Thiscall>::*)(int)>(vMethod._vMethod);
+            VirtualOffsetSelector<Thiscall> offsetSelctor;
+            return (offsetSelctor.*sMethod)(0);
+        }
+
+        template<typename C, typename R,  typename ... arglist>
+        static unsigned int getOffset(FuncWithConvention<C, R, Cdecl, arglist...> vMethod) {
+            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector<Cdecl>::*)(int)>(vMethod._vMethod);
+            VirtualOffsetSelector<Cdecl> offsetSelctor;
+            return (offsetSelctor.*sMethod)(0);
+        }
+
         template<typename C, typename R, typename ... arglist>
-        static unsigned int getOffset(R (C::*vMethod)(arglist...)) {
-            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector::*)(int)>(vMethod);
-            VirtualOffsetSelector offsetSelctor;
+        static unsigned int getOffset(FuncWithConvention<C, R, Stdcall, arglist...> vMethod) {
+            auto sMethod = reinterpret_cast<unsigned int (__stdcall VirtualOffsetSelector<Stdcall>::*)(int)>(vMethod._vMethod);
+            VirtualOffsetSelector<Stdcall> offsetSelctor;
             return (offsetSelctor.*sMethod)(0);
         }
 
         template<typename C>
         static typename std::enable_if<std::has_virtual_destructor<C>::value, unsigned int>::type
         getDestructorOffset() {
-            VirtualOffsetSelector offsetSelctor;
+
+            VirtualOffsetSelector<ConventionHelper::DefaultConvention> offsetSelctor;
             union_cast<C *>(&offsetSelctor)->~C();
             return offsetSelctor.offset;
         }
@@ -5381,7 +5525,7 @@ namespace fakeit {
                 }
             };
 
-            unsigned int vtSize = getOffset(&Derrived::endOfVt);
+            unsigned int vtSize = getOffset( ConventionHelper::Wrap( &Derrived::endOfVt ) );
             return vtSize;
         }
     };
@@ -5952,15 +6096,14 @@ namespace fakeit {
 
 
     template<typename R, typename ... arglist>
-    class MethodProxyCreator {
+	class MethodProxyCreatorBase{
 
+	public:
 
-
-    public:
-
-        template<unsigned int id>
+        template<unsigned int id, typename CONVENTION>
         MethodProxy createMethodProxy(unsigned int offset) {
-            return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
+            return MethodProxy(id, offset, union_cast<void *>
+				(&MethodProxyCreator<R, CONVENTION, arglist...>::methodProxyX < id > ));
         }
 
     protected:
@@ -5973,9 +6116,44 @@ namespace fakeit {
                             id);
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
+	};
+
+
+    template<typename R, typename CONVENTION, typename ... arglist>
+	class MethodProxyCreator {};
+
+
+	template<typename R, typename ... arglist>
+    class MethodProxyCreator< R, Thiscall, arglist...>: public MethodProxyCreatorBase< R, arglist...> {
+
+    public:
 
         template<int id>
-        R methodProxyX(arglist ... args) {
+        R __thiscall methodProxyX(arglist ... args) {
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+    };
+
+
+	template<typename R, typename ... arglist>
+    class MethodProxyCreator< R, Stdcall, arglist...>: public MethodProxyCreatorBase< R, arglist...> {
+
+    public:
+
+        template<int id>
+        R __stdcall methodProxyX(arglist ... args) {
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+    };
+
+
+	template<typename R, typename ... arglist>
+    class MethodProxyCreator< R, Cdecl, arglist...>: public MethodProxyCreatorBase< R, arglist...> {
+
+    public:
+
+        template<int id>
+        R __cdecl methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
     };
@@ -6058,17 +6236,24 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
-        void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
+        template<int id, typename R, typename CONVENTION, typename ... arglist>
+        void stubMethod(FuncWithConvention<C, R, CONVENTION, arglist... > vMethod, MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
-            MethodProxyCreator<R, arglist...> creator;
-            bind(creator.template createMethodProxy<id + 1>(offset), methodInvocationHandler);
+            MethodProxyCreator<R, CONVENTION, arglist...> creator;
+            bind(creator.createMethodProxy<id + 1, CONVENTION>(offset), methodInvocationHandler);
         }
 
         void stubDtor(MethodInvocationHandler<void> *methodInvocationHandler) {
             auto offset = VTUtils::getDestructorOffset<C>();
-            MethodProxyCreator<void> creator;
-            bindDtor(creator.createMethodProxy<0>(offset), methodInvocationHandler);
+
+            MethodProxyCreator<void, ConventionHelper::DefaultConvention> creator;
+            bindDtor(creator.createMethodProxy<0,ConventionHelper::DefaultConvention>(offset), methodInvocationHandler);
+        }
+
+        template<typename R, typename CONVENTION, typename ... arglist>
+        bool isMethodStubbed(FuncWithConvention<C, R, CONVENTION, arglist... > vMethod) {
+            unsigned int offset = VTUtils::getOffset(vMethod);
+            return isBinded(offset);
         }
 
         template<typename R, typename ... arglist>
@@ -6082,8 +6267,8 @@ namespace fakeit {
             return isBinded(offset);
         }
 
-        template<typename R, typename ... arglist>
-        Destructible *getMethodMock(R(C::*vMethod)(arglist...)) {
+        template<typename R, typename CONVENTION, typename ... arglist>
+        Destructible *getMethodMock(FuncWithConvention<C, R, CONVENTION, arglist... > vMethod) {
             auto offset = VTUtils::getOffset(vMethod);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -8027,9 +8212,9 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DATA_TYPE>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
-            return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
+        template<int id, typename R, typename CONVENTION, typename ... arglist>
+        MockingContext<R, arglist...> stubMethod( FuncWithConvention< C, R, CONVENTION, arglist... > vMethod ) {
+            return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, CONVENTION, arglist... >
                    (*this, vMethod));
         }
 
@@ -8105,19 +8290,19 @@ namespace fakeit {
 
         };
 
-        template<typename R, typename ... arglist>
+
+        template<typename R, typename CONVENTION, typename ... arglist>
         class MethodMockingContextImpl : public MethodMockingContextBase<R, arglist...> {
         protected:
 
-            R (C::*_vMethod)(arglist...);
+           FuncWithConvention<C, R, CONVENTION, arglist...> _vMethod;
 
         public:
             virtual ~MethodMockingContextImpl() = default;
 
-            MethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
+            MethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, FuncWithConvention<C, R, CONVENTION, arglist...> vMethod)
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
-
 
             virtual std::function<R(arglist&...)> getOriginalMethod() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
@@ -8129,21 +8314,20 @@ namespace fakeit {
             }
         };
 
-
-        template<int id, typename R, typename ... arglist>
-        class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
+        template<int id, typename R, typename CONVENTION, typename ... arglist>
+        class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, CONVENTION, arglist...> {
         protected:
 
             virtual RecordedMethodBody<R, arglist...> &getRecordedMethodBody() override {
                 return MethodMockingContextBase<R, arglist...>::_mock.template stubMethodIfNotStubbed<id>(
                         MethodMockingContextBase<R, arglist...>::_mock._proxy,
-                        MethodMockingContextImpl<R, arglist...>::_vMethod);
+                        MethodMockingContextImpl<R, CONVENTION, arglist...>::_vMethod);
             }
 
         public:
 
-            UniqueMethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
-                    : MethodMockingContextImpl<R, arglist...>(mock, vMethod) {
+            UniqueMethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, FuncWithConvention<C, R, CONVENTION, arglist...> vMethod)
+                    : MethodMockingContextImpl<R, CONVENTION, arglist...>(mock, vMethod) {
             }
         };
 
@@ -8203,8 +8387,8 @@ namespace fakeit {
 			return reinterpret_cast<C *>(fake);
         }
 
-        template<typename R, typename ... arglist>
-        void *getOriginalMethod(R (C::*vMethod)(arglist...)) {
+        template<typename R, typename CONVENTION, typename ... arglist>
+        void *getOriginalMethod(FuncWithConvention<C, R, CONVENTION, arglist...> vMethod) {
             auto vt = _proxy.getOriginalVT();
             auto offset = VTUtils::getOffset(vMethod);
             void *origMethodPtr = vt.getMethod(offset);
@@ -8218,11 +8402,11 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<unsigned int id, typename R, typename CONVENTION, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
-                                                                  R (C::*vMethod)(arglist...)) {
+                                                                  FuncWithConvention<C, R, CONVENTION, arglist... > vMethod ) {
             if (!proxy.isMethodStubbed(vMethod)) {
-                proxy.template stubMethod<id>(vMethod, createRecordedMethodBody < R, arglist... > (*this, vMethod));
+                proxy.template stubMethod<id>(vMethod, createRecordedMethodBody <R, CONVENTION, arglist... > (*this, vMethod ));
             }
             Destructible *d = proxy.getMethodMock(vMethod);
             RecordedMethodBody<R, arglist...> *methodMock = dynamic_cast<RecordedMethodBody<R, arglist...> *>(d);
@@ -8238,10 +8422,10 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        template<typename R, typename ... arglist>
+        template<typename R, typename CONVENTION, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
-                                                                           R(C::*vMethod)(arglist...)) {
-            return new RecordedMethodBody<R, arglist...>(mock.getFakeIt(), typeid(vMethod).name());
+                                                                           FuncWithConvention<C, R, CONVENTION, arglist... > vMethod) {
+            return new RecordedMethodBody<R, arglist...>(mock.getFakeIt(), typeid(vMethod._vMethod).name());
         }
 
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
@@ -8302,6 +8486,91 @@ namespace fakeit {
     }
     using namespace fakeit::internal;
 
+
+	struct func_traits{
+
+	#ifdef _MSC_VER
+
+		#define CC_CDECL __cdecl
+	#else
+
+		#define CC_CDECL
+	#endif
+
+
+
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) volatile ))( arglist... ) {
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) const ))( arglist... ) {
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(CC_CDECL T::* remove_cv( R(CC_CDECL T::*vMethod )( arglist... ) ))( arglist... ) {
+			return vMethod;
+		};
+
+
+	#if defined( _MSC_VER ) && ! defined( _WIN64 )
+
+
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
+			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) const ))( arglist... ) {
+			return reinterpret_cast< R( __stdcall T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__stdcall T::* remove_cv( R(__stdcall T::*vMethod )( arglist... ) ))( arglist... ) {
+			return vMethod;
+		};
+
+
+
+		template<typename T, typename R, typename... arglist>
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
+			return reinterpret_cast< R ( T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) volatile ))( arglist... ) {
+			return reinterpret_cast< R( __thiscall T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) const ))( arglist... ) {
+			return reinterpret_cast< R( __thiscall T::* )( arglist... ) >( vMethod );
+		};
+
+		template<typename T, typename R, typename... arglist>
+		static R(__thiscall T::* remove_cv( R(__thiscall T::*vMethod )( arglist... ) ))( arglist... ) {
+			return vMethod;
+		};
+	#endif
+
+		template<typename Func>
+		using remove_cv_t = decltype( remove_cv( std::declval<Func>() ) );
+	};
+
     template<typename C, typename ... baseclasses>
     class Mock : public ActualInvocationsSource {
         MockImpl<C, baseclasses...> impl;
@@ -8336,66 +8605,73 @@ namespace fakeit {
 			impl.clear();
 		}
 
-        template<class DATA_TYPE, typename ... arglist,
+		template<class DATA_TYPE, typename ... arglist,
                 class = typename std::enable_if<std::is_member_object_pointer<DATA_TYPE C::*>::value>::type>
         DataMemberStubbingRoot<C, DATA_TYPE> Stub(DATA_TYPE C::* member, const arglist &... ctorargs) {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
-            return impl.template stubMethod<id>(vMethod);
+        MockingContext<R, arglist...> stubImpl(R(CC_CDECL T::*vMethod)(arglist...)) {
+			R( CC_CDECL C:: * cMethod )( arglist... ) = vMethod;
+            return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        MockingContext<void, arglist...> stubImpl(R(CC_CDECL T::*vMethod)(arglist...)) {
+			auto vMethodWithoutConstVolatile = reinterpret_cast< void( CC_CDECL T::* )( arglist... ) >( vMethod );
+
+			void( CC_CDECL C:: * cMethod )( arglist... ) = vMethodWithoutConstVolatile;
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
+        }
+
+
+	#if defined( _MSC_VER ) && ! defined( _WIN64 )
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stubImpl(R(__stdcall T::*vMethod)(arglist...)) {
+			R( __stdcall C:: * cMethod )( arglist... ) = vMethod;
+            return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+			MockingContext<void, arglist...> stubImpl( R( __stdcall T::* vMethod )( arglist... ) )
+		{
+			auto vMethodWithoutConstVolatile = reinterpret_cast< void( __stdcall T::* )( arglist... ) >( vMethod );
+
+			void( __stdcall C:: * cMethod )( arglist... ) = vMethodWithoutConstVolatile;
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
+		}
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stubImpl(R(__thiscall T::*vMethod)(arglist...)) {
+
+			R( __thiscall C:: * cMethod )( arglist... ) = vMethod;
+            return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
+			MockingContext<void, arglist...> stubImpl( R( __thiscall T::* vMethod )( arglist... ) )
+		{
+			auto vMethodWithoutConstVolatile = reinterpret_cast< void( __thiscall T::* )( arglist... ) >( vMethod );
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
+			void( __thiscall C:: * cMethod )( arglist... ) = vMethodWithoutConstVolatile;
+			return impl.template stubMethod<id>( ConventionHelper::Wrap( cMethod ) );
+		}
+
+	#endif
+
+		template<int id, typename Func>
+		auto stub( Func func ) -> decltype( stubImpl<id>( func_traits::remove_cv( func ) ) )
+		{
+			return stubImpl<id>( func_traits::remove_cv( func ) );
+		}
 
         DtorMockingContext dtor() {
             return impl.stubDtor();
@@ -8406,7 +8682,6 @@ namespace fakeit {
         }
 
     };
-
 }
 
 #include <exception>

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:14:36.031769
+ *  Generated: 2018-08-17 00:22:40.428924
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5316,7 +5316,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -8017,11 +8018,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8300,9 +8301,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -5468,6 +5468,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:22:40.428924
+ *  Generated: 2019-06-01 12:14:44.281637
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -983,7 +983,19 @@ namespace fakeit {
         }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -1119,6 +1131,11 @@ namespace fakeit {
     }
 
 }
+#if __has_include("catch2/catch.hpp")
+#   include "catch2/catch.hpp"
+#else
+#   include "catch.hpp"
+#endif
 
 namespace fakeit {
 
@@ -5822,6 +5839,7 @@ namespace fakeit {
 
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif
@@ -8476,7 +8494,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8736,7 +8754,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -9084,7 +9102,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/cute/fakeit.hpp
+++ b/single_header/cute/fakeit.hpp
@@ -1,0 +1,9300 @@
+#pragma once
+/*
+ *  FakeIt - A Simplified C++ Mocking Framework
+ *  Copyright (c) Eran Pe'er 2013
+ *  Generated: 2019-10-18 14:29:08.645463
+ *  Distributed under the MIT License. Please refer to the LICENSE file at:
+ *  https://github.com/eranpeer/FakeIt
+ */
+
+#ifndef fakeit_h__
+#define fakeit_h__
+
+
+
+#include <functional>
+#include <memory>
+#include <set>
+#include <vector>
+#include <stdexcept>
+#if defined (__GNUG__) || _MSC_VER >= 1900
+#define THROWS noexcept(false)
+#define NO_THROWS noexcept(true)
+#elif defined (_MSC_VER)
+#define THROWS throw(...)
+#define NO_THROWS
+#endif
+#include <typeinfo>
+#include <unordered_set>
+#include <tuple>
+#include <string>
+#include <iosfwd>
+#include <atomic>
+#include <tuple>
+
+
+namespace fakeit {
+
+    template<class C>
+    struct naked_type {
+        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
+    };
+
+    template< class T > struct tuple_arg         { typedef T  type; };
+    template< class T > struct tuple_arg < T& >  { typedef T& type; };
+    template< class T > struct tuple_arg < T&& > { typedef T&&  type; };
+
+
+
+
+    template<typename... arglist>
+    using ArgumentsTuple = std::tuple < arglist... > ;
+
+    template< class T > struct test_arg         { typedef T& type; };
+    template< class T > struct test_arg< T& >   { typedef T& type; };
+    template< class T > struct test_arg< T&& >  { typedef T& type; };
+
+    template< class T > struct production_arg         { typedef T& type; };
+    template< class T > struct production_arg< T& >   { typedef T& type; };
+    template< class T > struct production_arg< T&& >  { typedef T&&  type; };
+
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template<typename R, typename... arglist>
+    struct VTableMethodType {
+#if defined (__GNUG__)
+        typedef R(*type)(void *, arglist...);
+#elif defined (_MSC_VER)
+        typedef R(__thiscall *type)(void *, arglist...);
+#endif
+    };
+}
+#include <typeinfo>
+#include <tuple>
+#include <string>
+#include <iosfwd>
+#include <sstream>
+#include <string>
+
+namespace fakeit {
+
+    struct FakeitContext;
+
+    template<typename C>
+    struct MockObject {
+        virtual ~MockObject() THROWS { };
+
+        virtual C &get() = 0;
+
+        virtual FakeitContext &getFakeIt() = 0;
+    };
+
+    struct MethodInfo {
+
+        static unsigned int nextMethodOrdinal() {
+            static std::atomic_uint ordinal{0};
+            return ++ordinal;
+        }
+
+        MethodInfo(unsigned int anId, std::string aName) :
+                _id(anId), _name(aName) { }
+
+        unsigned int id() const {
+            return _id;
+        }
+
+        std::string name() const {
+            return _name;
+        }
+
+        void setName(const std::string &value) {
+            _name = value;
+        }
+
+    private:
+        unsigned int _id;
+        std::string _name;
+    };
+
+    struct UnknownMethod {
+
+        static MethodInfo &instance() {
+            static MethodInfo instance(MethodInfo::nextMethodOrdinal(), "unknown");
+            return instance;
+        }
+
+    };
+
+}
+namespace fakeit {
+    class Destructible {
+    public:
+        virtual ~Destructible() {}
+    };
+}
+
+namespace fakeit {
+
+    struct Invocation : Destructible {
+
+        static unsigned int nextInvocationOrdinal() {
+            static std::atomic_uint invocationOrdinal{0};
+            return ++invocationOrdinal;
+        }
+
+        struct Matcher {
+
+            virtual ~Matcher() THROWS {
+            }
+
+            virtual bool matches(Invocation &invocation) = 0;
+
+            virtual std::string format() const = 0;
+        };
+
+        Invocation(unsigned int ordinal, MethodInfo &method) :
+                _ordinal(ordinal), _method(method), _isVerified(false) {
+        }
+
+        virtual ~Invocation() override = default;
+
+        unsigned int getOrdinal() const {
+            return _ordinal;
+        }
+
+        MethodInfo &getMethod() const {
+            return _method;
+        }
+
+        void markAsVerified() {
+            _isVerified = true;
+        }
+
+        bool isVerified() const {
+            return _isVerified;
+        }
+
+        virtual std::string format() const = 0;
+
+    private:
+        const unsigned int _ordinal;
+        MethodInfo &_method;
+        bool _isVerified;
+    };
+
+}
+#include <iosfwd>
+#include <tuple>
+#include <string>
+#include <sstream>
+#include <ostream>
+
+namespace fakeit {
+
+	template<typename T, class Enable = void>
+	struct Formatter;
+
+	template <>
+	struct Formatter<bool>
+	{
+		static std::string format(bool const &val)
+		{
+			return val ? "true" : "false";
+		}
+	};
+
+	template <>
+	struct Formatter<char>
+	{
+		static std::string format(char const &val)
+		{
+			std::string s;
+			s += "'";
+			s += val;
+			s += "'";
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
+		}
+	};
+
+	template<class C>
+	struct Formatter<C, typename std::enable_if<!is_ostreamable<C>::value>::type> {
+		static std::string format(C const &)
+		{
+			return "?";
+		}
+	};
+
+	template<class C>
+	struct Formatter<C, typename std::enable_if<is_ostreamable<C>::value>::type> {
+		static std::string format(C const &val)
+		{
+			std::ostringstream os;
+			os << val;
+			return os.str();
+		}
+	};
+
+
+	template <typename T>
+	using TypeFormatter = Formatter<typename fakeit::naked_type<T>::type>;
+}
+
+namespace fakeit {
+
+
+    template<class Tuple, std::size_t N>
+    struct TuplePrinter {
+        static void print(std::ostream &strm, const Tuple &t) {
+            TuplePrinter<Tuple, N - 1>::print(strm, t);
+            strm << ", " << fakeit::TypeFormatter<decltype(std::get<N - 1>(t))>::format(std::get<N - 1>(t));
+        }
+    };
+
+    template<class Tuple>
+    struct TuplePrinter<Tuple, 1> {
+        static void print(std::ostream &strm, const Tuple &t) {
+            strm << fakeit::TypeFormatter<decltype(std::get<0>(t))>::format(std::get<0>(t));
+        }
+    };
+
+    template<class Tuple>
+    struct TuplePrinter<Tuple, 0> {
+        static void print(std::ostream &, const Tuple &) {
+        }
+    };
+
+    template<class ... Args>
+    void print(std::ostream &strm, const std::tuple<Args...> &t) {
+        strm << "(";
+        TuplePrinter<decltype(t), sizeof...(Args)>::print(strm, t);
+        strm << ")";
+    }
+
+    template<class ... Args>
+    std::ostream &operator<<(std::ostream &strm, const std::tuple<Args...> &t) {
+        print(strm, t);
+        return strm;
+    }
+
+}
+
+
+namespace fakeit {
+
+    template<typename ... arglist>
+    struct ActualInvocation : public Invocation {
+
+        struct Matcher : public virtual Destructible {
+            virtual bool matches(ActualInvocation<arglist...> &actualInvocation) = 0;
+
+            virtual std::string format() const = 0;
+        };
+
+        ActualInvocation(unsigned int ordinal, MethodInfo &method, const typename fakeit::production_arg<arglist>::type... args) :
+            Invocation(ordinal, method), _matcher{ nullptr }
+            , actualArguments{ std::forward<arglist>(args)... }
+        {
+        }
+
+        ArgumentsTuple<arglist...> & getActualArguments() {
+            return actualArguments;
+        }
+
+
+        void setActualMatcher(Matcher *matcher) {
+            this->_matcher = matcher;
+        }
+
+        Matcher *getActualMatcher() {
+            return _matcher;
+        }
+
+        virtual std::string format() const override {
+            std::ostringstream out;
+            out << getMethod().name();
+            print(out, actualArguments);
+            return out.str();
+        }
+
+    private:
+
+        Matcher *_matcher;
+        ArgumentsTuple<arglist...> actualArguments;
+    };
+
+    template<typename ... arglist>
+    std::ostream &operator<<(std::ostream &strm, const ActualInvocation<arglist...> &ai) {
+        strm << ai.format();
+        return strm;
+    }
+
+}
+
+
+
+
+
+#include <unordered_set>
+
+namespace fakeit {
+
+	struct ActualInvocationsContainer {
+		virtual void clear() = 0;
+
+		virtual ~ActualInvocationsContainer() NO_THROWS { }
+	};
+
+    struct ActualInvocationsSource {
+        virtual void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const = 0;
+
+        virtual ~ActualInvocationsSource() NO_THROWS { }
+    };
+
+    struct InvocationsSourceProxy : public ActualInvocationsSource {
+
+        InvocationsSourceProxy(ActualInvocationsSource *inner) :
+                _inner(inner) {
+        }
+
+        void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const override {
+            _inner->getActualInvocations(into);
+        }
+
+    private:
+        std::shared_ptr<ActualInvocationsSource> _inner;
+    };
+
+    struct UnverifiedInvocationsSource : public ActualInvocationsSource {
+
+        UnverifiedInvocationsSource(InvocationsSourceProxy decorated) : _decorated(decorated) {
+        }
+
+        void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const override {
+            std::unordered_set<fakeit::Invocation *> all;
+            _decorated.getActualInvocations(all);
+            for (fakeit::Invocation *i : all) {
+                if (!i->isVerified()) {
+                    into.insert(i);
+                }
+            }
+        }
+
+    private:
+        InvocationsSourceProxy _decorated;
+    };
+
+    struct AggregateInvocationsSource : public ActualInvocationsSource {
+
+        AggregateInvocationsSource(std::vector<ActualInvocationsSource *> &sources) : _sources(sources) {
+        }
+
+        void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const override {
+            std::unordered_set<fakeit::Invocation *> tmp;
+            for (ActualInvocationsSource *source : _sources) {
+                source->getActualInvocations(tmp);
+            }
+            filter(tmp, into);
+        }
+
+    protected:
+        bool shouldInclude(fakeit::Invocation *) const {
+            return true;
+        }
+
+    private:
+        std::vector<ActualInvocationsSource *> _sources;
+
+        void filter(std::unordered_set<Invocation *> &source, std::unordered_set<Invocation *> &target) const {
+            for (Invocation *i:source) {
+                if (shouldInclude(i)) {
+                    target.insert(i);
+                }
+            }
+        }
+    };
+}
+
+namespace fakeit {
+
+    class Sequence {
+    private:
+
+    protected:
+
+        Sequence() {
+        }
+
+        virtual ~Sequence() THROWS {
+        }
+
+    public:
+
+
+        virtual void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const = 0;
+
+
+        virtual void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const = 0;
+
+        virtual unsigned int size() const = 0;
+
+        friend class VerifyFunctor;
+    };
+
+    class ConcatenatedSequence : public virtual Sequence {
+    private:
+        const Sequence &s1;
+        const Sequence &s2;
+
+    protected:
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
+        }
+
+    public:
+
+        virtual ~ConcatenatedSequence() {
+        }
+
+        unsigned int size() const override {
+            return s1.size() + s2.size();
+        }
+
+        const Sequence &getLeft() const {
+            return s1;
+        }
+
+        const Sequence &getRight() const {
+            return s2;
+        }
+
+        void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const override {
+            s1.getExpectedSequence(into);
+            s2.getExpectedSequence(into);
+        }
+
+        virtual void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
+            s1.getInvolvedMocks(into);
+            s2.getInvolvedMocks(into);
+        }
+
+        friend inline ConcatenatedSequence operator+(const Sequence &s1, const Sequence &s2);
+    };
+
+    class RepeatedSequence : public virtual Sequence {
+    private:
+        const Sequence &_s;
+        const int times;
+
+    protected:
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
+        }
+
+    public:
+
+        ~RepeatedSequence() {
+        }
+
+        unsigned int size() const override {
+            return _s.size() * times;
+        }
+
+        friend inline RepeatedSequence operator*(const Sequence &s, int times);
+
+        friend inline RepeatedSequence operator*(int times, const Sequence &s);
+
+        void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
+            _s.getInvolvedMocks(into);
+        }
+
+        void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const override {
+            for (int i = 0; i < times; i++)
+                _s.getExpectedSequence(into);
+        }
+
+        int getTimes() const {
+            return times;
+        }
+
+        const Sequence &getSequence() const {
+            return _s;
+        }
+    };
+
+    inline ConcatenatedSequence operator+(const Sequence &s1, const Sequence &s2) {
+        return ConcatenatedSequence(s1, s2);
+    }
+
+    inline RepeatedSequence operator*(const Sequence &s, int times) {
+        if (times <= 0)
+            throw std::invalid_argument("times");
+        return RepeatedSequence(s, times);
+    }
+
+    inline RepeatedSequence operator*(int times, const Sequence &s) {
+        if (times <= 0)
+            throw std::invalid_argument("times");
+        return RepeatedSequence(s, times);
+    }
+
+}
+
+namespace fakeit {
+
+    enum class VerificationType {
+        Exact, AtLeast, NoMoreInvocations
+    };
+
+    enum class UnexpectedType {
+        Unmocked, Unmatched
+    };
+
+    struct VerificationEvent {
+
+        VerificationEvent(VerificationType aVerificationType) :
+                _verificationType(aVerificationType), _line(0) {
+        }
+
+        virtual ~VerificationEvent() = default;
+
+        VerificationType verificationType() const {
+            return _verificationType;
+        }
+
+        void setFileInfo(const char * aFile, int aLine, const char * aCallingMethod) {
+            _file = aFile;
+            _callingMethod = aCallingMethod;
+            _line = aLine;
+        }
+
+        const char * file() const {
+            return _file;
+        }
+
+        int line() const {
+            return _line;
+        }
+
+        const char * callingMethod() const {
+            return _callingMethod;
+        }
+
+    private:
+        VerificationType _verificationType;
+		const char * _file;
+        int _line;
+        const char * _callingMethod;
+    };
+
+    struct NoMoreInvocationsVerificationEvent : public VerificationEvent {
+
+        ~NoMoreInvocationsVerificationEvent() = default;
+
+        NoMoreInvocationsVerificationEvent(
+                std::vector<Invocation *> &allTheIvocations,
+                std::vector<Invocation *> &anUnverifedIvocations) :
+                VerificationEvent(VerificationType::NoMoreInvocations),
+                _allIvocations(allTheIvocations),
+                _unverifedIvocations(anUnverifedIvocations) {
+        }
+
+        const std::vector<Invocation *> &allIvocations() const {
+            return _allIvocations;
+        }
+
+        const std::vector<Invocation *> &unverifedIvocations() const {
+            return _unverifedIvocations;
+        }
+
+    private:
+        const std::vector<Invocation *> _allIvocations;
+        const std::vector<Invocation *> _unverifedIvocations;
+    };
+
+    struct SequenceVerificationEvent : public VerificationEvent {
+
+        ~SequenceVerificationEvent() = default;
+
+        SequenceVerificationEvent(VerificationType aVerificationType,
+                                  std::vector<Sequence *> &anExpectedPattern,
+                                  std::vector<Invocation *> &anActualSequence,
+                                  int anExpectedCount,
+                                  int anActualCount) :
+                VerificationEvent(aVerificationType),
+                _expectedPattern(anExpectedPattern),
+                _actualSequence(anActualSequence),
+                _expectedCount(anExpectedCount),
+                _actualCount(anActualCount)
+        {
+        }
+
+        const std::vector<Sequence *> &expectedPattern() const {
+            return _expectedPattern;
+        }
+
+        const std::vector<Invocation *> &actualSequence() const {
+            return _actualSequence;
+        }
+
+        int expectedCount() const {
+            return _expectedCount;
+        }
+
+        int actualCount() const {
+            return _actualCount;
+        }
+
+    private:
+        const std::vector<Sequence *> _expectedPattern;
+        const std::vector<Invocation *> _actualSequence;
+        const int _expectedCount;
+        const int _actualCount;
+    };
+
+    struct UnexpectedMethodCallEvent {
+        UnexpectedMethodCallEvent(UnexpectedType unexpectedType, const Invocation &invocation) :
+                _unexpectedType(unexpectedType), _invocation(invocation) {
+        }
+
+        const Invocation &getInvocation() const {
+            return _invocation;
+        }
+
+        UnexpectedType getUnexpectedType() const {
+            return _unexpectedType;
+        }
+
+        const UnexpectedType _unexpectedType;
+        const Invocation &_invocation;
+    };
+
+}
+
+namespace fakeit {
+
+    struct VerificationEventHandler {
+        virtual void handle(const SequenceVerificationEvent &e) = 0;
+
+        virtual void handle(const NoMoreInvocationsVerificationEvent &e) = 0;
+    };
+
+    struct EventHandler : public VerificationEventHandler {
+        using VerificationEventHandler::handle;
+
+        virtual void handle(const UnexpectedMethodCallEvent &e) = 0;
+    };
+
+}
+#include <vector>
+#include <string>
+
+namespace fakeit {
+
+    struct UnexpectedMethodCallEvent;
+    struct SequenceVerificationEvent;
+    struct NoMoreInvocationsVerificationEvent;
+
+    struct EventFormatter {
+
+        virtual std::string format(const fakeit::UnexpectedMethodCallEvent &e) = 0;
+
+        virtual std::string format(const fakeit::SequenceVerificationEvent &e) = 0;
+
+        virtual std::string format(const fakeit::NoMoreInvocationsVerificationEvent &e) = 0;
+
+    };
+
+}
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
+
+namespace fakeit {
+
+    struct FakeitContext : public EventHandler, protected EventFormatter {
+
+        virtual ~FakeitContext() = default;
+
+        void handle(const UnexpectedMethodCallEvent &e) override {
+            fireEvent(e);
+            auto &eh = getTestingFrameworkAdapter();
+            #ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+            assert(!"Unexpected method invocation");
+            #endif
+            eh.handle(e);
+        }
+
+        void handle(const SequenceVerificationEvent &e) override {
+            fireEvent(e);
+            auto &eh = getTestingFrameworkAdapter();
+            return eh.handle(e);
+        }
+
+        void handle(const NoMoreInvocationsVerificationEvent &e) override {
+            fireEvent(e);
+            auto &eh = getTestingFrameworkAdapter();
+            return eh.handle(e);
+        }
+
+        std::string format(const UnexpectedMethodCallEvent &e) override {
+            auto &eventFormatter = getEventFormatter();
+            return eventFormatter.format(e);
+        }
+
+        std::string format(const SequenceVerificationEvent &e) override {
+            auto &eventFormatter = getEventFormatter();
+            return eventFormatter.format(e);
+        }
+
+        std::string format(const NoMoreInvocationsVerificationEvent &e) override {
+            auto &eventFormatter = getEventFormatter();
+            return eventFormatter.format(e);
+        }
+
+        void addEventHandler(EventHandler &eventListener) {
+            _eventListeners.push_back(&eventListener);
+        }
+
+        void clearEventHandlers() {
+            _eventListeners.clear();
+        }
+
+    protected:
+        virtual EventHandler &getTestingFrameworkAdapter() = 0;
+
+        virtual EventFormatter &getEventFormatter() = 0;
+
+    private:
+        std::vector<EventHandler *> _eventListeners;
+
+        void fireEvent(const NoMoreInvocationsVerificationEvent &evt) {
+            for (auto listener : _eventListeners)
+                listener->handle(evt);
+        }
+
+        void fireEvent(const UnexpectedMethodCallEvent &evt) {
+            for (auto listener : _eventListeners)
+                listener->handle(evt);
+        }
+
+        void fireEvent(const SequenceVerificationEvent &evt) {
+            for (auto listener : _eventListeners)
+                listener->handle(evt);
+        }
+
+    };
+
+}
+#include <iostream>
+#include <iosfwd>
+
+namespace fakeit {
+
+    struct DefaultEventFormatter : public EventFormatter {
+
+        virtual std::string format(const UnexpectedMethodCallEvent &e) override {
+            std::ostringstream out;
+            out << "Unexpected method invocation: ";
+            out << e.getInvocation().format() << std::endl;
+            if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
+                out << "  Could not find any recorded behavior to support this method call.";
+            } else {
+                out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
+            }
+            return out.str();
+        }
+
+
+        virtual std::string format(const SequenceVerificationEvent &e) override {
+            std::ostringstream out;
+            out << "Verification error" << std::endl;
+
+            out << "Expected pattern: ";
+            const std::vector<fakeit::Sequence *> expectedPattern = e.expectedPattern();
+            out << formatExpectedPattern(expectedPattern) << std::endl;
+
+            out << "Expected matches: ";
+            formatExpectedCount(out, e.verificationType(), e.expectedCount());
+            out << std::endl;
+
+            out << "Actual matches  : " << e.actualCount() << std::endl;
+
+            auto actualSequence = e.actualSequence();
+            out << "Actual sequence : total of " << actualSequence.size() << " actual invocations";
+            if (actualSequence.size() == 0) {
+                out << ".";
+            } else {
+                out << ":" << std::endl;
+            }
+            formatInvocationList(out, actualSequence);
+
+            return out.str();
+        }
+
+        virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
+            std::ostringstream out;
+            out << "Verification error" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
+            formatInvocationList(out, e.unverifedIvocations());
+            return out.str();
+        }
+
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
+    private:
+
+        static std::string formatSequence(const Sequence &val) {
+            const ConcatenatedSequence *cs = dynamic_cast<const ConcatenatedSequence *>(&val);
+            if (cs) {
+                return format(*cs);
+            }
+            const RepeatedSequence *rs = dynamic_cast<const RepeatedSequence *>(&val);
+            if (rs) {
+                return format(*rs);
+            }
+
+
+            std::vector<Invocation::Matcher *> vec;
+            val.getExpectedSequence(vec);
+            return vec[0]->format();
+        }
+
+        static void formatExpectedCount(std::ostream &out, fakeit::VerificationType verificationType,
+                                        int expectedCount) {
+            if (verificationType == fakeit::VerificationType::Exact)
+                out << "exactly ";
+
+            if (verificationType == fakeit::VerificationType::AtLeast)
+                out << "at least ";
+
+            out << expectedCount;
+        }
+
+        static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
+            size_t max_size = actualSequence.size();
+            if (max_size > 50)
+                max_size = 50;
+
+            for (unsigned int i = 0; i < max_size; i++) {
+                out << "  ";
+                auto invocation = actualSequence[i];
+                out << invocation->format();
+                if (i < max_size - 1)
+                    out << std::endl;
+            }
+
+            if (actualSequence.size() > max_size)
+                out << std::endl << "  ...";
+        }
+
+        static std::string format(const ConcatenatedSequence &val) {
+            std::ostringstream out;
+            out << formatSequence(val.getLeft()) << " + " << formatSequence(val.getRight());
+            return out.str();
+        }
+
+        static std::string format(const RepeatedSequence &val) {
+            std::ostringstream out;
+            const ConcatenatedSequence *cs = dynamic_cast<const ConcatenatedSequence *>(&val.getSequence());
+            const RepeatedSequence *rs = dynamic_cast<const RepeatedSequence *>(&val.getSequence());
+            if (rs || cs)
+                out << '(';
+            out << formatSequence(val.getSequence());
+            if (rs || cs)
+                out << ')';
+
+            out << " * " << val.getTimes();
+            return out.str();
+        }
+    };
+}
+#include <exception>
+
+
+namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
+
+    struct FakeitException {
+        std::exception err;
+
+        virtual ~FakeitException() = default;
+
+        virtual std::string what() const = 0;
+
+        friend std::ostream &operator<<(std::ostream &os, const FakeitException &val) {
+            os << val.what();
+            return os;
+        }
+    };
+
+
+
+
+    struct UnexpectedMethodCallException : public FakeitException {
+
+        UnexpectedMethodCallException(std::string format) :
+                _format(format) {
+        }
+
+        virtual std::string what() const override {
+            return _format;
+        }
+
+    private:
+        std::string _format;
+    };
+
+}
+
+namespace fakeit {
+
+    struct DefaultEventLogger : public fakeit::EventHandler {
+
+        DefaultEventLogger(EventFormatter &formatter) : _formatter(formatter), _out(std::cout) { }
+
+        virtual void handle(const UnexpectedMethodCallEvent &e) override {
+            _out << _formatter.format(e) << std::endl;
+        }
+
+        virtual void handle(const SequenceVerificationEvent &e) override {
+            _out << _formatter.format(e) << std::endl;
+        }
+
+        virtual void handle(const NoMoreInvocationsVerificationEvent &e) override {
+            _out << _formatter.format(e) << std::endl;
+        }
+
+    private:
+        EventFormatter &_formatter;
+        std::ostream &_out;
+    };
+
+}
+
+namespace fakeit {
+
+    class AbstractFakeit : public FakeitContext {
+    public:
+        virtual ~AbstractFakeit() = default;
+
+    protected:
+
+        virtual fakeit::EventHandler &accessTestingFrameworkAdapter() = 0;
+
+        virtual EventFormatter &accessEventFormatter() = 0;
+    };
+
+    class DefaultFakeit : public AbstractFakeit {
+        DefaultEventFormatter _formatter;
+        fakeit::EventFormatter *_customFormatter;
+        fakeit::EventHandler *_testingFrameworkAdapter;
+
+    public:
+
+        DefaultFakeit() : _formatter(),
+                          _customFormatter(nullptr),
+                          _testingFrameworkAdapter(nullptr) {
+        }
+
+        virtual ~DefaultFakeit() = default;
+
+        void setCustomEventFormatter(fakeit::EventFormatter &customEventFormatter) {
+            _customFormatter = &customEventFormatter;
+        }
+
+        void resetCustomEventFormatter() {
+            _customFormatter = nullptr;
+        }
+
+        void setTestingFrameworkAdapter(fakeit::EventHandler &testingFrameforkAdapter) {
+            _testingFrameworkAdapter = &testingFrameforkAdapter;
+        }
+
+        void resetTestingFrameworkAdapter() {
+            _testingFrameworkAdapter = nullptr;
+        }
+
+    protected:
+
+        fakeit::EventHandler &getTestingFrameworkAdapter() override {
+            if (_testingFrameworkAdapter)
+                return *_testingFrameworkAdapter;
+            return accessTestingFrameworkAdapter();
+        }
+
+        EventFormatter &getEventFormatter() override {
+            if (_customFormatter)
+                return *_customFormatter;
+            return accessEventFormatter();
+        }
+
+        EventFormatter &accessEventFormatter() override {
+            return _formatter;
+        }
+
+    };
+}
+
+namespace fakeit {
+
+	struct CuteAdapter : public EventHandler {
+		virtual ~CuteAdapter() = default;
+
+		CuteAdapter(EventFormatter &formatter)
+			: _formatter(formatter) {
+		}
+
+		virtual void handle(const UnexpectedMethodCallEvent &evt) override {
+			std::string format = _formatter.format(evt);
+			throw std::string(format);
+        }
+
+		virtual void handle(const SequenceVerificationEvent &evt) override {
+			std::string format(_formatter.format(evt));
+			throw cute::test_failure(format, evt.file(), evt.line());
+
+        }
+
+		virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {
+			std::string format = _formatter.format(evt);
+			throw cute::test_failure(format, evt.file(), evt.line());
+        }
+
+	private:
+		EventFormatter &_formatter;
+	};
+
+    class CuteFakeit : public DefaultFakeit {
+
+    public:
+        virtual ~CuteFakeit() = default;
+
+        CuteFakeit(): _CuteAdapter(*this) {
+        }
+
+        static CuteFakeit &getInstance() {
+            static CuteFakeit instance;
+            return instance;
+        }
+
+    protected:
+
+        fakeit::EventHandler &accessTestingFrameworkAdapter() override {
+            return _CuteAdapter;
+        }
+
+    private:
+
+        CuteAdapter _CuteAdapter;
+    };
+}
+
+static fakeit::DefaultFakeit& Fakeit = fakeit::CuteFakeit::getInstance();
+
+
+#include <type_traits>
+#include <unordered_set>
+
+#include <memory>
+#undef max
+#include <functional>
+#include <type_traits>
+#include <vector>
+#include <array>
+#include <new>
+#include <limits>
+
+#include <functional>
+#include <type_traits>
+namespace fakeit {
+
+    struct VirtualOffsetSelector {
+
+        unsigned int offset;
+
+        virtual unsigned int offset0(int) {
+            return offset = 0;
+        }
+
+        virtual unsigned int offset1(int) {
+            return offset = 1;
+        }
+
+        virtual unsigned int offset2(int) {
+            return offset = 2;
+        }
+
+        virtual unsigned int offset3(int) {
+            return offset = 3;
+        }
+
+        virtual unsigned int offset4(int) {
+            return offset = 4;
+        }
+
+        virtual unsigned int offset5(int) {
+            return offset = 5;
+        }
+
+        virtual unsigned int offset6(int) {
+            return offset = 6;
+        }
+
+        virtual unsigned int offset7(int) {
+            return offset = 7;
+        }
+
+        virtual unsigned int offset8(int) {
+            return offset = 8;
+        }
+
+        virtual unsigned int offset9(int) {
+            return offset = 9;
+        }
+
+        virtual unsigned int offset10(int) {
+            return offset = 10;
+        }
+
+        virtual unsigned int offset11(int) {
+            return offset = 11;
+        }
+
+        virtual unsigned int offset12(int) {
+            return offset = 12;
+        }
+
+        virtual unsigned int offset13(int) {
+            return offset = 13;
+        }
+
+        virtual unsigned int offset14(int) {
+            return offset = 14;
+        }
+
+        virtual unsigned int offset15(int) {
+            return offset = 15;
+        }
+
+        virtual unsigned int offset16(int) {
+            return offset = 16;
+        }
+
+        virtual unsigned int offset17(int) {
+            return offset = 17;
+        }
+
+        virtual unsigned int offset18(int) {
+            return offset = 18;
+        }
+
+        virtual unsigned int offset19(int) {
+            return offset = 19;
+        }
+
+        virtual unsigned int offset20(int) {
+            return offset = 20;
+        }
+
+        virtual unsigned int offset21(int) {
+            return offset = 21;
+        }
+
+        virtual unsigned int offset22(int) {
+            return offset = 22;
+        }
+
+        virtual unsigned int offset23(int) {
+            return offset = 23;
+        }
+
+        virtual unsigned int offset24(int) {
+            return offset = 24;
+        }
+
+        virtual unsigned int offset25(int) {
+            return offset = 25;
+        }
+
+        virtual unsigned int offset26(int) {
+            return offset = 26;
+        }
+
+        virtual unsigned int offset27(int) {
+            return offset = 27;
+        }
+
+        virtual unsigned int offset28(int) {
+            return offset = 28;
+        }
+
+        virtual unsigned int offset29(int) {
+            return offset = 29;
+        }
+
+        virtual unsigned int offset30(int) {
+            return offset = 30;
+        }
+
+        virtual unsigned int offset31(int) {
+            return offset = 31;
+        }
+
+        virtual unsigned int offset32(int) {
+            return offset = 32;
+        }
+
+        virtual unsigned int offset33(int) {
+            return offset = 33;
+        }
+
+        virtual unsigned int offset34(int) {
+            return offset = 34;
+        }
+
+        virtual unsigned int offset35(int) {
+            return offset = 35;
+        }
+
+        virtual unsigned int offset36(int) {
+            return offset = 36;
+        }
+
+        virtual unsigned int offset37(int) {
+            return offset = 37;
+        }
+
+        virtual unsigned int offset38(int) {
+            return offset = 38;
+        }
+
+        virtual unsigned int offset39(int) {
+            return offset = 39;
+        }
+
+        virtual unsigned int offset40(int) {
+            return offset = 40;
+        }
+
+        virtual unsigned int offset41(int) {
+            return offset = 41;
+        }
+
+        virtual unsigned int offset42(int) {
+            return offset = 42;
+        }
+
+        virtual unsigned int offset43(int) {
+            return offset = 43;
+        }
+
+        virtual unsigned int offset44(int) {
+            return offset = 44;
+        }
+
+        virtual unsigned int offset45(int) {
+            return offset = 45;
+        }
+
+        virtual unsigned int offset46(int) {
+            return offset = 46;
+        }
+
+        virtual unsigned int offset47(int) {
+            return offset = 47;
+        }
+
+        virtual unsigned int offset48(int) {
+            return offset = 48;
+        }
+
+        virtual unsigned int offset49(int) {
+            return offset = 49;
+        }
+
+        virtual unsigned int offset50(int) {
+            return offset = 50;
+        }
+
+        virtual unsigned int offset51(int) {
+            return offset = 51;
+        }
+
+        virtual unsigned int offset52(int) {
+            return offset = 52;
+        }
+
+        virtual unsigned int offset53(int) {
+            return offset = 53;
+        }
+
+        virtual unsigned int offset54(int) {
+            return offset = 54;
+        }
+
+        virtual unsigned int offset55(int) {
+            return offset = 55;
+        }
+
+        virtual unsigned int offset56(int) {
+            return offset = 56;
+        }
+
+        virtual unsigned int offset57(int) {
+            return offset = 57;
+        }
+
+        virtual unsigned int offset58(int) {
+            return offset = 58;
+        }
+
+        virtual unsigned int offset59(int) {
+            return offset = 59;
+        }
+
+        virtual unsigned int offset60(int) {
+            return offset = 60;
+        }
+
+        virtual unsigned int offset61(int) {
+            return offset = 61;
+        }
+
+        virtual unsigned int offset62(int) {
+            return offset = 62;
+        }
+
+        virtual unsigned int offset63(int) {
+            return offset = 63;
+        }
+
+        virtual unsigned int offset64(int) {
+            return offset = 64;
+        }
+
+        virtual unsigned int offset65(int) {
+            return offset = 65;
+        }
+
+        virtual unsigned int offset66(int) {
+            return offset = 66;
+        }
+
+        virtual unsigned int offset67(int) {
+            return offset = 67;
+        }
+
+        virtual unsigned int offset68(int) {
+            return offset = 68;
+        }
+
+        virtual unsigned int offset69(int) {
+            return offset = 69;
+        }
+
+        virtual unsigned int offset70(int) {
+            return offset = 70;
+        }
+
+        virtual unsigned int offset71(int) {
+            return offset = 71;
+        }
+
+        virtual unsigned int offset72(int) {
+            return offset = 72;
+        }
+
+        virtual unsigned int offset73(int) {
+            return offset = 73;
+        }
+
+        virtual unsigned int offset74(int) {
+            return offset = 74;
+        }
+
+        virtual unsigned int offset75(int) {
+            return offset = 75;
+        }
+
+        virtual unsigned int offset76(int) {
+            return offset = 76;
+        }
+
+        virtual unsigned int offset77(int) {
+            return offset = 77;
+        }
+
+        virtual unsigned int offset78(int) {
+            return offset = 78;
+        }
+
+        virtual unsigned int offset79(int) {
+            return offset = 79;
+        }
+
+        virtual unsigned int offset80(int) {
+            return offset = 80;
+        }
+
+        virtual unsigned int offset81(int) {
+            return offset = 81;
+        }
+
+        virtual unsigned int offset82(int) {
+            return offset = 82;
+        }
+
+        virtual unsigned int offset83(int) {
+            return offset = 83;
+        }
+
+        virtual unsigned int offset84(int) {
+            return offset = 84;
+        }
+
+        virtual unsigned int offset85(int) {
+            return offset = 85;
+        }
+
+        virtual unsigned int offset86(int) {
+            return offset = 86;
+        }
+
+        virtual unsigned int offset87(int) {
+            return offset = 87;
+        }
+
+        virtual unsigned int offset88(int) {
+            return offset = 88;
+        }
+
+        virtual unsigned int offset89(int) {
+            return offset = 89;
+        }
+
+        virtual unsigned int offset90(int) {
+            return offset = 90;
+        }
+
+        virtual unsigned int offset91(int) {
+            return offset = 91;
+        }
+
+        virtual unsigned int offset92(int) {
+            return offset = 92;
+        }
+
+        virtual unsigned int offset93(int) {
+            return offset = 93;
+        }
+
+        virtual unsigned int offset94(int) {
+            return offset = 94;
+        }
+
+        virtual unsigned int offset95(int) {
+            return offset = 95;
+        }
+
+        virtual unsigned int offset96(int) {
+            return offset = 96;
+        }
+
+        virtual unsigned int offset97(int) {
+            return offset = 97;
+        }
+
+        virtual unsigned int offset98(int) {
+            return offset = 98;
+        }
+
+        virtual unsigned int offset99(int) {
+            return offset = 99;
+        }
+
+        virtual unsigned int offset100(int) {
+            return offset = 100;
+        }
+
+        virtual unsigned int offset101(int) {
+            return offset = 101;
+        }
+
+        virtual unsigned int offset102(int) {
+            return offset = 102;
+        }
+
+        virtual unsigned int offset103(int) {
+            return offset = 103;
+        }
+
+        virtual unsigned int offset104(int) {
+            return offset = 104;
+        }
+
+        virtual unsigned int offset105(int) {
+            return offset = 105;
+        }
+
+        virtual unsigned int offset106(int) {
+            return offset = 106;
+        }
+
+        virtual unsigned int offset107(int) {
+            return offset = 107;
+        }
+
+        virtual unsigned int offset108(int) {
+            return offset = 108;
+        }
+
+        virtual unsigned int offset109(int) {
+            return offset = 109;
+        }
+
+        virtual unsigned int offset110(int) {
+            return offset = 110;
+        }
+
+        virtual unsigned int offset111(int) {
+            return offset = 111;
+        }
+
+        virtual unsigned int offset112(int) {
+            return offset = 112;
+        }
+
+        virtual unsigned int offset113(int) {
+            return offset = 113;
+        }
+
+        virtual unsigned int offset114(int) {
+            return offset = 114;
+        }
+
+        virtual unsigned int offset115(int) {
+            return offset = 115;
+        }
+
+        virtual unsigned int offset116(int) {
+            return offset = 116;
+        }
+
+        virtual unsigned int offset117(int) {
+            return offset = 117;
+        }
+
+        virtual unsigned int offset118(int) {
+            return offset = 118;
+        }
+
+        virtual unsigned int offset119(int) {
+            return offset = 119;
+        }
+
+        virtual unsigned int offset120(int) {
+            return offset = 120;
+        }
+
+        virtual unsigned int offset121(int) {
+            return offset = 121;
+        }
+
+        virtual unsigned int offset122(int) {
+            return offset = 122;
+        }
+
+        virtual unsigned int offset123(int) {
+            return offset = 123;
+        }
+
+        virtual unsigned int offset124(int) {
+            return offset = 124;
+        }
+
+        virtual unsigned int offset125(int) {
+            return offset = 125;
+        }
+
+        virtual unsigned int offset126(int) {
+            return offset = 126;
+        }
+
+        virtual unsigned int offset127(int) {
+            return offset = 127;
+        }
+
+        virtual unsigned int offset128(int) {
+            return offset = 128;
+        }
+
+        virtual unsigned int offset129(int) {
+            return offset = 129;
+        }
+
+        virtual unsigned int offset130(int) {
+            return offset = 130;
+        }
+
+        virtual unsigned int offset131(int) {
+            return offset = 131;
+        }
+
+        virtual unsigned int offset132(int) {
+            return offset = 132;
+        }
+
+        virtual unsigned int offset133(int) {
+            return offset = 133;
+        }
+
+        virtual unsigned int offset134(int) {
+            return offset = 134;
+        }
+
+        virtual unsigned int offset135(int) {
+            return offset = 135;
+        }
+
+        virtual unsigned int offset136(int) {
+            return offset = 136;
+        }
+
+        virtual unsigned int offset137(int) {
+            return offset = 137;
+        }
+
+        virtual unsigned int offset138(int) {
+            return offset = 138;
+        }
+
+        virtual unsigned int offset139(int) {
+            return offset = 139;
+        }
+
+        virtual unsigned int offset140(int) {
+            return offset = 140;
+        }
+
+        virtual unsigned int offset141(int) {
+            return offset = 141;
+        }
+
+        virtual unsigned int offset142(int) {
+            return offset = 142;
+        }
+
+        virtual unsigned int offset143(int) {
+            return offset = 143;
+        }
+
+        virtual unsigned int offset144(int) {
+            return offset = 144;
+        }
+
+        virtual unsigned int offset145(int) {
+            return offset = 145;
+        }
+
+        virtual unsigned int offset146(int) {
+            return offset = 146;
+        }
+
+        virtual unsigned int offset147(int) {
+            return offset = 147;
+        }
+
+        virtual unsigned int offset148(int) {
+            return offset = 148;
+        }
+
+        virtual unsigned int offset149(int) {
+            return offset = 149;
+        }
+
+        virtual unsigned int offset150(int) {
+            return offset = 150;
+        }
+
+        virtual unsigned int offset151(int) {
+            return offset = 151;
+        }
+
+        virtual unsigned int offset152(int) {
+            return offset = 152;
+        }
+
+        virtual unsigned int offset153(int) {
+            return offset = 153;
+        }
+
+        virtual unsigned int offset154(int) {
+            return offset = 154;
+        }
+
+        virtual unsigned int offset155(int) {
+            return offset = 155;
+        }
+
+        virtual unsigned int offset156(int) {
+            return offset = 156;
+        }
+
+        virtual unsigned int offset157(int) {
+            return offset = 157;
+        }
+
+        virtual unsigned int offset158(int) {
+            return offset = 158;
+        }
+
+        virtual unsigned int offset159(int) {
+            return offset = 159;
+        }
+
+        virtual unsigned int offset160(int) {
+            return offset = 160;
+        }
+
+        virtual unsigned int offset161(int) {
+            return offset = 161;
+        }
+
+        virtual unsigned int offset162(int) {
+            return offset = 162;
+        }
+
+        virtual unsigned int offset163(int) {
+            return offset = 163;
+        }
+
+        virtual unsigned int offset164(int) {
+            return offset = 164;
+        }
+
+        virtual unsigned int offset165(int) {
+            return offset = 165;
+        }
+
+        virtual unsigned int offset166(int) {
+            return offset = 166;
+        }
+
+        virtual unsigned int offset167(int) {
+            return offset = 167;
+        }
+
+        virtual unsigned int offset168(int) {
+            return offset = 168;
+        }
+
+        virtual unsigned int offset169(int) {
+            return offset = 169;
+        }
+
+        virtual unsigned int offset170(int) {
+            return offset = 170;
+        }
+
+        virtual unsigned int offset171(int) {
+            return offset = 171;
+        }
+
+        virtual unsigned int offset172(int) {
+            return offset = 172;
+        }
+
+        virtual unsigned int offset173(int) {
+            return offset = 173;
+        }
+
+        virtual unsigned int offset174(int) {
+            return offset = 174;
+        }
+
+        virtual unsigned int offset175(int) {
+            return offset = 175;
+        }
+
+        virtual unsigned int offset176(int) {
+            return offset = 176;
+        }
+
+        virtual unsigned int offset177(int) {
+            return offset = 177;
+        }
+
+        virtual unsigned int offset178(int) {
+            return offset = 178;
+        }
+
+        virtual unsigned int offset179(int) {
+            return offset = 179;
+        }
+
+        virtual unsigned int offset180(int) {
+            return offset = 180;
+        }
+
+        virtual unsigned int offset181(int) {
+            return offset = 181;
+        }
+
+        virtual unsigned int offset182(int) {
+            return offset = 182;
+        }
+
+        virtual unsigned int offset183(int) {
+            return offset = 183;
+        }
+
+        virtual unsigned int offset184(int) {
+            return offset = 184;
+        }
+
+        virtual unsigned int offset185(int) {
+            return offset = 185;
+        }
+
+        virtual unsigned int offset186(int) {
+            return offset = 186;
+        }
+
+        virtual unsigned int offset187(int) {
+            return offset = 187;
+        }
+
+        virtual unsigned int offset188(int) {
+            return offset = 188;
+        }
+
+        virtual unsigned int offset189(int) {
+            return offset = 189;
+        }
+
+        virtual unsigned int offset190(int) {
+            return offset = 190;
+        }
+
+        virtual unsigned int offset191(int) {
+            return offset = 191;
+        }
+
+        virtual unsigned int offset192(int) {
+            return offset = 192;
+        }
+
+        virtual unsigned int offset193(int) {
+            return offset = 193;
+        }
+
+        virtual unsigned int offset194(int) {
+            return offset = 194;
+        }
+
+        virtual unsigned int offset195(int) {
+            return offset = 195;
+        }
+
+        virtual unsigned int offset196(int) {
+            return offset = 196;
+        }
+
+        virtual unsigned int offset197(int) {
+            return offset = 197;
+        }
+
+        virtual unsigned int offset198(int) {
+            return offset = 198;
+        }
+
+        virtual unsigned int offset199(int) {
+            return offset = 199;
+        }
+
+
+        virtual unsigned int offset200(int) {
+            return offset = 200;
+        }
+
+        virtual unsigned int offset201(int) {
+            return offset = 201;
+        }
+
+        virtual unsigned int offset202(int) {
+            return offset = 202;
+        }
+
+        virtual unsigned int offset203(int) {
+            return offset = 203;
+        }
+
+        virtual unsigned int offset204(int) {
+            return offset = 204;
+        }
+
+        virtual unsigned int offset205(int) {
+            return offset = 205;
+        }
+
+        virtual unsigned int offset206(int) {
+            return offset = 206;
+        }
+
+        virtual unsigned int offset207(int) {
+            return offset = 207;
+        }
+
+        virtual unsigned int offset208(int) {
+            return offset = 208;
+        }
+
+        virtual unsigned int offset209(int) {
+            return offset = 209;
+        }
+
+        virtual unsigned int offset210(int) {
+            return offset = 210;
+        }
+
+        virtual unsigned int offset211(int) {
+            return offset = 211;
+        }
+
+        virtual unsigned int offset212(int) {
+            return offset = 212;
+        }
+
+        virtual unsigned int offset213(int) {
+            return offset = 213;
+        }
+
+        virtual unsigned int offset214(int) {
+            return offset = 214;
+        }
+
+        virtual unsigned int offset215(int) {
+            return offset = 215;
+        }
+
+        virtual unsigned int offset216(int) {
+            return offset = 216;
+        }
+
+        virtual unsigned int offset217(int) {
+            return offset = 217;
+        }
+
+        virtual unsigned int offset218(int) {
+            return offset = 218;
+        }
+
+        virtual unsigned int offset219(int) {
+            return offset = 219;
+        }
+
+        virtual unsigned int offset220(int) {
+            return offset = 220;
+        }
+
+        virtual unsigned int offset221(int) {
+            return offset = 221;
+        }
+
+        virtual unsigned int offset222(int) {
+            return offset = 222;
+        }
+
+        virtual unsigned int offset223(int) {
+            return offset = 223;
+        }
+
+        virtual unsigned int offset224(int) {
+            return offset = 224;
+        }
+
+        virtual unsigned int offset225(int) {
+            return offset = 225;
+        }
+
+        virtual unsigned int offset226(int) {
+            return offset = 226;
+        }
+
+        virtual unsigned int offset227(int) {
+            return offset = 227;
+        }
+
+        virtual unsigned int offset228(int) {
+            return offset = 228;
+        }
+
+        virtual unsigned int offset229(int) {
+            return offset = 229;
+        }
+
+        virtual unsigned int offset230(int) {
+            return offset = 230;
+        }
+
+        virtual unsigned int offset231(int) {
+            return offset = 231;
+        }
+
+        virtual unsigned int offset232(int) {
+            return offset = 232;
+        }
+
+        virtual unsigned int offset233(int) {
+            return offset = 233;
+        }
+
+        virtual unsigned int offset234(int) {
+            return offset = 234;
+        }
+
+        virtual unsigned int offset235(int) {
+            return offset = 235;
+        }
+
+        virtual unsigned int offset236(int) {
+            return offset = 236;
+        }
+
+        virtual unsigned int offset237(int) {
+            return offset = 237;
+        }
+
+        virtual unsigned int offset238(int) {
+            return offset = 238;
+        }
+
+        virtual unsigned int offset239(int) {
+            return offset = 239;
+        }
+
+        virtual unsigned int offset240(int) {
+            return offset = 240;
+        }
+
+        virtual unsigned int offset241(int) {
+            return offset = 241;
+        }
+
+        virtual unsigned int offset242(int) {
+            return offset = 242;
+        }
+
+        virtual unsigned int offset243(int) {
+            return offset = 243;
+        }
+
+        virtual unsigned int offset244(int) {
+            return offset = 244;
+        }
+
+        virtual unsigned int offset245(int) {
+            return offset = 245;
+        }
+
+        virtual unsigned int offset246(int) {
+            return offset = 246;
+        }
+
+        virtual unsigned int offset247(int) {
+            return offset = 247;
+        }
+
+        virtual unsigned int offset248(int) {
+            return offset = 248;
+        }
+
+        virtual unsigned int offset249(int) {
+            return offset = 249;
+        }
+
+        virtual unsigned int offset250(int) {
+            return offset = 250;
+        }
+
+        virtual unsigned int offset251(int) {
+            return offset = 251;
+        }
+
+        virtual unsigned int offset252(int) {
+            return offset = 252;
+        }
+
+        virtual unsigned int offset253(int) {
+            return offset = 253;
+        }
+
+        virtual unsigned int offset254(int) {
+            return offset = 254;
+        }
+
+        virtual unsigned int offset255(int) {
+            return offset = 255;
+        }
+
+        virtual unsigned int offset256(int) {
+            return offset = 256;
+        }
+
+        virtual unsigned int offset257(int) {
+            return offset = 257;
+        }
+
+        virtual unsigned int offset258(int) {
+            return offset = 258;
+        }
+
+        virtual unsigned int offset259(int) {
+            return offset = 259;
+        }
+
+        virtual unsigned int offset260(int) {
+            return offset = 260;
+        }
+
+        virtual unsigned int offset261(int) {
+            return offset = 261;
+        }
+
+        virtual unsigned int offset262(int) {
+            return offset = 262;
+        }
+
+        virtual unsigned int offset263(int) {
+            return offset = 263;
+        }
+
+        virtual unsigned int offset264(int) {
+            return offset = 264;
+        }
+
+        virtual unsigned int offset265(int) {
+            return offset = 265;
+        }
+
+        virtual unsigned int offset266(int) {
+            return offset = 266;
+        }
+
+        virtual unsigned int offset267(int) {
+            return offset = 267;
+        }
+
+        virtual unsigned int offset268(int) {
+            return offset = 268;
+        }
+
+        virtual unsigned int offset269(int) {
+            return offset = 269;
+        }
+
+        virtual unsigned int offset270(int) {
+            return offset = 270;
+        }
+
+        virtual unsigned int offset271(int) {
+            return offset = 271;
+        }
+
+        virtual unsigned int offset272(int) {
+            return offset = 272;
+        }
+
+        virtual unsigned int offset273(int) {
+            return offset = 273;
+        }
+
+        virtual unsigned int offset274(int) {
+            return offset = 274;
+        }
+
+        virtual unsigned int offset275(int) {
+            return offset = 275;
+        }
+
+        virtual unsigned int offset276(int) {
+            return offset = 276;
+        }
+
+        virtual unsigned int offset277(int) {
+            return offset = 277;
+        }
+
+        virtual unsigned int offset278(int) {
+            return offset = 278;
+        }
+
+        virtual unsigned int offset279(int) {
+            return offset = 279;
+        }
+
+        virtual unsigned int offset280(int) {
+            return offset = 280;
+        }
+
+        virtual unsigned int offset281(int) {
+            return offset = 281;
+        }
+
+        virtual unsigned int offset282(int) {
+            return offset = 282;
+        }
+
+        virtual unsigned int offset283(int) {
+            return offset = 283;
+        }
+
+        virtual unsigned int offset284(int) {
+            return offset = 284;
+        }
+
+        virtual unsigned int offset285(int) {
+            return offset = 285;
+        }
+
+        virtual unsigned int offset286(int) {
+            return offset = 286;
+        }
+
+        virtual unsigned int offset287(int) {
+            return offset = 287;
+        }
+
+        virtual unsigned int offset288(int) {
+            return offset = 288;
+        }
+
+        virtual unsigned int offset289(int) {
+            return offset = 289;
+        }
+
+        virtual unsigned int offset290(int) {
+            return offset = 290;
+        }
+
+        virtual unsigned int offset291(int) {
+            return offset = 291;
+        }
+
+        virtual unsigned int offset292(int) {
+            return offset = 292;
+        }
+
+        virtual unsigned int offset293(int) {
+            return offset = 293;
+        }
+
+        virtual unsigned int offset294(int) {
+            return offset = 294;
+        }
+
+        virtual unsigned int offset295(int) {
+            return offset = 295;
+        }
+
+        virtual unsigned int offset296(int) {
+            return offset = 296;
+        }
+
+        virtual unsigned int offset297(int) {
+            return offset = 297;
+        }
+
+        virtual unsigned int offset298(int) {
+            return offset = 298;
+        }
+
+        virtual unsigned int offset299(int) {
+            return offset = 299;
+        }
+
+
+        virtual unsigned int offset300(int) {
+            return offset = 300;
+        }
+
+        virtual unsigned int offset301(int) {
+            return offset = 301;
+        }
+
+        virtual unsigned int offset302(int) {
+            return offset = 302;
+        }
+
+        virtual unsigned int offset303(int) {
+            return offset = 303;
+        }
+
+        virtual unsigned int offset304(int) {
+            return offset = 304;
+        }
+
+        virtual unsigned int offset305(int) {
+            return offset = 305;
+        }
+
+        virtual unsigned int offset306(int) {
+            return offset = 306;
+        }
+
+        virtual unsigned int offset307(int) {
+            return offset = 307;
+        }
+
+        virtual unsigned int offset308(int) {
+            return offset = 308;
+        }
+
+        virtual unsigned int offset309(int) {
+            return offset = 309;
+        }
+
+        virtual unsigned int offset310(int) {
+            return offset = 310;
+        }
+
+        virtual unsigned int offset311(int) {
+            return offset = 311;
+        }
+
+        virtual unsigned int offset312(int) {
+            return offset = 312;
+        }
+
+        virtual unsigned int offset313(int) {
+            return offset = 313;
+        }
+
+        virtual unsigned int offset314(int) {
+            return offset = 314;
+        }
+
+        virtual unsigned int offset315(int) {
+            return offset = 315;
+        }
+
+        virtual unsigned int offset316(int) {
+            return offset = 316;
+        }
+
+        virtual unsigned int offset317(int) {
+            return offset = 317;
+        }
+
+        virtual unsigned int offset318(int) {
+            return offset = 318;
+        }
+
+        virtual unsigned int offset319(int) {
+            return offset = 319;
+        }
+
+        virtual unsigned int offset320(int) {
+            return offset = 320;
+        }
+
+        virtual unsigned int offset321(int) {
+            return offset = 321;
+        }
+
+        virtual unsigned int offset322(int) {
+            return offset = 322;
+        }
+
+        virtual unsigned int offset323(int) {
+            return offset = 323;
+        }
+
+        virtual unsigned int offset324(int) {
+            return offset = 324;
+        }
+
+        virtual unsigned int offset325(int) {
+            return offset = 325;
+        }
+
+        virtual unsigned int offset326(int) {
+            return offset = 326;
+        }
+
+        virtual unsigned int offset327(int) {
+            return offset = 327;
+        }
+
+        virtual unsigned int offset328(int) {
+            return offset = 328;
+        }
+
+        virtual unsigned int offset329(int) {
+            return offset = 329;
+        }
+
+        virtual unsigned int offset330(int) {
+            return offset = 330;
+        }
+
+        virtual unsigned int offset331(int) {
+            return offset = 331;
+        }
+
+        virtual unsigned int offset332(int) {
+            return offset = 332;
+        }
+
+        virtual unsigned int offset333(int) {
+            return offset = 333;
+        }
+
+        virtual unsigned int offset334(int) {
+            return offset = 334;
+        }
+
+        virtual unsigned int offset335(int) {
+            return offset = 335;
+        }
+
+        virtual unsigned int offset336(int) {
+            return offset = 336;
+        }
+
+        virtual unsigned int offset337(int) {
+            return offset = 337;
+        }
+
+        virtual unsigned int offset338(int) {
+            return offset = 338;
+        }
+
+        virtual unsigned int offset339(int) {
+            return offset = 339;
+        }
+
+        virtual unsigned int offset340(int) {
+            return offset = 340;
+        }
+
+        virtual unsigned int offset341(int) {
+            return offset = 341;
+        }
+
+        virtual unsigned int offset342(int) {
+            return offset = 342;
+        }
+
+        virtual unsigned int offset343(int) {
+            return offset = 343;
+        }
+
+        virtual unsigned int offset344(int) {
+            return offset = 344;
+        }
+
+        virtual unsigned int offset345(int) {
+            return offset = 345;
+        }
+
+        virtual unsigned int offset346(int) {
+            return offset = 346;
+        }
+
+        virtual unsigned int offset347(int) {
+            return offset = 347;
+        }
+
+        virtual unsigned int offset348(int) {
+            return offset = 348;
+        }
+
+        virtual unsigned int offset349(int) {
+            return offset = 349;
+        }
+
+        virtual unsigned int offset350(int) {
+            return offset = 350;
+        }
+
+        virtual unsigned int offset351(int) {
+            return offset = 351;
+        }
+
+        virtual unsigned int offset352(int) {
+            return offset = 352;
+        }
+
+        virtual unsigned int offset353(int) {
+            return offset = 353;
+        }
+
+        virtual unsigned int offset354(int) {
+            return offset = 354;
+        }
+
+        virtual unsigned int offset355(int) {
+            return offset = 355;
+        }
+
+        virtual unsigned int offset356(int) {
+            return offset = 356;
+        }
+
+        virtual unsigned int offset357(int) {
+            return offset = 357;
+        }
+
+        virtual unsigned int offset358(int) {
+            return offset = 358;
+        }
+
+        virtual unsigned int offset359(int) {
+            return offset = 359;
+        }
+
+        virtual unsigned int offset360(int) {
+            return offset = 360;
+        }
+
+        virtual unsigned int offset361(int) {
+            return offset = 361;
+        }
+
+        virtual unsigned int offset362(int) {
+            return offset = 362;
+        }
+
+        virtual unsigned int offset363(int) {
+            return offset = 363;
+        }
+
+        virtual unsigned int offset364(int) {
+            return offset = 364;
+        }
+
+        virtual unsigned int offset365(int) {
+            return offset = 365;
+        }
+
+        virtual unsigned int offset366(int) {
+            return offset = 366;
+        }
+
+        virtual unsigned int offset367(int) {
+            return offset = 367;
+        }
+
+        virtual unsigned int offset368(int) {
+            return offset = 368;
+        }
+
+        virtual unsigned int offset369(int) {
+            return offset = 369;
+        }
+
+        virtual unsigned int offset370(int) {
+            return offset = 370;
+        }
+
+        virtual unsigned int offset371(int) {
+            return offset = 371;
+        }
+
+        virtual unsigned int offset372(int) {
+            return offset = 372;
+        }
+
+        virtual unsigned int offset373(int) {
+            return offset = 373;
+        }
+
+        virtual unsigned int offset374(int) {
+            return offset = 374;
+        }
+
+        virtual unsigned int offset375(int) {
+            return offset = 375;
+        }
+
+        virtual unsigned int offset376(int) {
+            return offset = 376;
+        }
+
+        virtual unsigned int offset377(int) {
+            return offset = 377;
+        }
+
+        virtual unsigned int offset378(int) {
+            return offset = 378;
+        }
+
+        virtual unsigned int offset379(int) {
+            return offset = 379;
+        }
+
+        virtual unsigned int offset380(int) {
+            return offset = 380;
+        }
+
+        virtual unsigned int offset381(int) {
+            return offset = 381;
+        }
+
+        virtual unsigned int offset382(int) {
+            return offset = 382;
+        }
+
+        virtual unsigned int offset383(int) {
+            return offset = 383;
+        }
+
+        virtual unsigned int offset384(int) {
+            return offset = 384;
+        }
+
+        virtual unsigned int offset385(int) {
+            return offset = 385;
+        }
+
+        virtual unsigned int offset386(int) {
+            return offset = 386;
+        }
+
+        virtual unsigned int offset387(int) {
+            return offset = 387;
+        }
+
+        virtual unsigned int offset388(int) {
+            return offset = 388;
+        }
+
+        virtual unsigned int offset389(int) {
+            return offset = 389;
+        }
+
+        virtual unsigned int offset390(int) {
+            return offset = 390;
+        }
+
+        virtual unsigned int offset391(int) {
+            return offset = 391;
+        }
+
+        virtual unsigned int offset392(int) {
+            return offset = 392;
+        }
+
+        virtual unsigned int offset393(int) {
+            return offset = 393;
+        }
+
+        virtual unsigned int offset394(int) {
+            return offset = 394;
+        }
+
+        virtual unsigned int offset395(int) {
+            return offset = 395;
+        }
+
+        virtual unsigned int offset396(int) {
+            return offset = 396;
+        }
+
+        virtual unsigned int offset397(int) {
+            return offset = 397;
+        }
+
+        virtual unsigned int offset398(int) {
+            return offset = 398;
+        }
+
+        virtual unsigned int offset399(int) {
+            return offset = 399;
+        }
+
+
+        virtual unsigned int offset400(int) {
+            return offset = 400;
+        }
+
+        virtual unsigned int offset401(int) {
+            return offset = 401;
+        }
+
+        virtual unsigned int offset402(int) {
+            return offset = 402;
+        }
+
+        virtual unsigned int offset403(int) {
+            return offset = 403;
+        }
+
+        virtual unsigned int offset404(int) {
+            return offset = 404;
+        }
+
+        virtual unsigned int offset405(int) {
+            return offset = 405;
+        }
+
+        virtual unsigned int offset406(int) {
+            return offset = 406;
+        }
+
+        virtual unsigned int offset407(int) {
+            return offset = 407;
+        }
+
+        virtual unsigned int offset408(int) {
+            return offset = 408;
+        }
+
+        virtual unsigned int offset409(int) {
+            return offset = 409;
+        }
+
+        virtual unsigned int offset410(int) {
+            return offset = 410;
+        }
+
+        virtual unsigned int offset411(int) {
+            return offset = 411;
+        }
+
+        virtual unsigned int offset412(int) {
+            return offset = 412;
+        }
+
+        virtual unsigned int offset413(int) {
+            return offset = 413;
+        }
+
+        virtual unsigned int offset414(int) {
+            return offset = 414;
+        }
+
+        virtual unsigned int offset415(int) {
+            return offset = 415;
+        }
+
+        virtual unsigned int offset416(int) {
+            return offset = 416;
+        }
+
+        virtual unsigned int offset417(int) {
+            return offset = 417;
+        }
+
+        virtual unsigned int offset418(int) {
+            return offset = 418;
+        }
+
+        virtual unsigned int offset419(int) {
+            return offset = 419;
+        }
+
+        virtual unsigned int offset420(int) {
+            return offset = 420;
+        }
+
+        virtual unsigned int offset421(int) {
+            return offset = 421;
+        }
+
+        virtual unsigned int offset422(int) {
+            return offset = 422;
+        }
+
+        virtual unsigned int offset423(int) {
+            return offset = 423;
+        }
+
+        virtual unsigned int offset424(int) {
+            return offset = 424;
+        }
+
+        virtual unsigned int offset425(int) {
+            return offset = 425;
+        }
+
+        virtual unsigned int offset426(int) {
+            return offset = 426;
+        }
+
+        virtual unsigned int offset427(int) {
+            return offset = 427;
+        }
+
+        virtual unsigned int offset428(int) {
+            return offset = 428;
+        }
+
+        virtual unsigned int offset429(int) {
+            return offset = 429;
+        }
+
+        virtual unsigned int offset430(int) {
+            return offset = 430;
+        }
+
+        virtual unsigned int offset431(int) {
+            return offset = 431;
+        }
+
+        virtual unsigned int offset432(int) {
+            return offset = 432;
+        }
+
+        virtual unsigned int offset433(int) {
+            return offset = 433;
+        }
+
+        virtual unsigned int offset434(int) {
+            return offset = 434;
+        }
+
+        virtual unsigned int offset435(int) {
+            return offset = 435;
+        }
+
+        virtual unsigned int offset436(int) {
+            return offset = 436;
+        }
+
+        virtual unsigned int offset437(int) {
+            return offset = 437;
+        }
+
+        virtual unsigned int offset438(int) {
+            return offset = 438;
+        }
+
+        virtual unsigned int offset439(int) {
+            return offset = 439;
+        }
+
+        virtual unsigned int offset440(int) {
+            return offset = 440;
+        }
+
+        virtual unsigned int offset441(int) {
+            return offset = 441;
+        }
+
+        virtual unsigned int offset442(int) {
+            return offset = 442;
+        }
+
+        virtual unsigned int offset443(int) {
+            return offset = 443;
+        }
+
+        virtual unsigned int offset444(int) {
+            return offset = 444;
+        }
+
+        virtual unsigned int offset445(int) {
+            return offset = 445;
+        }
+
+        virtual unsigned int offset446(int) {
+            return offset = 446;
+        }
+
+        virtual unsigned int offset447(int) {
+            return offset = 447;
+        }
+
+        virtual unsigned int offset448(int) {
+            return offset = 448;
+        }
+
+        virtual unsigned int offset449(int) {
+            return offset = 449;
+        }
+
+        virtual unsigned int offset450(int) {
+            return offset = 450;
+        }
+
+        virtual unsigned int offset451(int) {
+            return offset = 451;
+        }
+
+        virtual unsigned int offset452(int) {
+            return offset = 452;
+        }
+
+        virtual unsigned int offset453(int) {
+            return offset = 453;
+        }
+
+        virtual unsigned int offset454(int) {
+            return offset = 454;
+        }
+
+        virtual unsigned int offset455(int) {
+            return offset = 455;
+        }
+
+        virtual unsigned int offset456(int) {
+            return offset = 456;
+        }
+
+        virtual unsigned int offset457(int) {
+            return offset = 457;
+        }
+
+        virtual unsigned int offset458(int) {
+            return offset = 458;
+        }
+
+        virtual unsigned int offset459(int) {
+            return offset = 459;
+        }
+
+        virtual unsigned int offset460(int) {
+            return offset = 460;
+        }
+
+        virtual unsigned int offset461(int) {
+            return offset = 461;
+        }
+
+        virtual unsigned int offset462(int) {
+            return offset = 462;
+        }
+
+        virtual unsigned int offset463(int) {
+            return offset = 463;
+        }
+
+        virtual unsigned int offset464(int) {
+            return offset = 464;
+        }
+
+        virtual unsigned int offset465(int) {
+            return offset = 465;
+        }
+
+        virtual unsigned int offset466(int) {
+            return offset = 466;
+        }
+
+        virtual unsigned int offset467(int) {
+            return offset = 467;
+        }
+
+        virtual unsigned int offset468(int) {
+            return offset = 468;
+        }
+
+        virtual unsigned int offset469(int) {
+            return offset = 469;
+        }
+
+        virtual unsigned int offset470(int) {
+            return offset = 470;
+        }
+
+        virtual unsigned int offset471(int) {
+            return offset = 471;
+        }
+
+        virtual unsigned int offset472(int) {
+            return offset = 472;
+        }
+
+        virtual unsigned int offset473(int) {
+            return offset = 473;
+        }
+
+        virtual unsigned int offset474(int) {
+            return offset = 474;
+        }
+
+        virtual unsigned int offset475(int) {
+            return offset = 475;
+        }
+
+        virtual unsigned int offset476(int) {
+            return offset = 476;
+        }
+
+        virtual unsigned int offset477(int) {
+            return offset = 477;
+        }
+
+        virtual unsigned int offset478(int) {
+            return offset = 478;
+        }
+
+        virtual unsigned int offset479(int) {
+            return offset = 479;
+        }
+
+        virtual unsigned int offset480(int) {
+            return offset = 480;
+        }
+
+        virtual unsigned int offset481(int) {
+            return offset = 481;
+        }
+
+        virtual unsigned int offset482(int) {
+            return offset = 482;
+        }
+
+        virtual unsigned int offset483(int) {
+            return offset = 483;
+        }
+
+        virtual unsigned int offset484(int) {
+            return offset = 484;
+        }
+
+        virtual unsigned int offset485(int) {
+            return offset = 485;
+        }
+
+        virtual unsigned int offset486(int) {
+            return offset = 486;
+        }
+
+        virtual unsigned int offset487(int) {
+            return offset = 487;
+        }
+
+        virtual unsigned int offset488(int) {
+            return offset = 488;
+        }
+
+        virtual unsigned int offset489(int) {
+            return offset = 489;
+        }
+
+        virtual unsigned int offset490(int) {
+            return offset = 490;
+        }
+
+        virtual unsigned int offset491(int) {
+            return offset = 491;
+        }
+
+        virtual unsigned int offset492(int) {
+            return offset = 492;
+        }
+
+        virtual unsigned int offset493(int) {
+            return offset = 493;
+        }
+
+        virtual unsigned int offset494(int) {
+            return offset = 494;
+        }
+
+        virtual unsigned int offset495(int) {
+            return offset = 495;
+        }
+
+        virtual unsigned int offset496(int) {
+            return offset = 496;
+        }
+
+        virtual unsigned int offset497(int) {
+            return offset = 497;
+        }
+
+        virtual unsigned int offset498(int) {
+            return offset = 498;
+        }
+
+        virtual unsigned int offset499(int) {
+            return offset = 499;
+        }
+
+
+        virtual unsigned int offset500(int) {
+            return offset = 500;
+        }
+
+        virtual unsigned int offset501(int) {
+            return offset = 501;
+        }
+
+        virtual unsigned int offset502(int) {
+            return offset = 502;
+        }
+
+        virtual unsigned int offset503(int) {
+            return offset = 503;
+        }
+
+        virtual unsigned int offset504(int) {
+            return offset = 504;
+        }
+
+        virtual unsigned int offset505(int) {
+            return offset = 505;
+        }
+
+        virtual unsigned int offset506(int) {
+            return offset = 506;
+        }
+
+        virtual unsigned int offset507(int) {
+            return offset = 507;
+        }
+
+        virtual unsigned int offset508(int) {
+            return offset = 508;
+        }
+
+        virtual unsigned int offset509(int) {
+            return offset = 509;
+        }
+
+        virtual unsigned int offset510(int) {
+            return offset = 510;
+        }
+
+        virtual unsigned int offset511(int) {
+            return offset = 511;
+        }
+
+        virtual unsigned int offset512(int) {
+            return offset = 512;
+        }
+
+        virtual unsigned int offset513(int) {
+            return offset = 513;
+        }
+
+        virtual unsigned int offset514(int) {
+            return offset = 514;
+        }
+
+        virtual unsigned int offset515(int) {
+            return offset = 515;
+        }
+
+        virtual unsigned int offset516(int) {
+            return offset = 516;
+        }
+
+        virtual unsigned int offset517(int) {
+            return offset = 517;
+        }
+
+        virtual unsigned int offset518(int) {
+            return offset = 518;
+        }
+
+        virtual unsigned int offset519(int) {
+            return offset = 519;
+        }
+
+        virtual unsigned int offset520(int) {
+            return offset = 520;
+        }
+
+        virtual unsigned int offset521(int) {
+            return offset = 521;
+        }
+
+        virtual unsigned int offset522(int) {
+            return offset = 522;
+        }
+
+        virtual unsigned int offset523(int) {
+            return offset = 523;
+        }
+
+        virtual unsigned int offset524(int) {
+            return offset = 524;
+        }
+
+        virtual unsigned int offset525(int) {
+            return offset = 525;
+        }
+
+        virtual unsigned int offset526(int) {
+            return offset = 526;
+        }
+
+        virtual unsigned int offset527(int) {
+            return offset = 527;
+        }
+
+        virtual unsigned int offset528(int) {
+            return offset = 528;
+        }
+
+        virtual unsigned int offset529(int) {
+            return offset = 529;
+        }
+
+        virtual unsigned int offset530(int) {
+            return offset = 530;
+        }
+
+        virtual unsigned int offset531(int) {
+            return offset = 531;
+        }
+
+        virtual unsigned int offset532(int) {
+            return offset = 532;
+        }
+
+        virtual unsigned int offset533(int) {
+            return offset = 533;
+        }
+
+        virtual unsigned int offset534(int) {
+            return offset = 534;
+        }
+
+        virtual unsigned int offset535(int) {
+            return offset = 535;
+        }
+
+        virtual unsigned int offset536(int) {
+            return offset = 536;
+        }
+
+        virtual unsigned int offset537(int) {
+            return offset = 537;
+        }
+
+        virtual unsigned int offset538(int) {
+            return offset = 538;
+        }
+
+        virtual unsigned int offset539(int) {
+            return offset = 539;
+        }
+
+        virtual unsigned int offset540(int) {
+            return offset = 540;
+        }
+
+        virtual unsigned int offset541(int) {
+            return offset = 541;
+        }
+
+        virtual unsigned int offset542(int) {
+            return offset = 542;
+        }
+
+        virtual unsigned int offset543(int) {
+            return offset = 543;
+        }
+
+        virtual unsigned int offset544(int) {
+            return offset = 544;
+        }
+
+        virtual unsigned int offset545(int) {
+            return offset = 545;
+        }
+
+        virtual unsigned int offset546(int) {
+            return offset = 546;
+        }
+
+        virtual unsigned int offset547(int) {
+            return offset = 547;
+        }
+
+        virtual unsigned int offset548(int) {
+            return offset = 548;
+        }
+
+        virtual unsigned int offset549(int) {
+            return offset = 549;
+        }
+
+        virtual unsigned int offset550(int) {
+            return offset = 550;
+        }
+
+        virtual unsigned int offset551(int) {
+            return offset = 551;
+        }
+
+        virtual unsigned int offset552(int) {
+            return offset = 552;
+        }
+
+        virtual unsigned int offset553(int) {
+            return offset = 553;
+        }
+
+        virtual unsigned int offset554(int) {
+            return offset = 554;
+        }
+
+        virtual unsigned int offset555(int) {
+            return offset = 555;
+        }
+
+        virtual unsigned int offset556(int) {
+            return offset = 556;
+        }
+
+        virtual unsigned int offset557(int) {
+            return offset = 557;
+        }
+
+        virtual unsigned int offset558(int) {
+            return offset = 558;
+        }
+
+        virtual unsigned int offset559(int) {
+            return offset = 559;
+        }
+
+        virtual unsigned int offset560(int) {
+            return offset = 560;
+        }
+
+        virtual unsigned int offset561(int) {
+            return offset = 561;
+        }
+
+        virtual unsigned int offset562(int) {
+            return offset = 562;
+        }
+
+        virtual unsigned int offset563(int) {
+            return offset = 563;
+        }
+
+        virtual unsigned int offset564(int) {
+            return offset = 564;
+        }
+
+        virtual unsigned int offset565(int) {
+            return offset = 565;
+        }
+
+        virtual unsigned int offset566(int) {
+            return offset = 566;
+        }
+
+        virtual unsigned int offset567(int) {
+            return offset = 567;
+        }
+
+        virtual unsigned int offset568(int) {
+            return offset = 568;
+        }
+
+        virtual unsigned int offset569(int) {
+            return offset = 569;
+        }
+
+        virtual unsigned int offset570(int) {
+            return offset = 570;
+        }
+
+        virtual unsigned int offset571(int) {
+            return offset = 571;
+        }
+
+        virtual unsigned int offset572(int) {
+            return offset = 572;
+        }
+
+        virtual unsigned int offset573(int) {
+            return offset = 573;
+        }
+
+        virtual unsigned int offset574(int) {
+            return offset = 574;
+        }
+
+        virtual unsigned int offset575(int) {
+            return offset = 575;
+        }
+
+        virtual unsigned int offset576(int) {
+            return offset = 576;
+        }
+
+        virtual unsigned int offset577(int) {
+            return offset = 577;
+        }
+
+        virtual unsigned int offset578(int) {
+            return offset = 578;
+        }
+
+        virtual unsigned int offset579(int) {
+            return offset = 579;
+        }
+
+        virtual unsigned int offset580(int) {
+            return offset = 580;
+        }
+
+        virtual unsigned int offset581(int) {
+            return offset = 581;
+        }
+
+        virtual unsigned int offset582(int) {
+            return offset = 582;
+        }
+
+        virtual unsigned int offset583(int) {
+            return offset = 583;
+        }
+
+        virtual unsigned int offset584(int) {
+            return offset = 584;
+        }
+
+        virtual unsigned int offset585(int) {
+            return offset = 585;
+        }
+
+        virtual unsigned int offset586(int) {
+            return offset = 586;
+        }
+
+        virtual unsigned int offset587(int) {
+            return offset = 587;
+        }
+
+        virtual unsigned int offset588(int) {
+            return offset = 588;
+        }
+
+        virtual unsigned int offset589(int) {
+            return offset = 589;
+        }
+
+        virtual unsigned int offset590(int) {
+            return offset = 590;
+        }
+
+        virtual unsigned int offset591(int) {
+            return offset = 591;
+        }
+
+        virtual unsigned int offset592(int) {
+            return offset = 592;
+        }
+
+        virtual unsigned int offset593(int) {
+            return offset = 593;
+        }
+
+        virtual unsigned int offset594(int) {
+            return offset = 594;
+        }
+
+        virtual unsigned int offset595(int) {
+            return offset = 595;
+        }
+
+        virtual unsigned int offset596(int) {
+            return offset = 596;
+        }
+
+        virtual unsigned int offset597(int) {
+            return offset = 597;
+        }
+
+        virtual unsigned int offset598(int) {
+            return offset = 598;
+        }
+
+        virtual unsigned int offset599(int) {
+            return offset = 599;
+        }
+
+
+        virtual unsigned int offset600(int) {
+            return offset = 600;
+        }
+
+        virtual unsigned int offset601(int) {
+            return offset = 601;
+        }
+
+        virtual unsigned int offset602(int) {
+            return offset = 602;
+        }
+
+        virtual unsigned int offset603(int) {
+            return offset = 603;
+        }
+
+        virtual unsigned int offset604(int) {
+            return offset = 604;
+        }
+
+        virtual unsigned int offset605(int) {
+            return offset = 605;
+        }
+
+        virtual unsigned int offset606(int) {
+            return offset = 606;
+        }
+
+        virtual unsigned int offset607(int) {
+            return offset = 607;
+        }
+
+        virtual unsigned int offset608(int) {
+            return offset = 608;
+        }
+
+        virtual unsigned int offset609(int) {
+            return offset = 609;
+        }
+
+        virtual unsigned int offset610(int) {
+            return offset = 610;
+        }
+
+        virtual unsigned int offset611(int) {
+            return offset = 611;
+        }
+
+        virtual unsigned int offset612(int) {
+            return offset = 612;
+        }
+
+        virtual unsigned int offset613(int) {
+            return offset = 613;
+        }
+
+        virtual unsigned int offset614(int) {
+            return offset = 614;
+        }
+
+        virtual unsigned int offset615(int) {
+            return offset = 615;
+        }
+
+        virtual unsigned int offset616(int) {
+            return offset = 616;
+        }
+
+        virtual unsigned int offset617(int) {
+            return offset = 617;
+        }
+
+        virtual unsigned int offset618(int) {
+            return offset = 618;
+        }
+
+        virtual unsigned int offset619(int) {
+            return offset = 619;
+        }
+
+        virtual unsigned int offset620(int) {
+            return offset = 620;
+        }
+
+        virtual unsigned int offset621(int) {
+            return offset = 621;
+        }
+
+        virtual unsigned int offset622(int) {
+            return offset = 622;
+        }
+
+        virtual unsigned int offset623(int) {
+            return offset = 623;
+        }
+
+        virtual unsigned int offset624(int) {
+            return offset = 624;
+        }
+
+        virtual unsigned int offset625(int) {
+            return offset = 625;
+        }
+
+        virtual unsigned int offset626(int) {
+            return offset = 626;
+        }
+
+        virtual unsigned int offset627(int) {
+            return offset = 627;
+        }
+
+        virtual unsigned int offset628(int) {
+            return offset = 628;
+        }
+
+        virtual unsigned int offset629(int) {
+            return offset = 629;
+        }
+
+        virtual unsigned int offset630(int) {
+            return offset = 630;
+        }
+
+        virtual unsigned int offset631(int) {
+            return offset = 631;
+        }
+
+        virtual unsigned int offset632(int) {
+            return offset = 632;
+        }
+
+        virtual unsigned int offset633(int) {
+            return offset = 633;
+        }
+
+        virtual unsigned int offset634(int) {
+            return offset = 634;
+        }
+
+        virtual unsigned int offset635(int) {
+            return offset = 635;
+        }
+
+        virtual unsigned int offset636(int) {
+            return offset = 636;
+        }
+
+        virtual unsigned int offset637(int) {
+            return offset = 637;
+        }
+
+        virtual unsigned int offset638(int) {
+            return offset = 638;
+        }
+
+        virtual unsigned int offset639(int) {
+            return offset = 639;
+        }
+
+        virtual unsigned int offset640(int) {
+            return offset = 640;
+        }
+
+        virtual unsigned int offset641(int) {
+            return offset = 641;
+        }
+
+        virtual unsigned int offset642(int) {
+            return offset = 642;
+        }
+
+        virtual unsigned int offset643(int) {
+            return offset = 643;
+        }
+
+        virtual unsigned int offset644(int) {
+            return offset = 644;
+        }
+
+        virtual unsigned int offset645(int) {
+            return offset = 645;
+        }
+
+        virtual unsigned int offset646(int) {
+            return offset = 646;
+        }
+
+        virtual unsigned int offset647(int) {
+            return offset = 647;
+        }
+
+        virtual unsigned int offset648(int) {
+            return offset = 648;
+        }
+
+        virtual unsigned int offset649(int) {
+            return offset = 649;
+        }
+
+        virtual unsigned int offset650(int) {
+            return offset = 650;
+        }
+
+        virtual unsigned int offset651(int) {
+            return offset = 651;
+        }
+
+        virtual unsigned int offset652(int) {
+            return offset = 652;
+        }
+
+        virtual unsigned int offset653(int) {
+            return offset = 653;
+        }
+
+        virtual unsigned int offset654(int) {
+            return offset = 654;
+        }
+
+        virtual unsigned int offset655(int) {
+            return offset = 655;
+        }
+
+        virtual unsigned int offset656(int) {
+            return offset = 656;
+        }
+
+        virtual unsigned int offset657(int) {
+            return offset = 657;
+        }
+
+        virtual unsigned int offset658(int) {
+            return offset = 658;
+        }
+
+        virtual unsigned int offset659(int) {
+            return offset = 659;
+        }
+
+        virtual unsigned int offset660(int) {
+            return offset = 660;
+        }
+
+        virtual unsigned int offset661(int) {
+            return offset = 661;
+        }
+
+        virtual unsigned int offset662(int) {
+            return offset = 662;
+        }
+
+        virtual unsigned int offset663(int) {
+            return offset = 663;
+        }
+
+        virtual unsigned int offset664(int) {
+            return offset = 664;
+        }
+
+        virtual unsigned int offset665(int) {
+            return offset = 665;
+        }
+
+        virtual unsigned int offset666(int) {
+            return offset = 666;
+        }
+
+        virtual unsigned int offset667(int) {
+            return offset = 667;
+        }
+
+        virtual unsigned int offset668(int) {
+            return offset = 668;
+        }
+
+        virtual unsigned int offset669(int) {
+            return offset = 669;
+        }
+
+        virtual unsigned int offset670(int) {
+            return offset = 670;
+        }
+
+        virtual unsigned int offset671(int) {
+            return offset = 671;
+        }
+
+        virtual unsigned int offset672(int) {
+            return offset = 672;
+        }
+
+        virtual unsigned int offset673(int) {
+            return offset = 673;
+        }
+
+        virtual unsigned int offset674(int) {
+            return offset = 674;
+        }
+
+        virtual unsigned int offset675(int) {
+            return offset = 675;
+        }
+
+        virtual unsigned int offset676(int) {
+            return offset = 676;
+        }
+
+        virtual unsigned int offset677(int) {
+            return offset = 677;
+        }
+
+        virtual unsigned int offset678(int) {
+            return offset = 678;
+        }
+
+        virtual unsigned int offset679(int) {
+            return offset = 679;
+        }
+
+        virtual unsigned int offset680(int) {
+            return offset = 680;
+        }
+
+        virtual unsigned int offset681(int) {
+            return offset = 681;
+        }
+
+        virtual unsigned int offset682(int) {
+            return offset = 682;
+        }
+
+        virtual unsigned int offset683(int) {
+            return offset = 683;
+        }
+
+        virtual unsigned int offset684(int) {
+            return offset = 684;
+        }
+
+        virtual unsigned int offset685(int) {
+            return offset = 685;
+        }
+
+        virtual unsigned int offset686(int) {
+            return offset = 686;
+        }
+
+        virtual unsigned int offset687(int) {
+            return offset = 687;
+        }
+
+        virtual unsigned int offset688(int) {
+            return offset = 688;
+        }
+
+        virtual unsigned int offset689(int) {
+            return offset = 689;
+        }
+
+        virtual unsigned int offset690(int) {
+            return offset = 690;
+        }
+
+        virtual unsigned int offset691(int) {
+            return offset = 691;
+        }
+
+        virtual unsigned int offset692(int) {
+            return offset = 692;
+        }
+
+        virtual unsigned int offset693(int) {
+            return offset = 693;
+        }
+
+        virtual unsigned int offset694(int) {
+            return offset = 694;
+        }
+
+        virtual unsigned int offset695(int) {
+            return offset = 695;
+        }
+
+        virtual unsigned int offset696(int) {
+            return offset = 696;
+        }
+
+        virtual unsigned int offset697(int) {
+            return offset = 697;
+        }
+
+        virtual unsigned int offset698(int) {
+            return offset = 698;
+        }
+
+        virtual unsigned int offset699(int) {
+            return offset = 699;
+        }
+
+
+        virtual unsigned int offset700(int) {
+            return offset = 700;
+        }
+
+        virtual unsigned int offset701(int) {
+            return offset = 701;
+        }
+
+        virtual unsigned int offset702(int) {
+            return offset = 702;
+        }
+
+        virtual unsigned int offset703(int) {
+            return offset = 703;
+        }
+
+        virtual unsigned int offset704(int) {
+            return offset = 704;
+        }
+
+        virtual unsigned int offset705(int) {
+            return offset = 705;
+        }
+
+        virtual unsigned int offset706(int) {
+            return offset = 706;
+        }
+
+        virtual unsigned int offset707(int) {
+            return offset = 707;
+        }
+
+        virtual unsigned int offset708(int) {
+            return offset = 708;
+        }
+
+        virtual unsigned int offset709(int) {
+            return offset = 709;
+        }
+
+        virtual unsigned int offset710(int) {
+            return offset = 710;
+        }
+
+        virtual unsigned int offset711(int) {
+            return offset = 711;
+        }
+
+        virtual unsigned int offset712(int) {
+            return offset = 712;
+        }
+
+        virtual unsigned int offset713(int) {
+            return offset = 713;
+        }
+
+        virtual unsigned int offset714(int) {
+            return offset = 714;
+        }
+
+        virtual unsigned int offset715(int) {
+            return offset = 715;
+        }
+
+        virtual unsigned int offset716(int) {
+            return offset = 716;
+        }
+
+        virtual unsigned int offset717(int) {
+            return offset = 717;
+        }
+
+        virtual unsigned int offset718(int) {
+            return offset = 718;
+        }
+
+        virtual unsigned int offset719(int) {
+            return offset = 719;
+        }
+
+        virtual unsigned int offset720(int) {
+            return offset = 720;
+        }
+
+        virtual unsigned int offset721(int) {
+            return offset = 721;
+        }
+
+        virtual unsigned int offset722(int) {
+            return offset = 722;
+        }
+
+        virtual unsigned int offset723(int) {
+            return offset = 723;
+        }
+
+        virtual unsigned int offset724(int) {
+            return offset = 724;
+        }
+
+        virtual unsigned int offset725(int) {
+            return offset = 725;
+        }
+
+        virtual unsigned int offset726(int) {
+            return offset = 726;
+        }
+
+        virtual unsigned int offset727(int) {
+            return offset = 727;
+        }
+
+        virtual unsigned int offset728(int) {
+            return offset = 728;
+        }
+
+        virtual unsigned int offset729(int) {
+            return offset = 729;
+        }
+
+        virtual unsigned int offset730(int) {
+            return offset = 730;
+        }
+
+        virtual unsigned int offset731(int) {
+            return offset = 731;
+        }
+
+        virtual unsigned int offset732(int) {
+            return offset = 732;
+        }
+
+        virtual unsigned int offset733(int) {
+            return offset = 733;
+        }
+
+        virtual unsigned int offset734(int) {
+            return offset = 734;
+        }
+
+        virtual unsigned int offset735(int) {
+            return offset = 735;
+        }
+
+        virtual unsigned int offset736(int) {
+            return offset = 736;
+        }
+
+        virtual unsigned int offset737(int) {
+            return offset = 737;
+        }
+
+        virtual unsigned int offset738(int) {
+            return offset = 738;
+        }
+
+        virtual unsigned int offset739(int) {
+            return offset = 739;
+        }
+
+        virtual unsigned int offset740(int) {
+            return offset = 740;
+        }
+
+        virtual unsigned int offset741(int) {
+            return offset = 741;
+        }
+
+        virtual unsigned int offset742(int) {
+            return offset = 742;
+        }
+
+        virtual unsigned int offset743(int) {
+            return offset = 743;
+        }
+
+        virtual unsigned int offset744(int) {
+            return offset = 744;
+        }
+
+        virtual unsigned int offset745(int) {
+            return offset = 745;
+        }
+
+        virtual unsigned int offset746(int) {
+            return offset = 746;
+        }
+
+        virtual unsigned int offset747(int) {
+            return offset = 747;
+        }
+
+        virtual unsigned int offset748(int) {
+            return offset = 748;
+        }
+
+        virtual unsigned int offset749(int) {
+            return offset = 749;
+        }
+
+        virtual unsigned int offset750(int) {
+            return offset = 750;
+        }
+
+        virtual unsigned int offset751(int) {
+            return offset = 751;
+        }
+
+        virtual unsigned int offset752(int) {
+            return offset = 752;
+        }
+
+        virtual unsigned int offset753(int) {
+            return offset = 753;
+        }
+
+        virtual unsigned int offset754(int) {
+            return offset = 754;
+        }
+
+        virtual unsigned int offset755(int) {
+            return offset = 755;
+        }
+
+        virtual unsigned int offset756(int) {
+            return offset = 756;
+        }
+
+        virtual unsigned int offset757(int) {
+            return offset = 757;
+        }
+
+        virtual unsigned int offset758(int) {
+            return offset = 758;
+        }
+
+        virtual unsigned int offset759(int) {
+            return offset = 759;
+        }
+
+        virtual unsigned int offset760(int) {
+            return offset = 760;
+        }
+
+        virtual unsigned int offset761(int) {
+            return offset = 761;
+        }
+
+        virtual unsigned int offset762(int) {
+            return offset = 762;
+        }
+
+        virtual unsigned int offset763(int) {
+            return offset = 763;
+        }
+
+        virtual unsigned int offset764(int) {
+            return offset = 764;
+        }
+
+        virtual unsigned int offset765(int) {
+            return offset = 765;
+        }
+
+        virtual unsigned int offset766(int) {
+            return offset = 766;
+        }
+
+        virtual unsigned int offset767(int) {
+            return offset = 767;
+        }
+
+        virtual unsigned int offset768(int) {
+            return offset = 768;
+        }
+
+        virtual unsigned int offset769(int) {
+            return offset = 769;
+        }
+
+        virtual unsigned int offset770(int) {
+            return offset = 770;
+        }
+
+        virtual unsigned int offset771(int) {
+            return offset = 771;
+        }
+
+        virtual unsigned int offset772(int) {
+            return offset = 772;
+        }
+
+        virtual unsigned int offset773(int) {
+            return offset = 773;
+        }
+
+        virtual unsigned int offset774(int) {
+            return offset = 774;
+        }
+
+        virtual unsigned int offset775(int) {
+            return offset = 775;
+        }
+
+        virtual unsigned int offset776(int) {
+            return offset = 776;
+        }
+
+        virtual unsigned int offset777(int) {
+            return offset = 777;
+        }
+
+        virtual unsigned int offset778(int) {
+            return offset = 778;
+        }
+
+        virtual unsigned int offset779(int) {
+            return offset = 779;
+        }
+
+        virtual unsigned int offset780(int) {
+            return offset = 780;
+        }
+
+        virtual unsigned int offset781(int) {
+            return offset = 781;
+        }
+
+        virtual unsigned int offset782(int) {
+            return offset = 782;
+        }
+
+        virtual unsigned int offset783(int) {
+            return offset = 783;
+        }
+
+        virtual unsigned int offset784(int) {
+            return offset = 784;
+        }
+
+        virtual unsigned int offset785(int) {
+            return offset = 785;
+        }
+
+        virtual unsigned int offset786(int) {
+            return offset = 786;
+        }
+
+        virtual unsigned int offset787(int) {
+            return offset = 787;
+        }
+
+        virtual unsigned int offset788(int) {
+            return offset = 788;
+        }
+
+        virtual unsigned int offset789(int) {
+            return offset = 789;
+        }
+
+        virtual unsigned int offset790(int) {
+            return offset = 790;
+        }
+
+        virtual unsigned int offset791(int) {
+            return offset = 791;
+        }
+
+        virtual unsigned int offset792(int) {
+            return offset = 792;
+        }
+
+        virtual unsigned int offset793(int) {
+            return offset = 793;
+        }
+
+        virtual unsigned int offset794(int) {
+            return offset = 794;
+        }
+
+        virtual unsigned int offset795(int) {
+            return offset = 795;
+        }
+
+        virtual unsigned int offset796(int) {
+            return offset = 796;
+        }
+
+        virtual unsigned int offset797(int) {
+            return offset = 797;
+        }
+
+        virtual unsigned int offset798(int) {
+            return offset = 798;
+        }
+
+        virtual unsigned int offset799(int) {
+            return offset = 799;
+        }
+
+
+        virtual unsigned int offset800(int) {
+            return offset = 800;
+        }
+
+        virtual unsigned int offset801(int) {
+            return offset = 801;
+        }
+
+        virtual unsigned int offset802(int) {
+            return offset = 802;
+        }
+
+        virtual unsigned int offset803(int) {
+            return offset = 803;
+        }
+
+        virtual unsigned int offset804(int) {
+            return offset = 804;
+        }
+
+        virtual unsigned int offset805(int) {
+            return offset = 805;
+        }
+
+        virtual unsigned int offset806(int) {
+            return offset = 806;
+        }
+
+        virtual unsigned int offset807(int) {
+            return offset = 807;
+        }
+
+        virtual unsigned int offset808(int) {
+            return offset = 808;
+        }
+
+        virtual unsigned int offset809(int) {
+            return offset = 809;
+        }
+
+        virtual unsigned int offset810(int) {
+            return offset = 810;
+        }
+
+        virtual unsigned int offset811(int) {
+            return offset = 811;
+        }
+
+        virtual unsigned int offset812(int) {
+            return offset = 812;
+        }
+
+        virtual unsigned int offset813(int) {
+            return offset = 813;
+        }
+
+        virtual unsigned int offset814(int) {
+            return offset = 814;
+        }
+
+        virtual unsigned int offset815(int) {
+            return offset = 815;
+        }
+
+        virtual unsigned int offset816(int) {
+            return offset = 816;
+        }
+
+        virtual unsigned int offset817(int) {
+            return offset = 817;
+        }
+
+        virtual unsigned int offset818(int) {
+            return offset = 818;
+        }
+
+        virtual unsigned int offset819(int) {
+            return offset = 819;
+        }
+
+        virtual unsigned int offset820(int) {
+            return offset = 820;
+        }
+
+        virtual unsigned int offset821(int) {
+            return offset = 821;
+        }
+
+        virtual unsigned int offset822(int) {
+            return offset = 822;
+        }
+
+        virtual unsigned int offset823(int) {
+            return offset = 823;
+        }
+
+        virtual unsigned int offset824(int) {
+            return offset = 824;
+        }
+
+        virtual unsigned int offset825(int) {
+            return offset = 825;
+        }
+
+        virtual unsigned int offset826(int) {
+            return offset = 826;
+        }
+
+        virtual unsigned int offset827(int) {
+            return offset = 827;
+        }
+
+        virtual unsigned int offset828(int) {
+            return offset = 828;
+        }
+
+        virtual unsigned int offset829(int) {
+            return offset = 829;
+        }
+
+        virtual unsigned int offset830(int) {
+            return offset = 830;
+        }
+
+        virtual unsigned int offset831(int) {
+            return offset = 831;
+        }
+
+        virtual unsigned int offset832(int) {
+            return offset = 832;
+        }
+
+        virtual unsigned int offset833(int) {
+            return offset = 833;
+        }
+
+        virtual unsigned int offset834(int) {
+            return offset = 834;
+        }
+
+        virtual unsigned int offset835(int) {
+            return offset = 835;
+        }
+
+        virtual unsigned int offset836(int) {
+            return offset = 836;
+        }
+
+        virtual unsigned int offset837(int) {
+            return offset = 837;
+        }
+
+        virtual unsigned int offset838(int) {
+            return offset = 838;
+        }
+
+        virtual unsigned int offset839(int) {
+            return offset = 839;
+        }
+
+        virtual unsigned int offset840(int) {
+            return offset = 840;
+        }
+
+        virtual unsigned int offset841(int) {
+            return offset = 841;
+        }
+
+        virtual unsigned int offset842(int) {
+            return offset = 842;
+        }
+
+        virtual unsigned int offset843(int) {
+            return offset = 843;
+        }
+
+        virtual unsigned int offset844(int) {
+            return offset = 844;
+        }
+
+        virtual unsigned int offset845(int) {
+            return offset = 845;
+        }
+
+        virtual unsigned int offset846(int) {
+            return offset = 846;
+        }
+
+        virtual unsigned int offset847(int) {
+            return offset = 847;
+        }
+
+        virtual unsigned int offset848(int) {
+            return offset = 848;
+        }
+
+        virtual unsigned int offset849(int) {
+            return offset = 849;
+        }
+
+        virtual unsigned int offset850(int) {
+            return offset = 850;
+        }
+
+        virtual unsigned int offset851(int) {
+            return offset = 851;
+        }
+
+        virtual unsigned int offset852(int) {
+            return offset = 852;
+        }
+
+        virtual unsigned int offset853(int) {
+            return offset = 853;
+        }
+
+        virtual unsigned int offset854(int) {
+            return offset = 854;
+        }
+
+        virtual unsigned int offset855(int) {
+            return offset = 855;
+        }
+
+        virtual unsigned int offset856(int) {
+            return offset = 856;
+        }
+
+        virtual unsigned int offset857(int) {
+            return offset = 857;
+        }
+
+        virtual unsigned int offset858(int) {
+            return offset = 858;
+        }
+
+        virtual unsigned int offset859(int) {
+            return offset = 859;
+        }
+
+        virtual unsigned int offset860(int) {
+            return offset = 860;
+        }
+
+        virtual unsigned int offset861(int) {
+            return offset = 861;
+        }
+
+        virtual unsigned int offset862(int) {
+            return offset = 862;
+        }
+
+        virtual unsigned int offset863(int) {
+            return offset = 863;
+        }
+
+        virtual unsigned int offset864(int) {
+            return offset = 864;
+        }
+
+        virtual unsigned int offset865(int) {
+            return offset = 865;
+        }
+
+        virtual unsigned int offset866(int) {
+            return offset = 866;
+        }
+
+        virtual unsigned int offset867(int) {
+            return offset = 867;
+        }
+
+        virtual unsigned int offset868(int) {
+            return offset = 868;
+        }
+
+        virtual unsigned int offset869(int) {
+            return offset = 869;
+        }
+
+        virtual unsigned int offset870(int) {
+            return offset = 870;
+        }
+
+        virtual unsigned int offset871(int) {
+            return offset = 871;
+        }
+
+        virtual unsigned int offset872(int) {
+            return offset = 872;
+        }
+
+        virtual unsigned int offset873(int) {
+            return offset = 873;
+        }
+
+        virtual unsigned int offset874(int) {
+            return offset = 874;
+        }
+
+        virtual unsigned int offset875(int) {
+            return offset = 875;
+        }
+
+        virtual unsigned int offset876(int) {
+            return offset = 876;
+        }
+
+        virtual unsigned int offset877(int) {
+            return offset = 877;
+        }
+
+        virtual unsigned int offset878(int) {
+            return offset = 878;
+        }
+
+        virtual unsigned int offset879(int) {
+            return offset = 879;
+        }
+
+        virtual unsigned int offset880(int) {
+            return offset = 880;
+        }
+
+        virtual unsigned int offset881(int) {
+            return offset = 881;
+        }
+
+        virtual unsigned int offset882(int) {
+            return offset = 882;
+        }
+
+        virtual unsigned int offset883(int) {
+            return offset = 883;
+        }
+
+        virtual unsigned int offset884(int) {
+            return offset = 884;
+        }
+
+        virtual unsigned int offset885(int) {
+            return offset = 885;
+        }
+
+        virtual unsigned int offset886(int) {
+            return offset = 886;
+        }
+
+        virtual unsigned int offset887(int) {
+            return offset = 887;
+        }
+
+        virtual unsigned int offset888(int) {
+            return offset = 888;
+        }
+
+        virtual unsigned int offset889(int) {
+            return offset = 889;
+        }
+
+        virtual unsigned int offset890(int) {
+            return offset = 890;
+        }
+
+        virtual unsigned int offset891(int) {
+            return offset = 891;
+        }
+
+        virtual unsigned int offset892(int) {
+            return offset = 892;
+        }
+
+        virtual unsigned int offset893(int) {
+            return offset = 893;
+        }
+
+        virtual unsigned int offset894(int) {
+            return offset = 894;
+        }
+
+        virtual unsigned int offset895(int) {
+            return offset = 895;
+        }
+
+        virtual unsigned int offset896(int) {
+            return offset = 896;
+        }
+
+        virtual unsigned int offset897(int) {
+            return offset = 897;
+        }
+
+        virtual unsigned int offset898(int) {
+            return offset = 898;
+        }
+
+        virtual unsigned int offset899(int) {
+            return offset = 899;
+        }
+
+
+        virtual unsigned int offset900(int) {
+            return offset = 900;
+        }
+
+        virtual unsigned int offset901(int) {
+            return offset = 901;
+        }
+
+        virtual unsigned int offset902(int) {
+            return offset = 902;
+        }
+
+        virtual unsigned int offset903(int) {
+            return offset = 903;
+        }
+
+        virtual unsigned int offset904(int) {
+            return offset = 904;
+        }
+
+        virtual unsigned int offset905(int) {
+            return offset = 905;
+        }
+
+        virtual unsigned int offset906(int) {
+            return offset = 906;
+        }
+
+        virtual unsigned int offset907(int) {
+            return offset = 907;
+        }
+
+        virtual unsigned int offset908(int) {
+            return offset = 908;
+        }
+
+        virtual unsigned int offset909(int) {
+            return offset = 909;
+        }
+
+        virtual unsigned int offset910(int) {
+            return offset = 910;
+        }
+
+        virtual unsigned int offset911(int) {
+            return offset = 911;
+        }
+
+        virtual unsigned int offset912(int) {
+            return offset = 912;
+        }
+
+        virtual unsigned int offset913(int) {
+            return offset = 913;
+        }
+
+        virtual unsigned int offset914(int) {
+            return offset = 914;
+        }
+
+        virtual unsigned int offset915(int) {
+            return offset = 915;
+        }
+
+        virtual unsigned int offset916(int) {
+            return offset = 916;
+        }
+
+        virtual unsigned int offset917(int) {
+            return offset = 917;
+        }
+
+        virtual unsigned int offset918(int) {
+            return offset = 918;
+        }
+
+        virtual unsigned int offset919(int) {
+            return offset = 919;
+        }
+
+        virtual unsigned int offset920(int) {
+            return offset = 920;
+        }
+
+        virtual unsigned int offset921(int) {
+            return offset = 921;
+        }
+
+        virtual unsigned int offset922(int) {
+            return offset = 922;
+        }
+
+        virtual unsigned int offset923(int) {
+            return offset = 923;
+        }
+
+        virtual unsigned int offset924(int) {
+            return offset = 924;
+        }
+
+        virtual unsigned int offset925(int) {
+            return offset = 925;
+        }
+
+        virtual unsigned int offset926(int) {
+            return offset = 926;
+        }
+
+        virtual unsigned int offset927(int) {
+            return offset = 927;
+        }
+
+        virtual unsigned int offset928(int) {
+            return offset = 928;
+        }
+
+        virtual unsigned int offset929(int) {
+            return offset = 929;
+        }
+
+        virtual unsigned int offset930(int) {
+            return offset = 930;
+        }
+
+        virtual unsigned int offset931(int) {
+            return offset = 931;
+        }
+
+        virtual unsigned int offset932(int) {
+            return offset = 932;
+        }
+
+        virtual unsigned int offset933(int) {
+            return offset = 933;
+        }
+
+        virtual unsigned int offset934(int) {
+            return offset = 934;
+        }
+
+        virtual unsigned int offset935(int) {
+            return offset = 935;
+        }
+
+        virtual unsigned int offset936(int) {
+            return offset = 936;
+        }
+
+        virtual unsigned int offset937(int) {
+            return offset = 937;
+        }
+
+        virtual unsigned int offset938(int) {
+            return offset = 938;
+        }
+
+        virtual unsigned int offset939(int) {
+            return offset = 939;
+        }
+
+        virtual unsigned int offset940(int) {
+            return offset = 940;
+        }
+
+        virtual unsigned int offset941(int) {
+            return offset = 941;
+        }
+
+        virtual unsigned int offset942(int) {
+            return offset = 942;
+        }
+
+        virtual unsigned int offset943(int) {
+            return offset = 943;
+        }
+
+        virtual unsigned int offset944(int) {
+            return offset = 944;
+        }
+
+        virtual unsigned int offset945(int) {
+            return offset = 945;
+        }
+
+        virtual unsigned int offset946(int) {
+            return offset = 946;
+        }
+
+        virtual unsigned int offset947(int) {
+            return offset = 947;
+        }
+
+        virtual unsigned int offset948(int) {
+            return offset = 948;
+        }
+
+        virtual unsigned int offset949(int) {
+            return offset = 949;
+        }
+
+        virtual unsigned int offset950(int) {
+            return offset = 950;
+        }
+
+        virtual unsigned int offset951(int) {
+            return offset = 951;
+        }
+
+        virtual unsigned int offset952(int) {
+            return offset = 952;
+        }
+
+        virtual unsigned int offset953(int) {
+            return offset = 953;
+        }
+
+        virtual unsigned int offset954(int) {
+            return offset = 954;
+        }
+
+        virtual unsigned int offset955(int) {
+            return offset = 955;
+        }
+
+        virtual unsigned int offset956(int) {
+            return offset = 956;
+        }
+
+        virtual unsigned int offset957(int) {
+            return offset = 957;
+        }
+
+        virtual unsigned int offset958(int) {
+            return offset = 958;
+        }
+
+        virtual unsigned int offset959(int) {
+            return offset = 959;
+        }
+
+        virtual unsigned int offset960(int) {
+            return offset = 960;
+        }
+
+        virtual unsigned int offset961(int) {
+            return offset = 961;
+        }
+
+        virtual unsigned int offset962(int) {
+            return offset = 962;
+        }
+
+        virtual unsigned int offset963(int) {
+            return offset = 963;
+        }
+
+        virtual unsigned int offset964(int) {
+            return offset = 964;
+        }
+
+        virtual unsigned int offset965(int) {
+            return offset = 965;
+        }
+
+        virtual unsigned int offset966(int) {
+            return offset = 966;
+        }
+
+        virtual unsigned int offset967(int) {
+            return offset = 967;
+        }
+
+        virtual unsigned int offset968(int) {
+            return offset = 968;
+        }
+
+        virtual unsigned int offset969(int) {
+            return offset = 969;
+        }
+
+        virtual unsigned int offset970(int) {
+            return offset = 970;
+        }
+
+        virtual unsigned int offset971(int) {
+            return offset = 971;
+        }
+
+        virtual unsigned int offset972(int) {
+            return offset = 972;
+        }
+
+        virtual unsigned int offset973(int) {
+            return offset = 973;
+        }
+
+        virtual unsigned int offset974(int) {
+            return offset = 974;
+        }
+
+        virtual unsigned int offset975(int) {
+            return offset = 975;
+        }
+
+        virtual unsigned int offset976(int) {
+            return offset = 976;
+        }
+
+        virtual unsigned int offset977(int) {
+            return offset = 977;
+        }
+
+        virtual unsigned int offset978(int) {
+            return offset = 978;
+        }
+
+        virtual unsigned int offset979(int) {
+            return offset = 979;
+        }
+
+        virtual unsigned int offset980(int) {
+            return offset = 980;
+        }
+
+        virtual unsigned int offset981(int) {
+            return offset = 981;
+        }
+
+        virtual unsigned int offset982(int) {
+            return offset = 982;
+        }
+
+        virtual unsigned int offset983(int) {
+            return offset = 983;
+        }
+
+        virtual unsigned int offset984(int) {
+            return offset = 984;
+        }
+
+        virtual unsigned int offset985(int) {
+            return offset = 985;
+        }
+
+        virtual unsigned int offset986(int) {
+            return offset = 986;
+        }
+
+        virtual unsigned int offset987(int) {
+            return offset = 987;
+        }
+
+        virtual unsigned int offset988(int) {
+            return offset = 988;
+        }
+
+        virtual unsigned int offset989(int) {
+            return offset = 989;
+        }
+
+        virtual unsigned int offset990(int) {
+            return offset = 990;
+        }
+
+        virtual unsigned int offset991(int) {
+            return offset = 991;
+        }
+
+        virtual unsigned int offset992(int) {
+            return offset = 992;
+        }
+
+        virtual unsigned int offset993(int) {
+            return offset = 993;
+        }
+
+        virtual unsigned int offset994(int) {
+            return offset = 994;
+        }
+
+        virtual unsigned int offset995(int) {
+            return offset = 995;
+        }
+
+        virtual unsigned int offset996(int) {
+            return offset = 996;
+        }
+
+        virtual unsigned int offset997(int) {
+            return offset = 997;
+        }
+
+        virtual unsigned int offset998(int) {
+            return offset = 998;
+        }
+
+        virtual unsigned int offset999(int) {
+            return offset = 999;
+        }
+
+        virtual unsigned int offset1000(int) {
+            return offset = 1000;
+        }
+
+    };
+}
+namespace fakeit {
+
+    template<typename TARGET, typename SOURCE>
+    TARGET union_cast(SOURCE source) {
+
+        union {
+            SOURCE source;
+            TARGET target;
+        } u;
+        u.source = source;
+        return u.target;
+    }
+
+}
+
+namespace fakeit {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
+    };
+
+    class VTUtils {
+    public:
+
+        template<typename C, typename R, typename ... arglist>
+        static unsigned int getOffset(R (C::*vMethod)(arglist...)) {
+            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector::*)(int)>(vMethod);
+            VirtualOffsetSelector offsetSelctor;
+            return (offsetSelctor.*sMethod)(0);
+        }
+
+        template<typename C>
+        static typename std::enable_if<std::has_virtual_destructor<C>::value, unsigned int>::type
+        getDestructorOffset() {
+            VirtualOffsetSelector offsetSelctor;
+            union_cast<C *>(&offsetSelctor)->~C();
+            return offsetSelctor.offset;
+        }
+
+        template<typename C>
+        static typename std::enable_if<!std::has_virtual_destructor<C>::value, unsigned int>::type
+        getDestructorOffset() {
+            throw NoVirtualDtor();
+        }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
+
+        template<typename C>
+        static unsigned int getVTSize() {
+            struct Derrived : public C {
+                virtual void endOfVt() {
+                }
+            };
+
+            unsigned int vtSize = getOffset(&Derrived::endOfVt);
+            return vtSize;
+        }
+    };
+
+
+}
+#ifdef _MSC_VER
+namespace fakeit {
+
+    typedef unsigned long dword_;
+
+    struct TypeDescriptor {
+        TypeDescriptor() :
+                ptrToVTable(0), spare(0) {
+
+            int **tiVFTPtr = (int **) (&typeid(void));
+            int *i = (int *) tiVFTPtr[0];
+			char *type_info_vft_ptr = (char *) i;
+            ptrToVTable = type_info_vft_ptr;
+        }
+
+		char *ptrToVTable;
+        dword_ spare;
+        char name[8];
+    };
+
+    struct PMD {
+
+
+
+        int mdisp;
+
+        int pdisp;
+        int vdisp;
+
+        PMD() :
+                mdisp(0), pdisp(-1), vdisp(0) {
+        }
+    };
+
+    struct RTTIBaseClassDescriptor {
+        RTTIBaseClassDescriptor() :
+                pTypeDescriptor(nullptr), numContainedBases(0), attributes(0) {
+        }
+
+        const std::type_info *pTypeDescriptor;
+        dword_ numContainedBases;
+        struct PMD where;
+        dword_ attributes;
+    };
+
+    template<typename C, typename... baseclasses>
+    struct RTTIClassHierarchyDescriptor {
+        RTTIClassHierarchyDescriptor() :
+                signature(0),
+                attributes(0),
+                numBaseClasses(0),
+                pBaseClassArray(nullptr) {
+            pBaseClassArray = new RTTIBaseClassDescriptor *[1 + sizeof...(baseclasses)];
+            addBaseClass < C, baseclasses...>();
+        }
+
+        ~RTTIClassHierarchyDescriptor() {
+            for (int i = 0; i < 1 + sizeof...(baseclasses); i++) {
+                RTTIBaseClassDescriptor *desc = pBaseClassArray[i];
+                delete desc;
+            }
+            delete[] pBaseClassArray;
+        }
+
+        dword_ signature;
+        dword_ attributes;
+        dword_ numBaseClasses;
+        RTTIBaseClassDescriptor **pBaseClassArray;
+
+        template<typename BaseType>
+        void addBaseClass() {
+            static_assert(std::is_base_of<BaseType, C>::value, "C must be a derived class of BaseType");
+            RTTIBaseClassDescriptor *desc = new RTTIBaseClassDescriptor();
+            desc->pTypeDescriptor = &typeid(BaseType);
+            pBaseClassArray[numBaseClasses] = desc;
+            for (unsigned int i = 0; i < numBaseClasses; i++) {
+                pBaseClassArray[i]->numContainedBases++;
+            }
+            numBaseClasses++;
+        }
+
+        template<typename head, typename B1, typename... tail>
+        void addBaseClass() {
+            static_assert(std::is_base_of<B1, head>::value, "invalid inheritance list");
+            addBaseClass<head>();
+            addBaseClass<B1, tail...>();
+        }
+
+    };
+
+	template<typename C, typename... baseclasses>
+	struct RTTICompleteObjectLocator {
+#ifdef _WIN64
+		RTTICompleteObjectLocator(const std::type_info &unused) :
+			signature(0), offset(0), cdOffset(0),
+			typeDescriptorOffset(0), classDescriptorOffset(0)
+		{
+                    (void)unused;
+		}
+
+		dword_ signature;
+		dword_ offset;
+		dword_ cdOffset;
+		dword_ typeDescriptorOffset;
+		dword_ classDescriptorOffset;
+#else
+		RTTICompleteObjectLocator(const std::type_info &info) :
+			signature(0), offset(0), cdOffset(0),
+			pTypeDescriptor(&info),
+			pClassDescriptor(new RTTIClassHierarchyDescriptor<C, baseclasses...>()) {
+		}
+
+		~RTTICompleteObjectLocator() {
+			delete pClassDescriptor;
+		}
+
+		dword_ signature;
+		dword_ offset;
+		dword_ cdOffset;
+		const std::type_info *pTypeDescriptor;
+		struct RTTIClassHierarchyDescriptor<C, baseclasses...> *pClassDescriptor;
+#endif
+	};
+
+
+    struct VirtualTableBase {
+
+        static VirtualTableBase &getVTable(void *instance) {
+            fakeit::VirtualTableBase *vt = (fakeit::VirtualTableBase *) (instance);
+            return *vt;
+        }
+
+        VirtualTableBase(void **firstMethod) : _firstMethod(firstMethod) { }
+
+        void *getCookie(int index) {
+            return _firstMethod[-2 - index];
+        }
+
+        void setCookie(int index, void *value) {
+            _firstMethod[-2 - index] = value;
+        }
+
+        void *getMethod(unsigned int index) const {
+            return _firstMethod[index];
+        }
+
+        void setMethod(unsigned int index, void *method) {
+            _firstMethod[index] = method;
+        }
+
+    protected:
+        void **_firstMethod;
+    };
+
+    template<class C, class... baseclasses>
+    struct VirtualTable : public VirtualTableBase {
+
+        class Handle {
+
+            friend struct VirtualTable<C, baseclasses...>;
+
+            void **firstMethod;
+
+            Handle(void **method) : firstMethod(method) { }
+
+        public:
+
+            VirtualTable<C, baseclasses...> &restore() {
+                VirtualTable<C, baseclasses...> *vt = (VirtualTable<C, baseclasses...> *) this;
+                return *vt;
+            }
+        };
+
+        static VirtualTable<C, baseclasses...> &getVTable(C &instance) {
+            fakeit::VirtualTable<C, baseclasses...> *vt = (fakeit::VirtualTable<C, baseclasses...> *) (&instance);
+            return *vt;
+        }
+
+        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+            unsigned int size = VTUtils::getVTSize<C>();
+            for (unsigned int i = 0; i < size; i++) {
+                _firstMethod[i] = from.getMethod(i);
+            }
+        }
+
+        VirtualTable() : VirtualTable(buildVTArray()) {
+        }
+
+        ~VirtualTable() {
+
+        }
+
+        void dispose() {
+            _firstMethod--;
+            RTTICompleteObjectLocator<C, baseclasses...> *locator = (RTTICompleteObjectLocator<C, baseclasses...> *) _firstMethod[0];
+            delete locator;
+            _firstMethod -= numOfCookies;
+            delete[] _firstMethod;
+        }
+
+
+        unsigned int dtor(int) {
+            C *c = (C *) this;
+            C &cRef = *c;
+            auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
+            void *dtorPtr = vt.getCookie(numOfCookies - 1);
+            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
+            method(c);
+            return 0;
+        }
+
+        void setDtor(void *method) {
+
+
+
+
+
+            void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
+            unsigned int index = VTUtils::getDestructorOffset<C>();
+            _firstMethod[index] = dtorPtr;
+            setCookie(numOfCookies - 1, method);
+        }
+
+        unsigned int getSize() {
+            return VTUtils::getVTSize<C>();
+        }
+
+        void initAll(void *value) {
+            auto size = getSize();
+            for (unsigned int i = 0; i < size; i++) {
+                setMethod(i, value);
+            }
+        }
+
+        Handle createHandle() {
+            Handle h(_firstMethod);
+            return h;
+        }
+
+    private:
+
+        class SimpleType {
+        };
+
+        static_assert(sizeof(unsigned int (SimpleType::*)()) == sizeof(unsigned int (C::*)()),
+            "Can't mock a type with multiple inheritance or with non-polymorphic base class");
+        static const unsigned int numOfCookies = 3;
+
+        static void **buildVTArray() {
+            int vtSize = VTUtils::getVTSize<C>();
+            auto array = new void *[vtSize + numOfCookies + 1]{};
+            RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
+                    typeid(C));
+            array += numOfCookies;
+            array[0] = objectLocator;
+            array++;
+            return array;
+        }
+
+        VirtualTable(void **firstMethod) : VirtualTableBase(firstMethod) {
+        }
+    };
+}
+#else
+#ifndef __clang__
+#include <type_traits>
+#include <tr2/type_traits>
+
+namespace fakeit {
+    template<typename ... T1>
+    class has_one_base {
+    };
+
+    template<typename T1, typename T2, typename ... types>
+    class has_one_base<std::tr2::__reflection_typelist<T1, T2, types...>> : public std::false_type {
+    };
+
+    template<typename T1>
+    class has_one_base<std::tr2::__reflection_typelist<T1>>
+            : public has_one_base<typename std::tr2::direct_bases<T1>::type> {
+    };
+
+    template<>
+    class has_one_base<std::tr2::__reflection_typelist<>> : public std::true_type {
+    };
+
+    template<typename T>
+    class is_simple_inheritance_layout : public has_one_base<typename std::tr2::direct_bases<T>::type> {
+    };
+}
+
+#endif
+
+namespace fakeit {
+
+    struct VirtualTableBase {
+
+        static VirtualTableBase &getVTable(void *instance) {
+            fakeit::VirtualTableBase *vt = (fakeit::VirtualTableBase *) (instance);
+            return *vt;
+        }
+
+        VirtualTableBase(void **firstMethod) : _firstMethod(firstMethod) { }
+
+        void *getCookie(int index) {
+            return _firstMethod[-3 - index];
+        }
+
+        void setCookie(int index, void *value) {
+            _firstMethod[-3 - index] = value;
+        }
+
+        void *getMethod(unsigned int index) const {
+            return _firstMethod[index];
+        }
+
+        void setMethod(unsigned int index, void *method) {
+            _firstMethod[index] = method;
+        }
+
+    protected:
+        void **_firstMethod;
+    };
+
+    template<class C, class ... baseclasses>
+    struct VirtualTable : public VirtualTableBase {
+
+#ifndef __clang__
+        static_assert(is_simple_inheritance_layout<C>::value, "Can't mock a type with multiple inheritance");
+#endif
+
+        class Handle {
+
+            friend struct VirtualTable<C, baseclasses...>;
+            void **firstMethod;
+
+            Handle(void **method) :
+                    firstMethod(method) {
+            }
+
+        public:
+
+            VirtualTable<C, baseclasses...> &restore() {
+                VirtualTable<C, baseclasses...> *vt = (VirtualTable<C, baseclasses...> *) this;
+                return *vt;
+            }
+        };
+
+        static VirtualTable<C, baseclasses...> &getVTable(C &instance) {
+            fakeit::VirtualTable<C, baseclasses...> *vt = (fakeit::VirtualTable<C, baseclasses...> *) (&instance);
+            return *vt;
+        }
+
+        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+            unsigned int size = VTUtils::getVTSize<C>();
+
+            for (size_t i = 0; i < size; ++i) {
+                _firstMethod[i] = from.getMethod(i);
+            }
+        }
+
+        VirtualTable() :
+                VirtualTable(buildVTArray()) {
+        }
+
+        void dispose() {
+            _firstMethod--;
+            _firstMethod--;
+            _firstMethod -= numOfCookies;
+            delete[] _firstMethod;
+        }
+
+        unsigned int dtor(int) {
+            C *c = (C *) this;
+            C &cRef = *c;
+            auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
+            unsigned int index = VTUtils::getDestructorOffset<C>();
+            void *dtorPtr = vt.getMethod(index);
+            void(*method)(C *) = union_cast<void (*)(C *)>(dtorPtr);
+            method(c);
+            return 0;
+        }
+
+
+        void setDtor(void *method) {
+            unsigned int index = VTUtils::getDestructorOffset<C>();
+            void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
+
+
+            _firstMethod[index] = method;
+
+            _firstMethod[index + 1] = dtorPtr;
+        }
+
+
+        unsigned int getSize() {
+            return VTUtils::getVTSize<C>();
+        }
+
+        void initAll(void *value) {
+            unsigned int size = getSize();
+            for (unsigned int i = 0; i < size; i++) {
+                setMethod(i, value);
+            }
+        }
+
+        const std::type_info *getTypeId() {
+            return (const std::type_info *) (_firstMethod[-1]);
+        }
+
+        Handle createHandle() {
+            Handle h(_firstMethod);
+            return h;
+        }
+
+    private:
+        static const unsigned int numOfCookies = 2;
+
+        static void **buildVTArray() {
+            int size = VTUtils::getVTSize<C>();
+            auto array = new void *[size + 2 + numOfCookies]{};
+            array += numOfCookies;
+            array++;
+            array[0] = const_cast<std::type_info *>(&typeid(C));
+            array++;
+            return array;
+        }
+
+        VirtualTable(void **firstMethod) : VirtualTableBase(firstMethod) {
+        }
+
+    };
+}
+#endif
+namespace fakeit {
+
+    struct NoMoreRecordedActionException {
+    };
+
+    template<typename R, typename ... arglist>
+    struct MethodInvocationHandler : Destructible {
+        virtual R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) = 0;
+    };
+
+}
+#include <new>
+
+namespace fakeit {
+
+#ifdef __GNUG__
+#ifndef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#endif
+
+
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4200 )
+#endif
+
+
+    template<typename C, typename ... baseclasses>
+    class FakeObject {
+
+        VirtualTable<C, baseclasses...> vtable;
+
+        static const size_t SIZE = sizeof(C) - sizeof(VirtualTable<C, baseclasses...>);
+        char instanceArea[SIZE ? SIZE : 0];
+
+        FakeObject(FakeObject const &) = delete;
+        FakeObject &operator=(FakeObject const &) = delete;
+
+    public:
+
+        FakeObject() : vtable() {
+            initializeDataMembersArea();
+        }
+
+        ~FakeObject() {
+            vtable.dispose();
+        }
+
+        void initializeDataMembersArea() {
+            for (size_t i = 0; i < SIZE; ++i) instanceArea[i] = (char) 0;
+        }
+
+        void setMethod(unsigned int index, void *method) {
+            vtable.setMethod(index, method);
+        }
+
+        VirtualTable<C, baseclasses...> &getVirtualTable() {
+            return vtable;
+        }
+
+        void setVirtualTable(VirtualTable<C, baseclasses...> &t) {
+            vtable = t;
+        }
+
+        void setDtor(void *dtor) {
+            vtable.setDtor(dtor);
+        }
+    };
+
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
+
+#ifdef __GNUG__
+#ifndef __clang__
+#pragma GCC diagnostic pop
+#endif
+#endif
+
+}
+namespace fakeit {
+
+    struct MethodProxy {
+
+        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+                _id(id),
+                _offset(offset),
+                _vMethod(vMethod) {
+        }
+
+        unsigned int getOffset() const {
+            return _offset;
+        }
+
+        unsigned int getId() const {
+            return _id;
+        }
+
+        void *getProxy() const {
+            return union_cast<void *>(_vMethod);
+        }
+
+    private:
+        unsigned int _id;
+        unsigned int _offset;
+        void *_vMethod;
+    };
+}
+#include <utility>
+
+
+namespace fakeit {
+
+    struct InvocationHandlerCollection {
+        static const unsigned int VT_COOKIE_INDEX = 0;
+
+        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+
+        static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
+            VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
+            InvocationHandlerCollection *invocationHandlerCollection = (InvocationHandlerCollection *) vt.getCookie(
+                    InvocationHandlerCollection::VT_COOKIE_INDEX);
+            return invocationHandlerCollection;
+        }
+    };
+
+
+    template<typename R, typename ... arglist>
+    class MethodProxyCreator {
+
+
+
+    public:
+
+        template<unsigned int id>
+        MethodProxy createMethodProxy(unsigned int offset) {
+            return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
+        }
+
+    protected:
+
+        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+            InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
+                    this);
+            MethodInvocationHandler<R, arglist...> *invocationHandler =
+                    (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
+                            id);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+
+        template<int id>
+        R methodProxyX(arglist ... args) {
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+    };
+}
+
+namespace fakeit {
+
+    class InvocationHandlers : public InvocationHandlerCollection {
+        std::vector<std::shared_ptr<Destructible>> &_methodMocks;
+        std::vector<unsigned int> &_offsets;
+
+        unsigned int getOffset(unsigned int id) const
+        {
+            unsigned int offset = 0;
+            for (; offset < _offsets.size(); offset++) {
+                if (_offsets[offset] == id) {
+                    break;
+                }
+            }
+            return offset;
+        }
+
+    public:
+        InvocationHandlers(
+                std::vector<std::shared_ptr<Destructible>> &methodMocks,
+                std::vector<unsigned int> &offsets) :
+                _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
+        }
+
+        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+            unsigned int offset = getOffset(id);
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get();
+        }
+
+    };
+
+    template<typename C, typename ... baseclasses>
+    struct DynamicProxy {
+
+        static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
+
+        DynamicProxy(C &inst) :
+                instance(inst),
+                originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
+                _methodMocks(VTUtils::getVTSize<C>()),
+                _offsets(VTUtils::getVTSize<C>()),
+                _invocationHandlers(_methodMocks, _offsets) {
+            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.setCookie(InvocationHandlerCollection::VT_COOKIE_INDEX, &_invocationHandlers);
+            getFake().setVirtualTable(_cloneVt);
+        }
+
+        void detach() {
+            getFake().setVirtualTable(originalVtHandle.restore());
+        }
+
+        ~DynamicProxy() {
+            _cloneVt.dispose();
+        }
+
+        C &get() {
+            return instance;
+        }
+
+        void Reset() {
+			_methodMocks = {};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
+            _members = {};
+			_offsets = {};
+            _offsets.resize(VTUtils::getVTSize<C>());
+            _cloneVt.copyFrom(originalVtHandle.restore());
+        }
+
+		void Clear()
+        {
+        }
+
+        template<int id, typename R, typename ... arglist>
+        void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
+            auto offset = VTUtils::getOffset(vMethod);
+            MethodProxyCreator<R, arglist...> creator;
+            bind(creator.template createMethodProxy<id + 1>(offset), methodInvocationHandler);
+        }
+
+        void stubDtor(MethodInvocationHandler<void> *methodInvocationHandler) {
+            auto offset = VTUtils::getDestructorOffset<C>();
+            MethodProxyCreator<void> creator;
+            bindDtor(creator.createMethodProxy<0>(offset), methodInvocationHandler);
+        }
+
+        template<typename R, typename ... arglist>
+        bool isMethodStubbed(R(C::*vMethod)(arglist...)) {
+            unsigned int offset = VTUtils::getOffset(vMethod);
+            return isBinded(offset);
+        }
+
+        bool isDtorStubbed() {
+            unsigned int offset = VTUtils::getDestructorOffset<C>();
+            return isBinded(offset);
+        }
+
+        template<typename R, typename ... arglist>
+        Destructible *getMethodMock(R(C::*vMethod)(arglist...)) {
+            auto offset = VTUtils::getOffset(vMethod);
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get();
+        }
+
+        Destructible *getDtorMock() {
+            auto offset = VTUtils::getDestructorOffset<C>();
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get();
+        }
+
+        template<typename DATA_TYPE, typename ... arglist>
+        void stubDataMember(DATA_TYPE C::*member, const arglist &... initargs) {
+            DATA_TYPE C::*theMember = (DATA_TYPE C::*) member;
+            C &mock = get();
+            DATA_TYPE *memberPtr = &(mock.*theMember);
+            _members.push_back(
+                    std::shared_ptr<DataMemeberWrapper < DATA_TYPE, arglist...> >
+                    {new DataMemeberWrapper < DATA_TYPE, arglist...>(memberPtr,
+                    initargs...)});
+        }
+
+        template<typename DATA_TYPE>
+        void getMethodMocks(std::vector<DATA_TYPE> &into) const {
+            for (std::shared_ptr<Destructible> ptr : _methodMocks) {
+                DATA_TYPE p = dynamic_cast<DATA_TYPE>(ptr.get());
+                if (p) {
+                    into.push_back(p);
+                }
+            }
+        }
+
+        VirtualTable<C, baseclasses...> &getOriginalVT() {
+            VirtualTable<C, baseclasses...> &vt = originalVtHandle.restore();
+            return vt;
+        }
+
+    private:
+
+        template<typename DATA_TYPE, typename ... arglist>
+        class DataMemeberWrapper : public Destructible {
+        private:
+            DATA_TYPE *dataMember;
+        public:
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
+                new(dataMember) DATA_TYPE{initargs ...};
+            }
+
+            ~DataMemeberWrapper() override
+            {
+                dataMember->~DATA_TYPE();
+            }
+        };
+
+        static_assert(sizeof(C) == sizeof(FakeObject<C, baseclasses...>), "This is a problem");
+
+        C &instance;
+        typename VirtualTable<C, baseclasses...>::Handle originalVtHandle;
+        VirtualTable<C, baseclasses...> _cloneVt;
+
+        std::vector<std::shared_ptr<Destructible>> _methodMocks;
+        std::vector<std::shared_ptr<Destructible>> _members;
+        std::vector<unsigned int> _offsets;
+        InvocationHandlers _invocationHandlers;
+
+        FakeObject<C, baseclasses...> &getFake() {
+            return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
+        }
+
+        void bind(const MethodProxy &methodProxy, Destructible *invocationHandler) {
+            getFake().setMethod(methodProxy.getOffset(), methodProxy.getProxy());
+            _methodMocks[methodProxy.getOffset()].reset(invocationHandler);
+            _offsets[methodProxy.getOffset()] = methodProxy.getId();
+        }
+
+        void bindDtor(const MethodProxy &methodProxy, Destructible *invocationHandler) {
+            getFake().setDtor(methodProxy.getProxy());
+            _methodMocks[methodProxy.getOffset()].reset(invocationHandler);
+            _offsets[methodProxy.getOffset()] = methodProxy.getId();
+        }
+
+        template<typename DATA_TYPE>
+        DATA_TYPE getMethodMock(unsigned int offset) {
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return dynamic_cast<DATA_TYPE>(ptr.get());
+        }
+
+        template<typename BaseClass>
+        void checkMultipleInheritance() {
+            C *ptr = (C *) (unsigned int) 1;
+            BaseClass *basePtr = ptr;
+            int delta = (unsigned long) basePtr - (unsigned long) ptr;
+            if (delta > 0) {
+
+
+                throw std::invalid_argument(std::string("multiple inheritance is not supported"));
+            }
+        }
+
+        bool isBinded(unsigned int offset) {
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get() != nullptr;
+        }
+
+    };
+}
+#include <functional>
+#include <type_traits>
+#include <memory>
+#include <iosfwd>
+#include <vector>
+#include <functional>
+#include <tuple>
+#include <tuple>
+
+namespace fakeit {
+
+    template<int N>
+    struct apply_func {
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
+        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t, Args &... args) {
+            return apply_func<N - 1>::template applyTuple(f, t, std::get<N - 1>(t), args...);
+        }
+    };
+
+    template<>
+    struct apply_func < 0 > {
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
+        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> & , Args &... args) {
+            return f(args...);
+        }
+    };
+
+    struct TupleDispatcher {
+
+        template<typename R, typename ... ArgsF, typename ... ArgsT>
+        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t) {
+            return apply_func<sizeof...(ArgsT)>::template applyTuple(f, t);
+        }
+
+        template<typename R, typename ...arglist>
+        static R invoke(std::function<R(arglist &...)> func, const std::tuple<arglist...> &arguments) {
+            std::tuple<arglist...> &args = const_cast<std::tuple<arglist...> &>(arguments);
+            return applyTuple(func, args);
+        }
+
+        template<typename TupleType, typename FunctionType>
+        static void for_each(TupleType &&, FunctionType &,
+            std::integral_constant<size_t, std::tuple_size<typename std::remove_reference<TupleType>::type>::value>) {
+        }
+
+        template<std::size_t I, typename TupleType, typename FunctionType, typename = typename std::enable_if<
+            I != std::tuple_size<typename std::remove_reference<TupleType>::type>::value>::type>
+            static void for_each(TupleType &&t, FunctionType &f, std::integral_constant<size_t, I>) {
+            f(I, std::get < I >(t));
+            for_each(std::forward < TupleType >(t), f, std::integral_constant<size_t, I + 1>());
+        }
+
+        template<typename TupleType, typename FunctionType>
+        static void for_each(TupleType &&t, FunctionType &f) {
+            for_each(std::forward < TupleType >(t), f, std::integral_constant<size_t, 0>());
+        }
+
+        template<typename TupleType1, typename TupleType2, typename FunctionType>
+        static void for_each(TupleType1 &&, TupleType2 &&, FunctionType &,
+            std::integral_constant<size_t, std::tuple_size<typename std::remove_reference<TupleType1>::type>::value>) {
+        }
+
+        template<std::size_t I, typename TupleType1, typename TupleType2, typename FunctionType, typename = typename std::enable_if<
+            I != std::tuple_size<typename std::remove_reference<TupleType1>::type>::value>::type>
+            static void for_each(TupleType1 &&t, TupleType2 &&t2, FunctionType &f, std::integral_constant<size_t, I>) {
+            f(I, std::get < I >(t), std::get < I >(t2));
+            for_each(std::forward < TupleType1 >(t), std::forward < TupleType2 >(t2), f, std::integral_constant<size_t, I + 1>());
+        }
+
+        template<typename TupleType1, typename TupleType2, typename FunctionType>
+        static void for_each(TupleType1 &&t, TupleType2 &&t2, FunctionType &f) {
+            for_each(std::forward < TupleType1 >(t), std::forward < TupleType2 >(t2), f, std::integral_constant<size_t, 0>());
+        }
+    };
+}
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    struct ActualInvocationHandler : Destructible {
+        virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) = 0;
+    };
+
+}
+#include <functional>
+#include <tuple>
+#include <string>
+#include <iosfwd>
+#include <type_traits>
+#include <typeinfo>
+
+namespace fakeit {
+
+    struct DefaultValueInstatiationException {
+        virtual ~DefaultValueInstatiationException() = default;
+
+        virtual std::string what() const = 0;
+    };
+
+
+    template<class C>
+    struct is_constructible_type {
+        static const bool value =
+                std::is_default_constructible<typename naked_type<C>::type>::value
+                && !std::is_abstract<typename naked_type<C>::type>::value;
+    };
+
+    template<class C, class Enable = void>
+    struct DefaultValue;
+
+    template<class C>
+    struct DefaultValue<C, typename std::enable_if<!is_constructible_type<C>::value>::type> {
+        static C &value() {
+            if (std::is_reference<C>::value) {
+                typename naked_type<C>::type *ptr = nullptr;
+                return *ptr;
+            }
+
+            class Exception : public DefaultValueInstatiationException {
+                virtual std::string what() const
+
+                override {
+                    return (std::string("Type ") + std::string(typeid(C).name())
+                            + std::string(
+                            " is not default constructible. Could not instantiate a default return value")).c_str();
+                }
+            };
+
+            throw Exception();
+        }
+    };
+
+    template<class C>
+    struct DefaultValue<C, typename std::enable_if<is_constructible_type<C>::value>::type> {
+        static C &value() {
+            static typename naked_type<C>::type val{};
+            return val;
+        }
+    };
+
+
+    template<>
+    struct DefaultValue<void> {
+        static void value() {
+            return;
+        }
+    };
+
+    template<>
+    struct DefaultValue<bool> {
+        static bool &value() {
+            static bool value{false};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<char> {
+        static char &value() {
+            static char value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<char16_t> {
+        static char16_t &value() {
+            static char16_t value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<char32_t> {
+        static char32_t &value() {
+            static char32_t value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<wchar_t> {
+        static wchar_t &value() {
+            static wchar_t value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<short> {
+        static short &value() {
+            static short value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<int> {
+        static int &value() {
+            static int value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<long> {
+        static long &value() {
+            static long value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<long long> {
+        static long long &value() {
+            static long long value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<std::string> {
+        static std::string &value() {
+            static std::string value{};
+            return value;
+        }
+    };
+
+}
+namespace fakeit {
+
+    struct IMatcher : Destructible {
+        ~IMatcher() = default;
+        virtual std::string format() const = 0;
+    };
+
+    template<typename T>
+    struct TypedMatcher : IMatcher {
+        virtual bool matches(const T &actual) const = 0;
+    };
+
+    template<typename T>
+    struct TypedMatcherCreator {
+
+        virtual ~TypedMatcherCreator() = default;
+
+        virtual TypedMatcher<T> *createMatcher() const = 0;
+    };
+
+    template<typename T>
+    struct ComparisonMatcherCreator : public TypedMatcherCreator<T> {
+
+        virtual ~ComparisonMatcherCreator() = default;
+
+        ComparisonMatcherCreator(const T &arg)
+                : _expected(arg) {
+        }
+
+        struct Matcher : public TypedMatcher<T> {
+            Matcher(const T &expected)
+                    : _expected(expected) {
+            }
+
+            const T _expected;
+        };
+
+        const T &_expected;
+    };
+
+    namespace internal {
+        template<typename T>
+        struct TypedAnyMatcher : public TypedMatcherCreator<T> {
+
+            virtual ~TypedAnyMatcher() = default;
+
+            TypedAnyMatcher() {
+            }
+
+            struct Matcher : public TypedMatcher<T> {
+                virtual bool matches(const T &) const override {
+                    return true;
+                }
+
+                virtual std::string format() const override {
+                    return "Any";
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher();
+            }
+
+        };
+
+        template<typename T>
+        struct EqMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~EqMatcherCreator() = default;
+
+            EqMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual std::string format() const override {
+                    return TypeFormatter<T>::format(this->_expected);
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual == this->_expected;
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const {
+                return new Matcher(this->_expected);
+            }
+
+        };
+
+        template<typename T>
+        struct GtMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~GtMatcherCreator() = default;
+
+            GtMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual > this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string(">") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+        };
+
+        template<typename T>
+        struct GeMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~GeMatcherCreator() = default;
+
+            GeMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual >= this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string(">=") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+        };
+
+        template<typename T>
+        struct LtMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~LtMatcherCreator() = default;
+
+            LtMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual < this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string("<") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+
+        };
+
+        template<typename T>
+        struct LeMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~LeMatcherCreator() = default;
+
+            LeMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual <= this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string("<=") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+
+        };
+
+        template<typename T>
+        struct NeMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~NeMatcherCreator() = default;
+
+            NeMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual != this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string("!=") + TypeFormatter<T>::format(this->_expected);
+                }
+
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+
+        };
+    }
+
+    struct AnyMatcher {
+    } static _;
+
+    template<typename T>
+    internal::TypedAnyMatcher<T> Any() {
+        internal::TypedAnyMatcher<T> rv;
+        return rv;
+    }
+
+    template<typename T>
+    internal::EqMatcherCreator<T> Eq(const T &arg) {
+        internal::EqMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::GtMatcherCreator<T> Gt(const T &arg) {
+        internal::GtMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::GeMatcherCreator<T> Ge(const T &arg) {
+        internal::GeMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::LtMatcherCreator<T> Lt(const T &arg) {
+        internal::LtMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::LeMatcherCreator<T> Le(const T &arg) {
+        internal::LeMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::NeMatcherCreator<T> Ne(const T &arg) {
+        internal::NeMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+}
+
+namespace fakeit {
+
+    template<typename ... arglist>
+    struct ArgumentsMatcherInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
+
+        virtual ~ArgumentsMatcherInvocationMatcher() {
+            for (unsigned int i = 0; i < _matchers.size(); i++)
+                delete _matchers[i];
+        }
+
+        ArgumentsMatcherInvocationMatcher(const std::vector<Destructible *> &args)
+                : _matchers(args) {
+        }
+
+        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+            if (invocation.getActualMatcher() == this)
+                return true;
+            return matches(invocation.getActualArguments());
+        }
+
+        virtual std::string format() const override {
+            std::ostringstream out;
+            out << "(";
+            for (unsigned int i = 0; i < _matchers.size(); i++) {
+                if (i > 0) out << ", ";
+                IMatcher *m = dynamic_cast<IMatcher *>(_matchers[i]);
+                out << m->format();
+            }
+            out << ")";
+            return out.str();
+        }
+
+    private:
+
+        struct MatchingLambda {
+            MatchingLambda(const std::vector<Destructible *> &matchers)
+                    : _matchers(matchers) {
+            }
+
+            template<typename A>
+            void operator()(int index, A &actualArg) {
+                TypedMatcher<typename naked_type<A>::type> *matcher =
+                        dynamic_cast<TypedMatcher<typename naked_type<A>::type> *>(_matchers[index]);
+                if (_matching)
+                    _matching = matcher->matches(actualArg);
+            }
+
+            bool isMatching() {
+                return _matching;
+            }
+
+        private:
+            bool _matching = true;
+            const std::vector<Destructible *> &_matchers;
+        };
+
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            MatchingLambda l(_matchers);
+            fakeit::TupleDispatcher::for_each(actualArguments, l);
+            return l.isMatching();
+        }
+
+        const std::vector<Destructible *> _matchers;
+    };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    template<typename ... arglist>
+    struct UserDefinedInvocationMatcher : ActualInvocation<arglist...>::Matcher {
+        virtual ~UserDefinedInvocationMatcher() = default;
+
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
+        }
+
+        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+            if (invocation.getActualMatcher() == this)
+                return true;
+            return matches(invocation.getActualArguments());
+        }
+
+        virtual std::string format() const override {
+            return {"( user defined matcher )"};
+        }
+
+    private:
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            return TupleDispatcher::invoke<bool, typename tuple_arg<arglist>::type...>(matcher, actualArguments);
+        }
+
+        const std::function<bool(arglist &...)> matcher;
+    };
+
+    template<typename ... arglist>
+    struct DefaultInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
+
+        virtual ~DefaultInvocationMatcher() = default;
+
+        DefaultInvocationMatcher() {
+        }
+
+        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+            return matches(invocation.getActualArguments());
+        }
+
+        virtual std::string format() const override {
+            return {"( Any arguments )"};
+        }
+
+    private:
+
+        virtual bool matches(const ArgumentsTuple<arglist...>&) {
+            return true;
+        }
+    };
+
+}
+
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    class RecordedMethodBody : public MethodInvocationHandler<R, arglist...>, public ActualInvocationsSource, public ActualInvocationsContainer {
+
+        struct MatchedInvocationHandler : ActualInvocationHandler<R, arglist...> {
+
+            virtual ~MatchedInvocationHandler() = default;
+
+            MatchedInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) :
+                    _matcher{matcher}, _invocationHandler{invocationHandler} {
+            }
+
+            virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
+            {
+                Destructible &destructable = *_invocationHandler;
+                ActualInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<ActualInvocationHandler<R, arglist...> &>(destructable);
+                return invocationHandler.handleMethodInvocation(args);
+            }
+
+            typename ActualInvocation<arglist...>::Matcher &getMatcher() const {
+                Destructible &destructable = *_matcher;
+                typename ActualInvocation<arglist...>::Matcher &matcher = dynamic_cast<typename ActualInvocation<arglist...>::Matcher &>(destructable);
+                return matcher;
+            }
+
+        private:
+            std::shared_ptr<Destructible> _matcher;
+            std::shared_ptr<Destructible> _invocationHandler;
+        };
+
+
+        FakeitContext &_fakeit;
+        MethodInfo _method;
+
+        std::vector<std::shared_ptr<Destructible>> _invocationHandlers;
+        std::vector<std::shared_ptr<Destructible>> _actualInvocations;
+
+        MatchedInvocationHandler *buildMatchedInvocationHandler(
+                typename ActualInvocation<arglist...>::Matcher *invocationMatcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) {
+            return new MatchedInvocationHandler(invocationMatcher, invocationHandler);
+        }
+
+        MatchedInvocationHandler *getInvocationHandlerForActualArgs(ActualInvocation<arglist...> &invocation) {
+            for (auto i = _invocationHandlers.rbegin(); i != _invocationHandlers.rend(); ++i) {
+                std::shared_ptr<Destructible> curr = *i;
+                Destructible &destructable = *curr;
+                MatchedInvocationHandler &im = asMatchedInvocationHandler(destructable);
+                if (im.getMatcher().matches(invocation)) {
+                    return &im;
+                }
+            }
+            return nullptr;
+        }
+
+        MatchedInvocationHandler &asMatchedInvocationHandler(Destructible &destructable) {
+            MatchedInvocationHandler &im = dynamic_cast<MatchedInvocationHandler &>(destructable);
+            return im;
+        }
+
+        ActualInvocation<arglist...> &asActualInvocation(Destructible &destructable) const {
+            ActualInvocation<arglist...> &invocation = dynamic_cast<ActualInvocation<arglist...> &>(destructable);
+            return invocation;
+        }
+
+    public:
+
+        RecordedMethodBody(FakeitContext &fakeit, std::string name) :
+                _fakeit(fakeit), _method{MethodInfo::nextMethodOrdinal(), name} { }
+
+        virtual ~RecordedMethodBody() NO_THROWS {
+        }
+
+        MethodInfo &getMethod() {
+            return _method;
+        }
+
+        bool isOfMethod(MethodInfo &method) {
+
+            return method.id() == _method.id();
+        }
+
+        void addMethodInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+            ActualInvocationHandler<R, arglist...> *invocationHandler) {
+            ActualInvocationHandler<R, arglist...> *mock = buildMatchedInvocationHandler(matcher, invocationHandler);
+            std::shared_ptr<Destructible> destructable{mock};
+            _invocationHandlers.push_back(destructable);
+        }
+
+        void reset() {
+            _invocationHandlers.clear();
+            _actualInvocations.clear();
+        }
+
+		void clear() override {
+			_actualInvocations.clear();
+		}
+
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
+            unsigned int ordinal = Invocation::nextInvocationOrdinal();
+            MethodInfo &method = this->getMethod();
+            auto actualInvocation = new ActualInvocation<arglist...>(ordinal, method, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+
+
+            std::shared_ptr<Destructible> actualInvocationDtor{actualInvocation};
+
+            auto invocationHandler = getInvocationHandlerForActualArgs(*actualInvocation);
+            if (invocationHandler) {
+                auto &matcher = invocationHandler->getMatcher();
+                actualInvocation->setActualMatcher(&matcher);
+                _actualInvocations.push_back(actualInvocationDtor);
+                try {
+                    return invocationHandler->handleMethodInvocation(actualInvocation->getActualArguments());
+                } catch (NoMoreRecordedActionException &) {
+                }
+            }
+
+            UnexpectedMethodCallEvent event(UnexpectedType::Unmatched, *actualInvocation);
+            _fakeit.handle(event);
+            std::string format{_fakeit.format(event)};
+            UnexpectedMethodCallException e(format);
+            throw e;
+        }
+
+        void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) {
+            for (auto destructablePtr : _actualInvocations) {
+                ActualInvocation<arglist...> &invocation = asActualInvocation(*destructablePtr);
+                scanner(invocation);
+            }
+        }
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            for (auto destructablePtr : _actualInvocations) {
+                Invocation &invocation = asActualInvocation(*destructablePtr);
+                into.insert(&invocation);
+            }
+        }
+
+        void setMethodDetails(const std::string &mockName, const std::string &methodName) {
+            const std::string fullName{mockName + "." + methodName};
+            _method.setName(fullName);
+        }
+
+    };
+
+}
+#include <functional>
+#include <type_traits>
+#include <stdexcept>
+#include <utility>
+#include <functional>
+#include <type_traits>
+
+namespace fakeit {
+
+    struct Quantity {
+        Quantity(const int q) :
+                quantity(q) {
+        }
+
+        const int quantity;
+    } static Once(1);
+
+    template<typename R>
+    struct Quantifier : public Quantity {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
+        }
+
+        const R &value;
+    };
+
+    template<>
+    struct Quantifier<void> : public Quantity {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
+        }
+    };
+
+    struct QuantifierFunctor : public Quantifier<void> {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
+        }
+
+        template<typename R>
+        Quantifier<R> operator()(const R &value) {
+            return Quantifier<R>(quantity, value);
+        }
+    };
+
+    template<int q>
+    struct Times : public Quantity {
+
+        Times<q>() : Quantity(q) { }
+
+        template<typename R>
+        static Quantifier<R> of(const R &value) {
+            return Quantifier<R>(q, value);
+        }
+
+        static Quantifier<void> Void() {
+            return Quantifier<void>(q);
+        }
+    };
+
+#if defined (__GNUG__) || (_MSC_VER >= 1900)
+
+    inline QuantifierFunctor operator
+    ""
+
+    _Times(unsigned long long n) {
+        return QuantifierFunctor((int) n);
+    }
+
+    inline QuantifierFunctor operator
+    ""
+
+    _Time(unsigned long long n) {
+        if (n != 1)
+            throw std::invalid_argument("Only 1_Time is supported. Use X_Times (with s) if X is bigger than 1");
+        return QuantifierFunctor((int) n);
+    }
+
+#endif
+
+}
+#include <functional>
+#include <atomic>
+#include <tuple>
+#include <type_traits>
+
+
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    struct Action : Destructible {
+        virtual R invoke(const ArgumentsTuple<arglist...> &) = 0;
+
+        virtual bool isDone() = 0;
+    };
+
+    template<typename R, typename ... arglist>
+    struct Repeat : Action<R, arglist...> {
+        virtual ~Repeat() = default;
+
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func), times(1) {
+        }
+
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
+        }
+
+        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+            times--;
+            return TupleDispatcher::invoke<R, arglist...>(f, args);
+        }
+
+        virtual bool isDone() override {
+            return times == 0;
+        }
+
+    private:
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
+        long times;
+    };
+
+    template<typename R, typename ... arglist>
+    struct RepeatForever : public Action<R, arglist...> {
+
+        virtual ~RepeatForever() = default;
+
+        RepeatForever(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func) {
+        }
+
+        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+            return TupleDispatcher::invoke<R, arglist...>(f, args);
+        }
+
+        virtual bool isDone() override {
+            return false;
+        }
+
+    private:
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
+    };
+
+    template<typename R, typename ... arglist>
+    struct ReturnDefaultValue : public Action<R, arglist...> {
+        virtual ~ReturnDefaultValue() = default;
+
+        virtual R invoke(const ArgumentsTuple<arglist...> &) override {
+            return DefaultValue<R>::value();
+        }
+
+        virtual bool isDone() override {
+            return false;
+        }
+    };
+
+    template<typename R, typename ... arglist>
+    struct ReturnDelegateValue : public Action<R, arglist...> {
+
+        ReturnDelegateValue(std::function<R(const typename fakeit::test_arg<arglist>::type...)> delegate) : _delegate(delegate) { }
+
+        virtual ~ReturnDelegateValue() = default;
+
+        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+            return TupleDispatcher::invoke<R, arglist...>(_delegate, args);
+        }
+
+        virtual bool isDone() override {
+            return false;
+        }
+
+    private:
+        std::function<R(const typename fakeit::test_arg<arglist>::type...)> _delegate;
+    };
+
+}
+
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    struct MethodStubbingProgress {
+
+        virtual ~MethodStubbingProgress() THROWS {
+        }
+
+        template<typename U = R>
+        typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
+        Return(const R &r) {
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        template<typename U = R>
+        typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
+        Return(const R &r) {
+            return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        MethodStubbingProgress<R, arglist...> &
+        Return(const Quantifier<R> &q) {
+            const R &value = q.value;
+            auto method = [value](const arglist &...) -> R { return value; };
+            return DoImpl(new Repeat<R, arglist...>(method, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<R, arglist...> &
+        Return(const first &f, const second &s, const tail &... t) {
+            Return(f);
+            return Return(s, t...);
+        }
+
+
+        template<typename U = R>
+        typename std::enable_if<!std::is_reference<U>::value, void>::type
+        AlwaysReturn(const R &r) {
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        template<typename U = R>
+        typename std::enable_if<std::is_reference<U>::value, void>::type
+        AlwaysReturn(const R &r) {
+            return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        MethodStubbingProgress<R, arglist...> &
+        Return() {
+            return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
+        }
+
+        void AlwaysReturn() {
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
+        }
+
+        template<typename E>
+        MethodStubbingProgress<R, arglist...> &Throw(const E &e) {
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
+        }
+
+        template<typename E>
+        MethodStubbingProgress<R, arglist...> &
+        Throw(const Quantifier<E> &q) {
+            const E &value = q.value;
+            auto method = [value](const arglist &...) -> R { throw value; };
+            return DoImpl(new Repeat<R, arglist...>(method, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<R, arglist...> &
+        Throw(const first &f, const second &s, const tail &... t) {
+            Throw(f);
+            return Throw(s, t...);
+        }
+
+        template<typename E>
+        void AlwaysThrow(const E &e) {
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
+        }
+
+        virtual MethodStubbingProgress<R, arglist...> &
+            Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<R, arglist...>(method));
+        }
+
+        template<typename F>
+        MethodStubbingProgress<R, arglist...> &
+        Do(const Quantifier<F> &q) {
+            return DoImpl(new Repeat<R, arglist...>(q.value, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<R, arglist...> &
+        Do(const first &f, const second &s, const tail &... t) {
+            Do(f);
+            return Do(s, t...);
+        }
+
+        virtual void AlwaysDo(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+            DoImpl(new RepeatForever<R, arglist...>(method));
+        }
+
+    protected:
+
+        virtual MethodStubbingProgress<R, arglist...> &DoImpl(Action<R, arglist...> *action) = 0;
+
+    private:
+        MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+    };
+
+
+    template<typename ... arglist>
+    struct MethodStubbingProgress<void, arglist...> {
+
+        virtual ~MethodStubbingProgress() THROWS {
+        }
+
+        MethodStubbingProgress<void, arglist...> &Return() {
+            auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
+                return DefaultValue<void>::value();
+            };
+            return Do(lambda);
+        }
+
+        virtual MethodStubbingProgress<void, arglist...> &Do(
+            std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<void, arglist...>(method));
+        }
+
+
+        void AlwaysReturn() {
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> void { return DefaultValue<void>::value(); });
+        }
+
+        MethodStubbingProgress<void, arglist...> &
+        Return(const Quantifier<void> &q) {
+            auto method = [](const arglist &...) -> void { return DefaultValue<void>::value(); };
+            return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
+        }
+
+        template<typename E>
+        MethodStubbingProgress<void, arglist...> &Throw(const E &e) {
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
+        }
+
+        template<typename E>
+        MethodStubbingProgress<void, arglist...> &
+        Throw(const Quantifier<E> &q) {
+            const E &value = q.value;
+            auto method = [value](const typename fakeit::test_arg<arglist>::type...) -> void { throw value; };
+            return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<void, arglist...> &
+        Throw(const first &f, const second &s, const tail &... t) {
+            Throw(f);
+            return Throw(s, t...);
+        }
+
+        template<typename E>
+        void AlwaysThrow(const E e) {
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
+        }
+
+           template<typename F>
+        MethodStubbingProgress<void, arglist...> &
+        Do(const Quantifier<F> &q) {
+            return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<void, arglist...> &
+        Do(const first &f, const second &s, const tail &... t) {
+            Do(f);
+            return Do(s, t...);
+        }
+
+        virtual void AlwaysDo(std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            DoImpl(new RepeatForever<void, arglist...>(method));
+        }
+
+    protected:
+
+        virtual MethodStubbingProgress<void, arglist...> &DoImpl(Action<void, arglist...> *action) = 0;
+
+    private:
+        MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+    };
+
+
+}
+#include <vector>
+#include <functional>
+
+namespace fakeit {
+
+    class Finally {
+    private:
+        std::function<void()> _finallyClause;
+
+        Finally(const Finally &);
+
+        Finally &operator=(const Finally &);
+
+    public:
+        explicit Finally(std::function<void()> f) :
+                _finallyClause(f) {
+        }
+
+        ~Finally() {
+            _finallyClause();
+        }
+    };
+}
+
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    struct ActionSequence : ActualInvocationHandler<R,arglist...> {
+
+        ActionSequence() {
+            clear();
+        }
+
+        void AppendDo(Action<R, arglist...> *action) {
+            append(action);
+        }
+
+        virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
+        {
+            std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
+            Destructible &destructable = *destructablePtr;
+            Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
+            std::function<void()> finallyClause = [&]() -> void {
+                if (action.isDone())
+                    _recordedActions.erase(_recordedActions.begin());
+            };
+            Finally onExit(finallyClause);
+            return action.invoke(args);
+        }
+
+    private:
+
+        struct NoMoreRecordedAction : Action<R, arglist...> {
+
+
+
+
+
+
+
+            virtual R invoke(const ArgumentsTuple<arglist...> &) override {
+                throw NoMoreRecordedActionException();
+            }
+
+            virtual bool isDone() override {
+                return false;
+            }
+        };
+
+        void append(Action<R, arglist...> *action) {
+            std::shared_ptr<Destructible> destructable{action};
+            _recordedActions.insert(_recordedActions.end() - 1, destructable);
+        }
+
+        void clear() {
+            _recordedActions.clear();
+            auto actionPtr = std::shared_ptr<Destructible> {new NoMoreRecordedAction()};
+            _recordedActions.push_back(actionPtr);
+        }
+
+        std::vector<std::shared_ptr<Destructible>> _recordedActions;
+    };
+
+}
+
+namespace fakeit {
+
+    template<typename C, typename DATA_TYPE>
+    class DataMemberStubbingRoot {
+    private:
+
+    public:
+        DataMemberStubbingRoot(const DataMemberStubbingRoot &) = default;
+
+        DataMemberStubbingRoot() = default;
+
+        void operator=(const DATA_TYPE&) {
+        }
+    };
+
+}
+#include <functional>
+#include <utility>
+#include <type_traits>
+#include <tuple>
+#include <memory>
+#include <vector>
+#include <unordered_set>
+#include <set>
+#include <iosfwd>
+
+namespace fakeit {
+
+    struct Xaction {
+        virtual void commit() = 0;
+    };
+}
+
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    struct SpyingContext : Xaction {
+        virtual void appendAction(Action<R, arglist...> *action) = 0;
+
+        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
+    };
+}
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    struct StubbingContext : public Xaction {
+        virtual void appendAction(Action<R, arglist...> *action) = 0;
+    };
+}
+#include <functional>
+#include <type_traits>
+#include <tuple>
+#include <memory>
+#include <vector>
+#include <unordered_set>
+
+
+namespace fakeit {
+
+    template<unsigned int index, typename ... arglist>
+    class MatchersCollector {
+
+        std::vector<Destructible *> &_matchers;
+
+    public:
+
+
+        template<std::size_t N>
+        using ArgType = typename std::tuple_element<N, std::tuple<arglist...>>::type;
+
+        template<std::size_t N>
+        using NakedArgType = typename naked_type<ArgType<index>>::type;
+
+        template<std::size_t N>
+        using ArgMatcherCreatorType = decltype(std::declval<TypedMatcherCreator<NakedArgType<N>>>());
+
+        MatchersCollector(std::vector<Destructible *> &matchers)
+                : _matchers(matchers) {
+        }
+
+        void CollectMatchers() {
+        }
+
+        template<typename Head>
+        typename std::enable_if<
+                std::is_constructible<NakedArgType<index>, Head>::value, void>
+        ::type CollectMatchers(const Head &value) {
+
+            TypedMatcher<NakedArgType<index>> *d = Eq<NakedArgType<index>>(value).createMatcher();
+            _matchers.push_back(d);
+        }
+
+        template<typename Head, typename ...Tail>
+        typename std::enable_if<
+                std::is_constructible<NakedArgType<index>, Head>::value
+                , void>
+        ::type CollectMatchers(const Head &head, const Tail &... tail) {
+            CollectMatchers(head);
+            MatchersCollector<index + 1, arglist...> c(_matchers);
+            c.CollectMatchers(tail...);
+        }
+
+        template<typename Head>
+        typename std::enable_if<
+                std::is_base_of<TypedMatcherCreator<NakedArgType<index>>, Head>::value, void>
+        ::type CollectMatchers(const Head &creator) {
+            TypedMatcher<NakedArgType<index>> *d = creator.createMatcher();
+            _matchers.push_back(d);
+        }
+
+        template<typename Head, typename ...Tail>
+
+        typename std::enable_if<
+                std::is_base_of<TypedMatcherCreator<NakedArgType<index>>, Head>::value, void>
+        ::type CollectMatchers(const Head &head, const Tail &... tail) {
+            CollectMatchers(head);
+            MatchersCollector<index + 1, arglist...> c(_matchers);
+            c.CollectMatchers(tail...);
+        }
+
+        template<typename Head>
+        typename std::enable_if<
+                std::is_same<AnyMatcher, Head>::value, void>
+        ::type CollectMatchers(const Head &) {
+            TypedMatcher<NakedArgType<index>> *d = Any<NakedArgType<index>>().createMatcher();
+            _matchers.push_back(d);
+        }
+
+        template<typename Head, typename ...Tail>
+        typename std::enable_if<
+                std::is_same<AnyMatcher, Head>::value, void>
+        ::type CollectMatchers(const Head &head, const Tail &... tail) {
+            CollectMatchers(head);
+            MatchersCollector<index + 1, arglist...> c(_matchers);
+            c.CollectMatchers(tail...);
+        }
+
+    };
+
+}
+
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    class MethodMockingContext :
+            public Sequence,
+            public ActualInvocationsSource,
+            public virtual StubbingContext<R, arglist...>,
+            public virtual SpyingContext<R, arglist...>,
+            private Invocation::Matcher {
+    public:
+
+        struct Context : Destructible {
+
+
+            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
+
+            virtual std::string getMethodName() = 0;
+
+            virtual void addMethodInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) = 0;
+
+            virtual void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) = 0;
+
+            virtual void setMethodDetails(std::string mockName, std::string methodName) = 0;
+
+            virtual bool isOfMethod(MethodInfo &method) = 0;
+
+            virtual ActualInvocationsSource &getInvolvedMock() = 0;
+        };
+
+    private:
+        class Implementation {
+
+            Context *_stubbingContext;
+            ActionSequence<R, arglist...> *_recordedActionSequence;
+            typename ActualInvocation<arglist...>::Matcher *_invocationMatcher;
+            bool _commited;
+
+            Context &getStubbingContext() const {
+                return *_stubbingContext;
+            }
+
+        public:
+
+            Implementation(Context *stubbingContext)
+                    : _stubbingContext(stubbingContext),
+                      _recordedActionSequence(new ActionSequence<R, arglist...>()),
+                      _invocationMatcher
+                              {
+                                      new DefaultInvocationMatcher<arglist...>()}, _commited(false) {
+            }
+
+            ~Implementation() {
+                delete _stubbingContext;
+                if (!_commited) {
+
+                    delete _recordedActionSequence;
+                    delete _invocationMatcher;
+                }
+            }
+
+            ActionSequence<R, arglist...> &getRecordedActionSequence() {
+                return *_recordedActionSequence;
+            }
+
+            std::string format() const {
+                std::string s = getStubbingContext().getMethodName();
+                s += _invocationMatcher->format();
+                return s;
+            }
+
+            void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+                auto scanner = [&](ActualInvocation<arglist...> &a) {
+                    if (_invocationMatcher->matches(a)) {
+                        into.insert(&a);
+                    }
+                };
+                getStubbingContext().scanActualInvocations(scanner);
+            }
+
+
+            bool matches(Invocation &invocation) {
+                MethodInfo &actualMethod = invocation.getMethod();
+                if (!getStubbingContext().isOfMethod(actualMethod)) {
+                    return false;
+                }
+
+                ActualInvocation<arglist...> &actualInvocation = dynamic_cast<ActualInvocation<arglist...> &>(invocation);
+                return _invocationMatcher->matches(actualInvocation);
+            }
+
+            void commit() {
+                getStubbingContext().addMethodInvocationHandler(_invocationMatcher, _recordedActionSequence);
+                _commited = true;
+            }
+
+            void appendAction(Action<R, arglist...> *action) {
+                getRecordedActionSequence().AppendDo(action);
+            }
+
+            void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+                appendAction(new RepeatForever<R, arglist...>(method));
+                commit();
+            }
+
+            void setMethodDetails(std::string mockName, std::string methodName) {
+                getStubbingContext().setMethodDetails(mockName, methodName);
+            }
+
+            void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const {
+                into.push_back(&getStubbingContext().getInvolvedMock());
+            }
+
+            typename std::function<R(arglist &...)> getOriginalMethod() {
+                return getStubbingContext().getOriginalMethod();
+            }
+
+            void setInvocationMatcher(typename ActualInvocation<arglist...>::Matcher *matcher) {
+                delete _invocationMatcher;
+                _invocationMatcher = matcher;
+            }
+        };
+
+    protected:
+
+        MethodMockingContext(Context *stubbingContext)
+                : _impl{new Implementation(stubbingContext)} {
+        }
+
+        MethodMockingContext(MethodMockingContext &) = default;
+
+
+
+        MethodMockingContext(MethodMockingContext &&other)
+                : _impl(std::move(other._impl)) {
+        }
+
+        virtual ~MethodMockingContext() NO_THROWS { }
+
+        std::string format() const override {
+            return _impl->format();
+        }
+
+        unsigned int size() const override {
+            return 1;
+        }
+
+
+        void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
+            _impl->getInvolvedMocks(into);
+        }
+
+        void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const override {
+            const Invocation::Matcher *b = this;
+            Invocation::Matcher *c = const_cast<Invocation::Matcher *>(b);
+            into.push_back(c);
+        }
+
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            _impl->getActualInvocations(into);
+        }
+
+
+        bool matches(Invocation &invocation) override {
+            return _impl->matches(invocation);
+        }
+
+        void commit() override {
+            _impl->commit();
+        }
+
+        void setMethodDetails(std::string mockName, std::string methodName) {
+            _impl->setMethodDetails(mockName, methodName);
+        }
+
+        void setMatchingCriteria(std::function<bool(arglist &...)> predicate) {
+            typename ActualInvocation<arglist...>::Matcher *matcher{
+                    new UserDefinedInvocationMatcher<arglist...>(predicate)};
+            _impl->setInvocationMatcher(matcher);
+        }
+
+        void setMatchingCriteria(const std::vector<Destructible *> &matchers) {
+            typename ActualInvocation<arglist...>::Matcher *matcher{
+                    new ArgumentsMatcherInvocationMatcher<arglist...>(matchers)};
+            _impl->setInvocationMatcher(matcher);
+        }
+
+
+        void appendAction(Action<R, arglist...> *action) override {
+            _impl->appendAction(action);
+        }
+
+        void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+            _impl->setMethodBodyByAssignment(method);
+        }
+
+        template<class ...matcherCreators, class = typename std::enable_if<
+                sizeof...(matcherCreators) == sizeof...(arglist)>::type>
+        void setMatchingCriteria(const matcherCreators &... matcherCreator) {
+            std::vector<Destructible *> matchers;
+
+            MatchersCollector<0, arglist...> c(matchers);
+            c.CollectMatchers(matcherCreator...);
+
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(matchers);
+        }
+
+    private:
+
+        typename std::function<R(arglist&...)> getOriginalMethod() override {
+            return _impl->getOriginalMethod();
+        }
+
+        std::shared_ptr<Implementation> _impl;
+    };
+
+    template<typename R, typename ... arglist>
+    class MockingContext :
+            public MethodMockingContext<R, arglist...> {
+        MockingContext &operator=(const MockingContext &) = delete;
+
+    public:
+
+        MockingContext(typename MethodMockingContext<R, arglist...>::Context *stubbingContext)
+                : MethodMockingContext<R, arglist...>(stubbingContext) {
+        }
+
+        MockingContext(MockingContext &) = default;
+
+        MockingContext(MockingContext &&other)
+                : MethodMockingContext<R, arglist...>(std::move(other)) {
+        }
+
+        MockingContext<R, arglist...> &setMethodDetails(std::string mockName, std::string methodName) {
+            MethodMockingContext<R, arglist...>::setMethodDetails(mockName, methodName);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &Using(const arglist &... args) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        template<class ...arg_matcher>
+        MockingContext<R, arglist...> &Using(const arg_matcher &... arg_matchers) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(arg_matchers...);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &operator()(const arglist &... args) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        void operator=(std::function<R(arglist &...)> method) {
+            MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
+        }
+
+        template<typename U = R>
+        typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R &r) {
+            auto method = [r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
+            MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
+        }
+
+        template<typename U = R>
+        typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R &r) {
+            auto method = [&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
+            MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
+        }
+    };
+
+    template<typename ... arglist>
+    class MockingContext<void, arglist...> :
+            public MethodMockingContext<void, arglist...> {
+        MockingContext &operator=(const MockingContext &) = delete;
+
+    public:
+
+        MockingContext(typename MethodMockingContext<void, arglist...>::Context *stubbingContext)
+                : MethodMockingContext<void, arglist...>(stubbingContext) {
+        }
+
+        MockingContext(MockingContext &) = default;
+
+        MockingContext(MockingContext &&other)
+                : MethodMockingContext<void, arglist...>(std::move(other)) {
+        }
+
+        MockingContext<void, arglist...> &setMethodDetails(std::string mockName, std::string methodName) {
+            MethodMockingContext<void, arglist...>::setMethodDetails(mockName, methodName);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &Using(const arglist &... args) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        template<class ...arg_matcher>
+        MockingContext<void, arglist...> &Using(const arg_matcher &... arg_matchers) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(arg_matchers...);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &operator()(const arglist &... args) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        void operator=(std::function<void(arglist &...)> method) {
+            MethodMockingContext<void, arglist...>::setMethodBodyByAssignment(method);
+        }
+
+    };
+
+    class DtorMockingContext : public MethodMockingContext<void> {
+    public:
+
+        DtorMockingContext(MethodMockingContext<void>::Context *stubbingContext)
+                : MethodMockingContext<void>(stubbingContext) {
+        }
+
+        DtorMockingContext(DtorMockingContext &other) : MethodMockingContext<void>(other) {
+        }
+
+        DtorMockingContext(DtorMockingContext &&other) : MethodMockingContext<void>(std::move(other)) {
+        }
+
+        void operator=(std::function<void()> method) {
+            MethodMockingContext<void>::setMethodBodyByAssignment(method);
+        }
+
+        DtorMockingContext &setMethodDetails(std::string mockName, std::string methodName) {
+            MethodMockingContext<void>::setMethodDetails(mockName, methodName);
+            return *this;
+        }
+    };
+
+}
+
+namespace fakeit {
+
+
+    template<typename C, typename ... baseclasses>
+    class MockImpl : private MockObject<C>, public virtual ActualInvocationsSource {
+    public:
+
+        MockImpl(FakeitContext &fakeit, C &obj)
+                : MockImpl<C, baseclasses...>(fakeit, obj, true) {
+        }
+
+        MockImpl(FakeitContext &fakeit)
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
+            fake->getVirtualTable().setCookie(1, this);
+        }
+
+        virtual ~MockImpl() NO_THROWS {
+            _proxy.detach();
+        }
+
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            std::vector<ActualInvocationsSource *> vec;
+            _proxy.getMethodMocks(vec);
+            for (ActualInvocationsSource *s : vec) {
+                s->getActualInvocations(into);
+            }
+        }
+
+	    void initDataMembersIfOwner()
+	    {
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
+			    fake->initializeDataMembersArea();
+		    }
+	    }
+
+	    void reset() {
+            _proxy.Reset();
+		    initDataMembersIfOwner();
+	    }
+
+		void clear()
+        {
+			std::vector<ActualInvocationsContainer *> vec;
+			_proxy.getMethodMocks(vec);
+			for (ActualInvocationsContainer *s : vec) {
+				s->clear();
+			}
+			initDataMembersIfOwner();
+        }
+
+        virtual C &get() override {
+            return _proxy.get();
+        }
+
+        virtual FakeitContext &getFakeIt() override {
+            return _fakeit;
+        }
+
+        template<class DATA_TYPE, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        DataMemberStubbingRoot<C, DATA_TYPE> stubDataMember(DATA_TYPE T::*member, const arglist &... ctorargs) {
+            _proxy.stubDataMember(member, ctorargs...);
+            return DataMemberStubbingRoot<T, DATA_TYPE>();
+        }
+
+        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
+            return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
+                   (*this, vMethod));
+        }
+
+        DtorMockingContext stubDtor() {
+            return DtorMockingContext(new DtorMockingContextImpl(*this));
+        }
+
+
+
+
+
+
+
+    private:
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
+        FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
+
+        template<typename R, typename ... arglist>
+        class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
+        protected:
+            MockImpl<C, baseclasses...> &_mock;
+
+            virtual RecordedMethodBody<R, arglist...> &getRecordedMethodBody() = 0;
+
+        public:
+            MethodMockingContextBase(MockImpl<C, baseclasses...> &mock) : _mock(mock) { }
+
+            virtual ~MethodMockingContextBase() = default;
+
+            void addMethodInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) {
+                getRecordedMethodBody().addMethodInvocationHandler(matcher, invocationHandler);
+            }
+
+            void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) {
+                getRecordedMethodBody().scanActualInvocations(scanner);
+            }
+
+            void setMethodDetails(std::string mockName, std::string methodName) {
+                getRecordedMethodBody().setMethodDetails(mockName, methodName);
+            }
+
+            bool isOfMethod(MethodInfo &method) {
+                return getRecordedMethodBody().isOfMethod(method);
+            }
+
+            ActualInvocationsSource &getInvolvedMock() {
+                return _mock;
+            }
+
+            std::string getMethodName() {
+                return getRecordedMethodBody().getMethod().name();
+            }
+
+        };
+
+        template<typename R, typename ... arglist>
+        class MethodMockingContextImpl : public MethodMockingContextBase<R, arglist...> {
+        protected:
+
+            R (C::*_vMethod)(arglist...);
+
+        public:
+            virtual ~MethodMockingContextImpl() = default;
+
+            MethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
+                    : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
+            }
+
+
+            virtual std::function<R(arglist&...)> getOriginalMethod() override {
+                void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
+                C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, std::forward<arglist>(args)...);
+                };
+            }
+        };
+
+
+        template<int id, typename R, typename ... arglist>
+        class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
+        protected:
+
+            virtual RecordedMethodBody<R, arglist...> &getRecordedMethodBody() override {
+                return MethodMockingContextBase<R, arglist...>::_mock.template stubMethodIfNotStubbed<id>(
+                        MethodMockingContextBase<R, arglist...>::_mock._proxy,
+                        MethodMockingContextImpl<R, arglist...>::_vMethod);
+            }
+
+        public:
+
+            UniqueMethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
+                    : MethodMockingContextImpl<R, arglist...>(mock, vMethod) {
+            }
+        };
+
+        class DtorMockingContextImpl : public MethodMockingContextBase<void> {
+
+        protected:
+
+            virtual RecordedMethodBody<void> &getRecordedMethodBody() override {
+                return MethodMockingContextBase<void>::_mock.stubDtorIfNotStubbed(
+                        MethodMockingContextBase<void>::_mock._proxy);
+            }
+
+        public:
+            virtual ~DtorMockingContextImpl() = default;
+
+            DtorMockingContextImpl(MockImpl<C, baseclasses...> &mock)
+                    : MethodMockingContextBase<void>(mock) {
+            }
+
+            virtual std::function<void()> getOriginalMethod() override {
+                C &instance = MethodMockingContextBase<void>::_mock.get();
+                return [=, &instance]() -> void {
+                };
+            }
+
+        };
+
+        static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
+            MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
+                    1));
+            return mock;
+        }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
+
+        void unmocked() {
+            ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
+            UnexpectedMethodCallEvent event(UnexpectedType::Unmocked, invocation);
+            auto &fakeit = getMockImpl(this)->_fakeit;
+            fakeit.handle(event);
+
+            std::string format = fakeit.format(event);
+            UnexpectedMethodCallException e(format);
+            throw e;
+        }
+
+        static C *createFakeInstance() {
+            FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
+            void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
+        }
+
+        template<typename R, typename ... arglist>
+        void *getOriginalMethod(R (C::*vMethod)(arglist...)) {
+            auto vt = _proxy.getOriginalVT();
+            auto offset = VTUtils::getOffset(vMethod);
+            void *origMethodPtr = vt.getMethod(offset);
+            return origMethodPtr;
+        }
+
+        void *getOriginalDtor() {
+            auto vt = _proxy.getOriginalVT();
+            auto offset = VTUtils::getDestructorOffset<C>();
+            void *origMethodPtr = vt.getMethod(offset);
+            return origMethodPtr;
+        }
+
+        template<unsigned int id, typename R, typename ... arglist>
+        RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
+                                                                  R (C::*vMethod)(arglist...)) {
+            if (!proxy.isMethodStubbed(vMethod)) {
+                proxy.template stubMethod<id>(vMethod, createRecordedMethodBody < R, arglist... > (*this, vMethod));
+            }
+            Destructible *d = proxy.getMethodMock(vMethod);
+            RecordedMethodBody<R, arglist...> *methodMock = dynamic_cast<RecordedMethodBody<R, arglist...> *>(d);
+            return *methodMock;
+        }
+
+        RecordedMethodBody<void> &stubDtorIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy) {
+            if (!proxy.isDtorStubbed()) {
+                proxy.stubDtor(createRecordedDtorBody(*this));
+            }
+            Destructible *d = proxy.getDtorMock();
+            RecordedMethodBody<void> *dtorMock = dynamic_cast<RecordedMethodBody<void> *>(d);
+            return *dtorMock;
+        }
+
+        template<typename R, typename ... arglist>
+        static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
+                                                                           R(C::*vMethod)(arglist...)) {
+            return new RecordedMethodBody<R, arglist...>(mock.getFakeIt(), typeid(vMethod).name());
+        }
+
+        static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
+            return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
+        }
+    };
+}
+namespace fakeit {
+
+    template<typename R, typename... Args>
+    struct Prototype;
+
+    template<typename R, typename... Args>
+    struct Prototype<R(Args...)> {
+
+        typedef R Type(Args...);
+
+        typedef R ConstType(Args...) const;
+
+        template<class C>
+        struct MemberType {
+
+            typedef Type(C::*type);
+            typedef ConstType(C::*cosntType);
+
+            static type get(type t) {
+                return t;
+            }
+
+            static cosntType getconst(cosntType t) {
+                return t;
+            }
+
+        };
+
+    };
+
+    template<int X, typename R, typename C, typename... arglist>
+    struct UniqueMethod {
+        R (C::*method)(arglist...);
+
+        UniqueMethod(R (C::*vMethod)(arglist...)) : method(vMethod) { }
+
+        int uniqueId() {
+            return X;
+        }
+
+
+
+
+    };
+
+}
+
+
+namespace fakeit {
+    namespace internal {
+    }
+    using namespace fakeit::internal;
+
+    template<typename C, typename ... baseclasses>
+    class Mock : public ActualInvocationsSource {
+        MockImpl<C, baseclasses...> impl;
+    public:
+        virtual ~Mock() = default;
+
+        static_assert(std::is_polymorphic<C>::value, "Can only mock a polymorphic type");
+
+        Mock() : impl(Fakeit) {
+        }
+
+        explicit Mock(C &obj) : impl(Fakeit, obj) {
+        }
+
+        virtual C &get() {
+            return impl.get();
+        }
+
+
+
+
+
+		C &operator()() {
+            return get();
+        }
+
+        void Reset() {
+            impl.reset();
+        }
+
+		void ClearInvocationHistory() {
+			impl.clear();
+		}
+
+        template<class DATA_TYPE, typename ... arglist,
+                class = typename std::enable_if<std::is_member_object_pointer<DATA_TYPE C::*>::value>::type>
+        DataMemberStubbingRoot<C, DATA_TYPE> Stub(DATA_TYPE C::* member, const arglist &... ctorargs) {
+            return impl.stubDataMember(member, ctorargs...);
+        }
+
+        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
+            return impl.template stubMethod<id>(vMethod);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        DtorMockingContext dtor() {
+            return impl.stubDtor();
+        }
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            impl.getActualInvocations(into);
+        }
+
+    };
+
+}
+
+#include <exception>
+
+namespace fakeit {
+
+    class RefCount {
+    private:
+        int count;
+
+    public:
+        void AddRef() {
+            count++;
+        }
+
+        int Release() {
+            return --count;
+        }
+    };
+
+    template<typename T>
+    class smart_ptr {
+    private:
+        T *pData;
+        RefCount *reference;
+
+    public:
+        smart_ptr() : pData(0), reference(0) {
+            reference = new RefCount();
+            reference->AddRef();
+        }
+
+        smart_ptr(T *pValue) : pData(pValue), reference(0) {
+            reference = new RefCount();
+            reference->AddRef();
+        }
+
+        smart_ptr(const smart_ptr<T> &sp) : pData(sp.pData), reference(sp.reference) {
+            reference->AddRef();
+        }
+
+        ~smart_ptr() THROWS {
+            if (reference->Release() == 0) {
+                delete reference;
+                delete pData;
+            }
+        }
+
+        T &operator*() {
+            return *pData;
+        }
+
+        T *operator->() {
+            return pData;
+        }
+
+        smart_ptr<T> &operator=(const smart_ptr<T> &sp) {
+            if (this != &sp) {
+
+
+                if (reference->Release() == 0) {
+                    delete reference;
+                    delete pData;
+                }
+
+
+
+                pData = sp.pData;
+                reference = sp.reference;
+                reference->AddRef();
+            }
+            return *this;
+        }
+    };
+
+}
+
+namespace fakeit {
+
+    class WhenFunctor {
+
+        struct StubbingChange {
+
+            friend class WhenFunctor;
+
+            virtual ~StubbingChange() THROWS {
+
+                if (UncaughtException()) {
+                    return;
+                }
+
+                _xaction.commit();
+            }
+
+            StubbingChange(StubbingChange &other) :
+                    _xaction(other._xaction) {
+            }
+
+        private:
+
+            StubbingChange(Xaction &xaction)
+                    : _xaction(xaction) {
+            }
+
+            Xaction &_xaction;
+        };
+
+    public:
+
+        template<typename R, typename ... arglist>
+        struct MethodProgress : MethodStubbingProgress<R, arglist...> {
+
+            friend class WhenFunctor;
+
+            virtual ~MethodProgress() override = default;
+
+            MethodProgress(MethodProgress &other) :
+                    _progress(other._progress), _context(other._context) {
+            }
+
+            MethodProgress(StubbingContext<R, arglist...> &xaction) :
+                    _progress(new StubbingChange(xaction)), _context(xaction) {
+            }
+
+        protected:
+
+            virtual MethodStubbingProgress<R, arglist...> &DoImpl(Action<R, arglist...> *action) override {
+                _context.appendAction(action);
+                return *this;
+            }
+
+        private:
+            smart_ptr<StubbingChange> _progress;
+            StubbingContext<R, arglist...> &_context;
+        };
+
+
+        WhenFunctor() {
+        }
+
+        template<typename R, typename ... arglist>
+        MethodProgress<R, arglist...> operator()(const StubbingContext<R, arglist...> &stubbingContext) {
+            StubbingContext<R, arglist...> &rootWithoutConst = const_cast<StubbingContext<R, arglist...> &>(stubbingContext);
+            MethodProgress<R, arglist...> progress(rootWithoutConst);
+            return progress;
+        }
+
+    };
+
+}
+namespace fakeit {
+
+    class FakeFunctor {
+    private:
+        template<typename R, typename ... arglist>
+        void fake(const StubbingContext<R, arglist...> &root) {
+            StubbingContext<R, arglist...> &rootWithoutConst = const_cast<StubbingContext<R, arglist...> &>(root);
+            rootWithoutConst.appendAction(new ReturnDefaultValue<R, arglist...>());
+            rootWithoutConst.commit();
+        }
+
+        void operator()() {
+        }
+
+    public:
+
+        template<typename H, typename ... M>
+        void operator()(const H &head, const M &... tail) {
+            fake(head);
+            this->operator()(tail...);
+        }
+
+    };
+
+}
+#include <set>
+#include <set>
+
+
+namespace fakeit {
+
+    struct InvocationUtils {
+
+        static void sortByInvocationOrder(std::unordered_set<Invocation *> &ivocations,
+                                          std::vector<Invocation *> &result) {
+            auto comparator = [](Invocation *a, Invocation *b) -> bool {
+                return a->getOrdinal() < b->getOrdinal();
+            };
+            std::set<Invocation *, bool (*)(Invocation *a, Invocation *b)> sortedIvocations(comparator);
+            for (auto i : ivocations)
+                sortedIvocations.insert(i);
+
+            for (auto i : sortedIvocations)
+                result.push_back(i);
+        }
+
+        static void collectActualInvocations(std::unordered_set<Invocation *> &actualInvocations,
+                                             std::vector<ActualInvocationsSource *> &invocationSources) {
+            for (auto source : invocationSources) {
+                source->getActualInvocations(actualInvocations);
+            }
+        }
+
+        static void selectNonVerifiedInvocations(std::unordered_set<Invocation *> &actualInvocations,
+                                                 std::unordered_set<Invocation *> &into) {
+            for (auto invocation : actualInvocations) {
+                if (!invocation->isVerified()) {
+                    into.insert(invocation);
+                }
+            }
+        }
+
+        static void collectInvocationSources(std::vector<ActualInvocationsSource *> &) {
+        }
+
+        template<typename ... list>
+        static void collectInvocationSources(std::vector<ActualInvocationsSource *> &into,
+                                             const ActualInvocationsSource &mock,
+                                             const list &... tail) {
+            into.push_back(const_cast<ActualInvocationsSource *>(&mock));
+            collectInvocationSources(into, tail...);
+        }
+
+        static void collectSequences(std::vector<Sequence *> &) {
+        }
+
+        template<typename ... list>
+        static void collectSequences(std::vector<Sequence *> &vec, const Sequence &sequence, const list &... tail) {
+            vec.push_back(&const_cast<Sequence &>(sequence));
+            collectSequences(vec, tail...);
+        }
+
+        static void collectInvolvedMocks(std::vector<Sequence *> &allSequences,
+                                         std::vector<ActualInvocationsSource *> &involvedMocks) {
+            for (auto sequence : allSequences) {
+                sequence->getInvolvedMocks(involvedMocks);
+            }
+        }
+
+        template<class T>
+        static T &remove_const(const T &s) {
+            return const_cast<T &>(s);
+        }
+
+    };
+
+}
+
+#include <memory>
+
+#include <vector>
+#include <unordered_set>
+
+namespace fakeit {
+    struct MatchAnalysis {
+        std::vector<Invocation *> actualSequence;
+        std::vector<Invocation *> matchedInvocations;
+        int count;
+
+        void run(InvocationsSourceProxy &involvedInvocationSources, std::vector<Sequence *> &expectedPattern) {
+            getActualInvocationSequence(involvedInvocationSources, actualSequence);
+            count = countMatches(expectedPattern, actualSequence, matchedInvocations);
+        }
+
+    private:
+        static void getActualInvocationSequence(InvocationsSourceProxy &involvedMocks,
+                                                std::vector<Invocation *> &actualSequence) {
+            std::unordered_set<Invocation *> actualInvocations;
+            collectActualInvocations(involvedMocks, actualInvocations);
+            InvocationUtils::sortByInvocationOrder(actualInvocations, actualSequence);
+        }
+
+        static int countMatches(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
+                                std::vector<Invocation *> &matchedInvocations) {
+            int end = -1;
+            int count = 0;
+            int startSearchIndex = 0;
+            while (findNextMatch(pattern, actualSequence, startSearchIndex, end, matchedInvocations)) {
+                count++;
+                startSearchIndex = end;
+            }
+            return count;
+        }
+
+        static void collectActualInvocations(InvocationsSourceProxy &involvedMocks,
+                                             std::unordered_set<Invocation *> &actualInvocations) {
+            involvedMocks.getActualInvocations(actualInvocations);
+        }
+
+        static bool findNextMatch(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
+                                  int startSearchIndex, int &end,
+                                  std::vector<Invocation *> &matchedInvocations) {
+            for (auto sequence : pattern) {
+                int index = findNextMatch(sequence, actualSequence, startSearchIndex);
+                if (index == -1) {
+                    return false;
+                }
+                collectMatchedInvocations(actualSequence, matchedInvocations, index, sequence->size());
+                startSearchIndex = index + sequence->size();
+            }
+            end = startSearchIndex;
+            return true;
+        }
+
+
+        static void collectMatchedInvocations(std::vector<Invocation *> &actualSequence,
+                                              std::vector<Invocation *> &matchedInvocations, int start,
+                                              int length) {
+            int indexAfterMatchedPattern = start + length;
+            for (; start < indexAfterMatchedPattern; start++) {
+                matchedInvocations.push_back(actualSequence[start]);
+            }
+        }
+
+
+        static bool isMatch(std::vector<Invocation *> &actualSequence,
+                            std::vector<Invocation::Matcher *> &expectedSequence, int start) {
+            bool found = true;
+            for (unsigned int j = 0; found && j < expectedSequence.size(); j++) {
+                Invocation *actual = actualSequence[start + j];
+                Invocation::Matcher *expected = expectedSequence[j];
+                found = found && expected->matches(*actual);
+            }
+            return found;
+        }
+
+        static int findNextMatch(Sequence *&pattern, std::vector<Invocation *> &actualSequence, int startSearchIndex) {
+            std::vector<Invocation::Matcher *> expectedSequence;
+            pattern->getExpectedSequence(expectedSequence);
+            for (int i = startSearchIndex; i < ((int) actualSequence.size() - (int) expectedSequence.size() + 1); i++) {
+                if (isMatch(actualSequence, expectedSequence, i)) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+    };
+}
+
+namespace fakeit {
+
+    struct SequenceVerificationExpectation {
+
+        friend class SequenceVerificationProgress;
+
+        ~SequenceVerificationExpectation() THROWS {
+            if (UncaughtException()) {
+                return;
+            }
+            VerifyExpectation(_fakeit);
+        }
+
+        void setExpectedPattern(std::vector<Sequence *> expectedPattern) {
+            _expectedPattern = expectedPattern;
+        }
+
+        void setExpectedCount(const int count) {
+            _expectedCount = count;
+        }
+
+        void setFileInfo(const char * file, int line, const char * callingMethod) {
+            _file = file;
+            _line = line;
+            _testMethod = callingMethod;
+        }
+
+    private:
+
+        VerificationEventHandler &_fakeit;
+        InvocationsSourceProxy _involvedInvocationSources;
+        std::vector<Sequence *> _expectedPattern;
+        int _expectedCount;
+
+        const char * _file;
+        int _line;
+		const char * _testMethod;
+        bool _isVerified;
+
+        SequenceVerificationExpectation(
+                VerificationEventHandler &fakeit,
+                InvocationsSourceProxy mocks,
+                std::vector<Sequence *> &expectedPattern) :
+                _fakeit(fakeit),
+                _involvedInvocationSources(mocks),
+                _expectedPattern(expectedPattern),
+                _expectedCount(-1),
+                _line(0),
+                _isVerified(false) {
+        }
+
+
+        void VerifyExpectation(VerificationEventHandler &verificationErrorHandler) {
+            if (_isVerified)
+                return;
+            _isVerified = true;
+
+            MatchAnalysis ma;
+            ma.run(_involvedInvocationSources, _expectedPattern);
+
+            if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
+                return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+            }
+
+            if (isExactVerification() && exactLimitNotMatched(ma.count)) {
+                return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+            }
+
+            markAsVerified(ma.matchedInvocations);
+        }
+
+        std::vector<Sequence *> &collectSequences(std::vector<Sequence *> &vec) {
+            return vec;
+        }
+
+        template<typename ... list>
+        std::vector<Sequence *> &collectSequences(std::vector<Sequence *> &vec, const Sequence &sequence,
+                                                  const list &... tail) {
+            vec.push_back(&const_cast<Sequence &>(sequence));
+            return collectSequences(vec, tail...);
+        }
+
+
+        static void markAsVerified(std::vector<Invocation *> &matchedInvocations) {
+            for (auto i : matchedInvocations) {
+                i->markAsVerified();
+            }
+        }
+
+        bool isAtLeastVerification() {
+
+            return _expectedCount < 0;
+        }
+
+        bool isExactVerification() {
+            return !isAtLeastVerification();
+        }
+
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
+        }
+
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
+        }
+
+        void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,
+                                          std::vector<Invocation *> actualSequence, int count) {
+            SequenceVerificationEvent evt(VerificationType::Exact, _expectedPattern, actualSequence, _expectedCount,
+                                          count);
+            evt.setFileInfo(_file, _line, _testMethod);
+            return verificationErrorHandler.handle(evt);
+        }
+
+        void handleAtLeastVerificationEvent(VerificationEventHandler &verificationErrorHandler,
+                                            std::vector<Invocation *> actualSequence, int count) {
+            SequenceVerificationEvent evt(VerificationType::AtLeast, _expectedPattern, actualSequence, -_expectedCount,
+                                          count);
+            evt.setFileInfo(_file, _line, _testMethod);
+            return verificationErrorHandler.handle(evt);
+        }
+
+    };
+
+}
+namespace fakeit {
+    class ThrowFalseEventHandler : public VerificationEventHandler {
+
+        void handle(const SequenceVerificationEvent &) override {
+            throw false;
+        }
+
+        void handle(const NoMoreInvocationsVerificationEvent &) override {
+            throw false;
+        }
+    };
+}
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+namespace fakeit {
+
+    template<typename T>
+    static std::string to_string(const T &n) {
+        std::ostringstream stm;
+        stm << n;
+        return stm.str();
+    }
+
+}
+
+
+namespace fakeit {
+
+    struct FakeitContext;
+
+    class SequenceVerificationProgress {
+
+        friend class UsingFunctor;
+
+        friend class VerifyFunctor;
+
+        friend class UsingProgress;
+
+        smart_ptr<SequenceVerificationExpectation> _expectationPtr;
+
+        SequenceVerificationProgress(SequenceVerificationExpectation *ptr) : _expectationPtr(ptr) {
+        }
+
+        SequenceVerificationProgress(
+                FakeitContext &fakeit,
+                InvocationsSourceProxy sources,
+                std::vector<Sequence *> &allSequences) :
+                SequenceVerificationProgress(new SequenceVerificationExpectation(fakeit, sources, allSequences)) {
+        }
+
+        virtual void verifyInvocations(const int times) {
+            _expectationPtr->setExpectedCount(times);
+        }
+
+        class Terminator {
+            smart_ptr<SequenceVerificationExpectation> _expectationPtr;
+
+            bool toBool() {
+                try {
+                    ThrowFalseEventHandler eh;
+                    _expectationPtr->VerifyExpectation(eh);
+                    return true;
+                }
+                catch (bool e) {
+                    return e;
+                }
+            }
+
+        public:
+            Terminator(smart_ptr<SequenceVerificationExpectation> expectationPtr) : _expectationPtr(expectationPtr) { };
+
+            operator bool() {
+                return toBool();
+            }
+
+            bool operator!() const { return !const_cast<Terminator *>(this)->toBool(); }
+        };
+
+    public:
+
+        ~SequenceVerificationProgress() THROWS { };
+
+        operator bool() const {
+            return Terminator(_expectationPtr);
+        }
+
+        bool operator!() const { return !Terminator(_expectationPtr); }
+
+        Terminator Never() {
+            Exactly(0);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Once() {
+            Exactly(1);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Twice() {
+            Exactly(2);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator AtLeastOnce() {
+            verifyInvocations(-1);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Exactly(const int times) {
+            if (times < 0) {
+                throw std::invalid_argument(std::string("bad argument times:").append(fakeit::to_string(times)));
+            }
+            verifyInvocations(times);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Exactly(const Quantity &q) {
+            Exactly(q.quantity);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator AtLeast(const int times) {
+            if (times < 0) {
+                throw std::invalid_argument(std::string("bad argument times:").append(fakeit::to_string(times)));
+            }
+            verifyInvocations(-times);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator AtLeast(const Quantity &q) {
+            AtLeast(q.quantity);
+            return Terminator(_expectationPtr);
+        }
+
+        SequenceVerificationProgress setFileInfo(const char * file, int line, const char * callingMethod) {
+            _expectationPtr->setFileInfo(file, line, callingMethod);
+            return *this;
+        }
+    };
+}
+
+namespace fakeit {
+
+    class UsingProgress {
+        fakeit::FakeitContext &_fakeit;
+        InvocationsSourceProxy _sources;
+
+        void collectSequences(std::vector<fakeit::Sequence *> &) {
+        }
+
+        template<typename ... list>
+        void collectSequences(std::vector<fakeit::Sequence *> &vec, const fakeit::Sequence &sequence,
+                              const list &... tail) {
+            vec.push_back(&const_cast<fakeit::Sequence &>(sequence));
+            collectSequences(vec, tail...);
+        }
+
+    public:
+
+        UsingProgress(fakeit::FakeitContext &fakeit, InvocationsSourceProxy source) :
+                _fakeit(fakeit),
+                _sources(source) {
+        }
+
+        template<typename ... list>
+        SequenceVerificationProgress Verify(const fakeit::Sequence &sequence, const list &... tail) {
+            std::vector<fakeit::Sequence *> allSequences;
+            collectSequences(allSequences, sequence, tail...);
+            SequenceVerificationProgress progress(_fakeit, _sources, allSequences);
+            return progress;
+        }
+
+    };
+}
+
+namespace fakeit {
+
+    class UsingFunctor {
+
+        friend class VerifyFunctor;
+
+        FakeitContext &_fakeit;
+
+    public:
+
+        UsingFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        template<typename ... list>
+        UsingProgress operator()(const ActualInvocationsSource &head, const list &... tail) {
+            std::vector<ActualInvocationsSource *> allMocks{&InvocationUtils::remove_const(head),
+                                                            &InvocationUtils::remove_const(tail)...};
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(allMocks)};
+            UsingProgress progress(_fakeit, aggregateInvocationsSource);
+            return progress;
+        }
+
+    };
+}
+#include <set>
+
+namespace fakeit {
+
+    class VerifyFunctor {
+
+        FakeitContext &_fakeit;
+
+
+    public:
+
+        VerifyFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        template<typename ... list>
+        SequenceVerificationProgress operator()(const Sequence &sequence, const list &... tail) {
+            std::vector<Sequence *> allSequences{&InvocationUtils::remove_const(sequence),
+                                                 &InvocationUtils::remove_const(tail)...};
+
+            std::vector<ActualInvocationsSource *> involvedSources;
+            InvocationUtils::collectInvolvedMocks(allSequences, involvedSources);
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(involvedSources)};
+
+            UsingProgress usingProgress(_fakeit, aggregateInvocationsSource);
+            return usingProgress.Verify(sequence, tail...);
+        }
+
+    };
+
+}
+#include <set>
+#include <memory>
+namespace fakeit {
+
+    class VerifyNoOtherInvocationsVerificationProgress {
+
+        friend class VerifyNoOtherInvocationsFunctor;
+
+        struct VerifyNoOtherInvocationsExpectation {
+
+            friend class VerifyNoOtherInvocationsVerificationProgress;
+
+            ~VerifyNoOtherInvocationsExpectation() THROWS {
+                if (UncaughtException()) {
+                    return;
+                }
+
+                VerifyExpectation(_fakeit);
+            }
+
+            void setFileInfo(const char * file, int line, const char * callingMethod) {
+                _file = file;
+                _line = line;
+                _callingMethod = callingMethod;
+            }
+
+        private:
+
+            VerificationEventHandler &_fakeit;
+            std::vector<ActualInvocationsSource *> _mocks;
+
+			const char * _file;
+            int _line;
+			const char * _callingMethod;
+            bool _isVerified;
+
+            VerifyNoOtherInvocationsExpectation(VerificationEventHandler &fakeit,
+                                                std::vector<ActualInvocationsSource *> mocks) :
+                    _fakeit(fakeit),
+                    _mocks(mocks),
+                    _line(0),
+                    _isVerified(false) {
+            }
+
+            VerifyNoOtherInvocationsExpectation(VerifyNoOtherInvocationsExpectation &other) = default;
+
+            void VerifyExpectation(VerificationEventHandler &verificationErrorHandler) {
+                if (_isVerified)
+                    return;
+                _isVerified = true;
+
+                std::unordered_set<Invocation *> actualInvocations;
+                InvocationUtils::collectActualInvocations(actualInvocations, _mocks);
+
+                std::unordered_set<Invocation *> nonVerifiedInvocations;
+                InvocationUtils::selectNonVerifiedInvocations(actualInvocations, nonVerifiedInvocations);
+
+                if (nonVerifiedInvocations.size() > 0) {
+                    std::vector<Invocation *> sortedNonVerifiedInvocations;
+                    InvocationUtils::sortByInvocationOrder(nonVerifiedInvocations, sortedNonVerifiedInvocations);
+
+                    std::vector<Invocation *> sortedActualInvocations;
+                    InvocationUtils::sortByInvocationOrder(actualInvocations, sortedActualInvocations);
+
+                    NoMoreInvocationsVerificationEvent evt(sortedActualInvocations, sortedNonVerifiedInvocations);
+                    evt.setFileInfo(_file, _line, _callingMethod);
+                    return verificationErrorHandler.handle(evt);
+                }
+            }
+
+        };
+
+        fakeit::smart_ptr<VerifyNoOtherInvocationsExpectation> _ptr;
+
+        VerifyNoOtherInvocationsVerificationProgress(VerifyNoOtherInvocationsExpectation *ptr) :
+                _ptr(ptr) {
+        }
+
+        VerifyNoOtherInvocationsVerificationProgress(FakeitContext &fakeit,
+                                                     std::vector<ActualInvocationsSource *> &invocationSources)
+                : VerifyNoOtherInvocationsVerificationProgress(
+                new VerifyNoOtherInvocationsExpectation(fakeit, invocationSources)
+        ) {
+        }
+
+        bool toBool() {
+            try {
+                ThrowFalseEventHandler ev;
+                _ptr->VerifyExpectation(ev);
+                return true;
+            }
+            catch (bool e) {
+                return e;
+            }
+        }
+
+    public:
+
+
+        ~VerifyNoOtherInvocationsVerificationProgress() THROWS {
+        };
+
+        VerifyNoOtherInvocationsVerificationProgress setFileInfo(const char * file, int line,
+			const char * callingMethod) {
+            _ptr->setFileInfo(file, line, callingMethod);
+            return *this;
+        }
+
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
+        }
+
+        bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }
+
+    };
+
+}
+
+
+namespace fakeit {
+    class VerifyNoOtherInvocationsFunctor {
+
+        FakeitContext &_fakeit;
+
+    public:
+
+        VerifyNoOtherInvocationsFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        void operator()() {
+        }
+
+        template<typename ... list>
+        VerifyNoOtherInvocationsVerificationProgress operator()(const ActualInvocationsSource &head,
+                                                                const list &... tail) {
+            std::vector<ActualInvocationsSource *> invocationSources{&InvocationUtils::remove_const(head),
+                                                                     &InvocationUtils::remove_const(tail)...};
+            VerifyNoOtherInvocationsVerificationProgress progress{_fakeit, invocationSources};
+            return progress;
+        }
+    };
+
+}
+namespace fakeit {
+
+    class SpyFunctor {
+    private:
+
+        template<typename R, typename ... arglist>
+        void spy(const SpyingContext<R, arglist...> &root) {
+            SpyingContext<R, arglist...> &rootWithoutConst = const_cast<SpyingContext<R, arglist...> &>(root);
+            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethod();
+            rootWithoutConst.appendAction(new ReturnDelegateValue<R, arglist...>(methodFromOriginalVT));
+            rootWithoutConst.commit();
+        }
+
+        void operator()() {
+        }
+
+    public:
+
+        template<typename H, typename ... M>
+        void operator()(const H &head, const M &... tail) {
+            spy(head);
+            this->operator()(tail...);
+        }
+
+    };
+
+}
+
+#include <vector>
+#include <set>
+
+namespace fakeit {
+    class VerifyUnverifiedFunctor {
+
+        FakeitContext &_fakeit;
+
+    public:
+
+        VerifyUnverifiedFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        template<typename ... list>
+        SequenceVerificationProgress operator()(const Sequence &sequence, const list &... tail) {
+            std::vector<Sequence *> allSequences{&InvocationUtils::remove_const(sequence),
+                                                 &InvocationUtils::remove_const(tail)...};
+
+            std::vector<ActualInvocationsSource *> involvedSources;
+            InvocationUtils::collectInvolvedMocks(allSequences, involvedSources);
+
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(involvedSources)};
+            InvocationsSourceProxy unverifiedInvocationsSource{
+                    new UnverifiedInvocationsSource(aggregateInvocationsSource)};
+
+            UsingProgress usingProgress(_fakeit, unverifiedInvocationsSource);
+            return usingProgress.Verify(sequence, tail...);
+        }
+
+    };
+
+    class UnverifiedFunctor {
+    public:
+        UnverifiedFunctor(FakeitContext &fakeit) : Verify(fakeit) {
+        }
+
+        VerifyUnverifiedFunctor Verify;
+
+        template<typename ... list>
+        UnverifiedInvocationsSource operator()(const ActualInvocationsSource &head, const list &... tail) {
+            std::vector<ActualInvocationsSource *> allMocks{&InvocationUtils::remove_const(head),
+                                                            &InvocationUtils::remove_const(tail)...};
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(allMocks)};
+            UnverifiedInvocationsSource unverifiedInvocationsSource{aggregateInvocationsSource};
+            return unverifiedInvocationsSource;
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+    };
+}
+
+namespace fakeit {
+
+    static UsingFunctor Using(Fakeit);
+    static VerifyFunctor Verify(Fakeit);
+    static VerifyNoOtherInvocationsFunctor VerifyNoOtherInvocations(Fakeit);
+    static UnverifiedFunctor Unverified(Fakeit);
+    static SpyFunctor Spy;
+    static FakeFunctor Fake;
+    static WhenFunctor When;
+
+    template<class T>
+    class SilenceUnusedVariableWarnings {
+
+        void use(void *) {
+        }
+
+        SilenceUnusedVariableWarnings() {
+            use(&Fake);
+            use(&When);
+            use(&Spy);
+            use(&Using);
+            use(&Verify);
+            use(&VerifyNoOtherInvocations);
+            use(&_);
+        }
+    };
+
+}
+#ifdef _MSC_VER
+#define __func__ __FUNCTION__
+#endif
+
+#define MOCK_TYPE(mock) \
+    std::remove_reference<decltype(mock.get())>::type
+
+#define OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
+
+#define CONST_OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
+
+#define Dtor(mock) \
+    mock.dtor().setMethodDetails(#mock,"destructor")
+
+#define Method(mock, method) \
+    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+
+#define OverloadedMethod(mock, method, prototype) \
+    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define ConstOverloadedMethod(mock, method, prototype) \
+    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define Verify(...) \
+        Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)
+
+#define Using(...) \
+        Using( __VA_ARGS__ )
+
+#define VerifyNoOtherInvocations(...) \
+    VerifyNoOtherInvocations( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)
+
+#define Fake(...) \
+    Fake( __VA_ARGS__ )
+
+#define When(call) \
+    When(call)
+
+
+#endif

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:22:33.240587
+ *  Generated: 2019-06-01 12:14:46.945919
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -983,7 +983,19 @@ namespace fakeit {
         }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -5718,6 +5730,7 @@ namespace fakeit {
 
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif
@@ -8372,7 +8385,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8632,7 +8645,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -8994,7 +9007,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-10-28 14:16:24.912771
+ *  Generated: 2018-07-27 08:18:53.216309
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -250,6 +250,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -873,6 +902,17 @@ namespace fakeit {
             return out.str();
         }
 
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
     private:
 
         static std::string formatSequence(const Sequence &val) {
@@ -904,8 +944,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -937,17 +977,6 @@ namespace fakeit {
 
             out << " * " << val.getTimes();
             return out.str();
-        }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
         }
     };
 }
@@ -1134,11 +1163,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::GTestFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5832,6 +5863,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -8761,7 +8796,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9016,8 +9051,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -5364,6 +5364,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:14:45.309082
+ *  Generated: 2018-08-17 00:22:33.240587
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5212,7 +5212,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -7913,11 +7914,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8196,9 +8197,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-07-27 08:19:04.732464
+ *  Generated: 2018-08-17 00:14:50.866238
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -770,6 +770,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -859,7 +862,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -896,7 +899,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -5232,7 +5235,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -5258,6 +5262,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -7855,21 +7871,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7884,8 +7891,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -7929,11 +7936,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -8041,11 +8071,15 @@ namespace fakeit {
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8061,8 +8095,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8100,10 +8137,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8113,7 +8146,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8187,7 +8219,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+
+		C &operator()() {
             return get();
         }
 
@@ -8708,12 +8744,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -5387,6 +5387,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-10-28 14:16:25.148538
+ *  Generated: 2018-07-27 08:19:04.732464
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -249,6 +249,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -872,6 +901,17 @@ namespace fakeit {
             return out.str();
         }
 
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
     private:
 
         static std::string formatSequence(const Sequence &val) {
@@ -903,8 +943,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -936,17 +976,6 @@ namespace fakeit {
 
             out << " * " << val.getTimes();
             return out.str();
-        }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
         }
     };
 }
@@ -1157,11 +1186,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::MettleFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5855,6 +5886,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -8770,7 +8805,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9025,8 +9060,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:22:25.788130
+ *  Generated: 2019-06-01 12:14:50.763017
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -982,7 +982,19 @@ namespace fakeit {
         }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -5741,6 +5753,7 @@ namespace fakeit {
 
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif
@@ -8395,7 +8408,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8655,7 +8668,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -9003,7 +9016,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:14:50.866238
+ *  Generated: 2018-08-17 00:22:25.788130
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5235,7 +5235,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -7936,11 +7937,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8219,9 +8220,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -8360,7 +8360,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8620,7 +8620,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -8982,7 +8982,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-10-28 14:16:25.398550
+ *  Generated: 2018-07-27 08:19:21.002469
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -250,6 +250,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -873,6 +902,17 @@ namespace fakeit {
             return out.str();
         }
 
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
     private:
 
         static std::string formatSequence(const Sequence &val) {
@@ -904,8 +944,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -937,17 +977,6 @@ namespace fakeit {
 
             out << " * " << val.getTimes();
             return out.str();
-        }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
         }
     };
 }
@@ -1159,11 +1188,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::MsTestFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5857,6 +5888,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -8786,7 +8821,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9041,8 +9076,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -5372,6 +5372,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -8380,7 +8380,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8640,7 +8640,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -9002,7 +9002,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-05-22 16:17:01.509423
+ *  Generated: 2018-07-27 08:19:27.167600
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -250,6 +250,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -915,8 +944,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -1079,28 +1108,28 @@ namespace fakeit {
 	struct NUnitAdapter : public EventHandler {
 		virtual ~NUnitAdapter() = default;
 
-        NUnitAdapter(EventFormatter &formatter)
+		NUnitAdapter(EventFormatter &formatter)
 			: _formatter(formatter) {
 		}
 
 		virtual void handle(const UnexpectedMethodCallEvent &evt) override {
 			std::string format = _formatter.format(evt);
-            NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
-        }
+			NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+		}
 
 		virtual void handle(const SequenceVerificationEvent &evt) override {
 			std::string format(_formatter.format(evt));
 
 
-            NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
-        }
+			NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+	        }
 
 		virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {
 			std::string format = _formatter.format(evt);
 
 
-            NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
-        }
+			NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+	        }
 
 	private:
 		EventFormatter &_formatter;
@@ -1142,11 +1171,13 @@ static fakeit::MethodInfo& scopeFixer = fakeit::UnknownMethod::instance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5840,6 +5871,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -1,0 +1,9221 @@
+#pragma once
+/*
+ *  FakeIt - A Simplified C++ Mocking Framework
+ *  Copyright (c) Eran Pe'er 2013
+ *  Generated: 2018-05-22 16:17:01.509423
+ *  Distributed under the MIT License. Please refer to the LICENSE file at:
+ *  https://github.com/eranpeer/FakeIt
+ */
+
+#ifndef fakeit_h__
+#define fakeit_h__
+
+
+
+#include <functional>
+#include <memory>
+#include <set>
+#include <vector>
+#include <stdexcept>
+#if defined (__GNUG__) || _MSC_VER >= 1900
+#define THROWS noexcept(false)
+#define NO_THROWS noexcept(true)
+#elif defined (_MSC_VER)
+#define THROWS throw(...)
+#define NO_THROWS
+#endif
+#include <typeinfo>
+#include <unordered_set>
+#include <tuple>
+#include <string>
+#include <iosfwd>
+#include <atomic>
+#include <tuple>
+
+
+namespace fakeit {
+
+    template<class C>
+    struct naked_type {
+        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
+    };
+
+    template< class T > struct tuple_arg         { typedef T  type; };
+    template< class T > struct tuple_arg < T& >  { typedef T& type; };
+    template< class T > struct tuple_arg < T&& > { typedef T&&  type; };
+
+
+
+
+    template<typename... arglist>
+    using ArgumentsTuple = std::tuple < arglist... > ;
+
+    template< class T > struct test_arg         { typedef T& type; };
+    template< class T > struct test_arg< T& >   { typedef T& type; };
+    template< class T > struct test_arg< T&& >  { typedef T& type; };
+
+    template< class T > struct production_arg         { typedef T& type; };
+    template< class T > struct production_arg< T& >   { typedef T& type; };
+    template< class T > struct production_arg< T&& >  { typedef T&&  type; };
+
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template<typename R, typename... arglist>
+    struct VTableMethodType {
+#if defined (__GNUG__)
+        typedef R(*type)(void *, arglist...);
+#elif defined (_MSC_VER)
+        typedef R(__thiscall *type)(void *, arglist...);
+#endif
+    };
+}
+#include <typeinfo>
+#include <tuple>
+#include <string>
+#include <iosfwd>
+#include <sstream>
+#include <string>
+
+namespace fakeit {
+
+    struct FakeitContext;
+
+    template<typename C>
+    struct MockObject {
+        virtual ~MockObject() THROWS { };
+
+        virtual C &get() = 0;
+
+        virtual FakeitContext &getFakeIt() = 0;
+    };
+
+    struct MethodInfo {
+
+        static unsigned int nextMethodOrdinal() {
+            static std::atomic_uint ordinal{0};
+            return ++ordinal;
+        }
+
+        MethodInfo(unsigned int anId, std::string aName) :
+                _id(anId), _name(aName) { }
+
+        unsigned int id() const {
+            return _id;
+        }
+
+        std::string name() const {
+            return _name;
+        }
+
+        void setName(const std::string &value) {
+            _name = value;
+        }
+
+    private:
+        unsigned int _id;
+        std::string _name;
+    };
+
+    struct UnknownMethod {
+
+        static MethodInfo &instance() {
+            static MethodInfo instance(MethodInfo::nextMethodOrdinal(), "unknown");
+            return instance;
+        }
+
+    };
+
+}
+namespace fakeit {
+    class Destructible {
+    public:
+        virtual ~Destructible() {}
+    };
+}
+
+namespace fakeit {
+
+    struct Invocation : Destructible {
+
+        static unsigned int nextInvocationOrdinal() {
+            static std::atomic_uint invocationOrdinal{0};
+            return ++invocationOrdinal;
+        }
+
+        struct Matcher {
+
+            virtual ~Matcher() THROWS {
+            }
+
+            virtual bool matches(Invocation &invocation) = 0;
+
+            virtual std::string format() const = 0;
+        };
+
+        Invocation(unsigned int ordinal, MethodInfo &method) :
+                _ordinal(ordinal), _method(method), _isVerified(false) {
+        }
+
+        virtual ~Invocation() override = default;
+
+        unsigned int getOrdinal() const {
+            return _ordinal;
+        }
+
+        MethodInfo &getMethod() const {
+            return _method;
+        }
+
+        void markAsVerified() {
+            _isVerified = true;
+        }
+
+        bool isVerified() const {
+            return _isVerified;
+        }
+
+        virtual std::string format() const = 0;
+
+    private:
+        const unsigned int _ordinal;
+        MethodInfo &_method;
+        bool _isVerified;
+    };
+
+}
+#include <iosfwd>
+#include <tuple>
+#include <string>
+#include <sstream>
+#include <ostream>
+
+namespace fakeit {
+
+	template<typename T, class Enable = void>
+	struct Formatter;
+
+	template <>
+	struct Formatter<bool>
+	{
+		static std::string format(bool const &val)
+		{
+			return val ? "true" : "false";
+		}
+	};
+
+	template <>
+	struct Formatter<char>
+	{
+		static std::string format(char const &val)
+		{
+			std::string s;
+			s += "'";
+			s += val;
+			s += "'";
+			return s;
+		}
+	};
+
+	template<class C>
+	struct Formatter<C, typename std::enable_if<!is_ostreamable<C>::value>::type> {
+		static std::string format(C const &)
+		{
+			return "?";
+		}
+	};
+
+	template<class C>
+	struct Formatter<C, typename std::enable_if<is_ostreamable<C>::value>::type> {
+		static std::string format(C const &val)
+		{
+			std::ostringstream os;
+			os << val;
+			return os.str();
+		}
+	};
+
+
+	template <typename T>
+	using TypeFormatter = Formatter<typename fakeit::naked_type<T>::type>;
+}
+
+namespace fakeit {
+
+
+    template<class Tuple, std::size_t N>
+    struct TuplePrinter {
+        static void print(std::ostream &strm, const Tuple &t) {
+            TuplePrinter<Tuple, N - 1>::print(strm, t);
+            strm << ", " << fakeit::TypeFormatter<decltype(std::get<N - 1>(t))>::format(std::get<N - 1>(t));
+        }
+    };
+
+    template<class Tuple>
+    struct TuplePrinter<Tuple, 1> {
+        static void print(std::ostream &strm, const Tuple &t) {
+            strm << fakeit::TypeFormatter<decltype(std::get<0>(t))>::format(std::get<0>(t));
+        }
+    };
+
+    template<class Tuple>
+    struct TuplePrinter<Tuple, 0> {
+        static void print(std::ostream &, const Tuple &) {
+        }
+    };
+
+    template<class ... Args>
+    void print(std::ostream &strm, const std::tuple<Args...> &t) {
+        strm << "(";
+        TuplePrinter<decltype(t), sizeof...(Args)>::print(strm, t);
+        strm << ")";
+    }
+
+    template<class ... Args>
+    std::ostream &operator<<(std::ostream &strm, const std::tuple<Args...> &t) {
+        print(strm, t);
+        return strm;
+    }
+
+}
+
+
+namespace fakeit {
+
+    template<typename ... arglist>
+    struct ActualInvocation : public Invocation {
+
+        struct Matcher : public virtual Destructible {
+            virtual bool matches(ActualInvocation<arglist...> &actualInvocation) = 0;
+
+            virtual std::string format() const = 0;
+        };
+
+        ActualInvocation(unsigned int ordinal, MethodInfo &method, const typename fakeit::production_arg<arglist>::type... args) :
+            Invocation(ordinal, method), _matcher{ nullptr }
+            , actualArguments{ std::forward<arglist>(args)... }
+        {
+        }
+
+        ArgumentsTuple<arglist...> & getActualArguments() {
+            return actualArguments;
+        }
+
+
+        void setActualMatcher(Matcher *matcher) {
+            this->_matcher = matcher;
+        }
+
+        Matcher *getActualMatcher() {
+            return _matcher;
+        }
+
+        virtual std::string format() const override {
+            std::ostringstream out;
+            out << getMethod().name();
+            print(out, actualArguments);
+            return out.str();
+        }
+
+    private:
+
+        Matcher *_matcher;
+        ArgumentsTuple<arglist...> actualArguments;
+    };
+
+    template<typename ... arglist>
+    std::ostream &operator<<(std::ostream &strm, const ActualInvocation<arglist...> &ai) {
+        strm << ai.format();
+        return strm;
+    }
+
+}
+
+
+
+
+
+#include <unordered_set>
+
+namespace fakeit {
+
+	struct ActualInvocationsContainer {
+		virtual void clear() = 0;
+
+		virtual ~ActualInvocationsContainer() NO_THROWS { }
+	};
+
+    struct ActualInvocationsSource {
+        virtual void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const = 0;
+
+        virtual ~ActualInvocationsSource() NO_THROWS { }
+    };
+
+    struct InvocationsSourceProxy : public ActualInvocationsSource {
+
+        InvocationsSourceProxy(ActualInvocationsSource *inner) :
+                _inner(inner) {
+        }
+
+        void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const override {
+            _inner->getActualInvocations(into);
+        }
+
+    private:
+        std::shared_ptr<ActualInvocationsSource> _inner;
+    };
+
+    struct UnverifiedInvocationsSource : public ActualInvocationsSource {
+
+        UnverifiedInvocationsSource(InvocationsSourceProxy decorated) : _decorated(decorated) {
+        }
+
+        void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const override {
+            std::unordered_set<fakeit::Invocation *> all;
+            _decorated.getActualInvocations(all);
+            for (fakeit::Invocation *i : all) {
+                if (!i->isVerified()) {
+                    into.insert(i);
+                }
+            }
+        }
+
+    private:
+        InvocationsSourceProxy _decorated;
+    };
+
+    struct AggregateInvocationsSource : public ActualInvocationsSource {
+
+        AggregateInvocationsSource(std::vector<ActualInvocationsSource *> &sources) : _sources(sources) {
+        }
+
+        void getActualInvocations(std::unordered_set<fakeit::Invocation *> &into) const override {
+            std::unordered_set<fakeit::Invocation *> tmp;
+            for (ActualInvocationsSource *source : _sources) {
+                source->getActualInvocations(tmp);
+            }
+            filter(tmp, into);
+        }
+
+    protected:
+        bool shouldInclude(fakeit::Invocation *) const {
+            return true;
+        }
+
+    private:
+        std::vector<ActualInvocationsSource *> _sources;
+
+        void filter(std::unordered_set<Invocation *> &source, std::unordered_set<Invocation *> &target) const {
+            for (Invocation *i:source) {
+                if (shouldInclude(i)) {
+                    target.insert(i);
+                }
+            }
+        }
+    };
+}
+
+namespace fakeit {
+
+    class Sequence {
+    private:
+
+    protected:
+
+        Sequence() {
+        }
+
+        virtual ~Sequence() THROWS {
+        }
+
+    public:
+
+
+        virtual void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const = 0;
+
+
+        virtual void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const = 0;
+
+        virtual unsigned int size() const = 0;
+
+        friend class VerifyFunctor;
+    };
+
+    class ConcatenatedSequence : public virtual Sequence {
+    private:
+        const Sequence &s1;
+        const Sequence &s2;
+
+    protected:
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
+        }
+
+    public:
+
+        virtual ~ConcatenatedSequence() {
+        }
+
+        unsigned int size() const override {
+            return s1.size() + s2.size();
+        }
+
+        const Sequence &getLeft() const {
+            return s1;
+        }
+
+        const Sequence &getRight() const {
+            return s2;
+        }
+
+        void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const override {
+            s1.getExpectedSequence(into);
+            s2.getExpectedSequence(into);
+        }
+
+        virtual void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
+            s1.getInvolvedMocks(into);
+            s2.getInvolvedMocks(into);
+        }
+
+        friend inline ConcatenatedSequence operator+(const Sequence &s1, const Sequence &s2);
+    };
+
+    class RepeatedSequence : public virtual Sequence {
+    private:
+        const Sequence &_s;
+        const int times;
+
+    protected:
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
+        }
+
+    public:
+
+        ~RepeatedSequence() {
+        }
+
+        unsigned int size() const override {
+            return _s.size() * times;
+        }
+
+        friend inline RepeatedSequence operator*(const Sequence &s, int times);
+
+        friend inline RepeatedSequence operator*(int times, const Sequence &s);
+
+        void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
+            _s.getInvolvedMocks(into);
+        }
+
+        void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const override {
+            for (int i = 0; i < times; i++)
+                _s.getExpectedSequence(into);
+        }
+
+        int getTimes() const {
+            return times;
+        }
+
+        const Sequence &getSequence() const {
+            return _s;
+        }
+    };
+
+    inline ConcatenatedSequence operator+(const Sequence &s1, const Sequence &s2) {
+        return ConcatenatedSequence(s1, s2);
+    }
+
+    inline RepeatedSequence operator*(const Sequence &s, int times) {
+        if (times <= 0)
+            throw std::invalid_argument("times");
+        return RepeatedSequence(s, times);
+    }
+
+    inline RepeatedSequence operator*(int times, const Sequence &s) {
+        if (times <= 0)
+            throw std::invalid_argument("times");
+        return RepeatedSequence(s, times);
+    }
+
+}
+
+namespace fakeit {
+
+    enum class VerificationType {
+        Exact, AtLeast, NoMoreInvocations
+    };
+
+    enum class UnexpectedType {
+        Unmocked, Unmatched
+    };
+
+    struct VerificationEvent {
+
+        VerificationEvent(VerificationType aVerificationType) :
+                _verificationType(aVerificationType), _line(0) {
+        }
+
+        virtual ~VerificationEvent() = default;
+
+        VerificationType verificationType() const {
+            return _verificationType;
+        }
+
+        void setFileInfo(const char * aFile, int aLine, const char * aCallingMethod) {
+            _file = aFile;
+            _callingMethod = aCallingMethod;
+            _line = aLine;
+        }
+
+        const char * file() const {
+            return _file;
+        }
+
+        int line() const {
+            return _line;
+        }
+
+        const char * callingMethod() const {
+            return _callingMethod;
+        }
+
+    private:
+        VerificationType _verificationType;
+		const char * _file;
+        int _line;
+        const char * _callingMethod;
+    };
+
+    struct NoMoreInvocationsVerificationEvent : public VerificationEvent {
+
+        ~NoMoreInvocationsVerificationEvent() = default;
+
+        NoMoreInvocationsVerificationEvent(
+                std::vector<Invocation *> &allTheIvocations,
+                std::vector<Invocation *> &anUnverifedIvocations) :
+                VerificationEvent(VerificationType::NoMoreInvocations),
+                _allIvocations(allTheIvocations),
+                _unverifedIvocations(anUnverifedIvocations) {
+        }
+
+        const std::vector<Invocation *> &allIvocations() const {
+            return _allIvocations;
+        }
+
+        const std::vector<Invocation *> &unverifedIvocations() const {
+            return _unverifedIvocations;
+        }
+
+    private:
+        const std::vector<Invocation *> _allIvocations;
+        const std::vector<Invocation *> _unverifedIvocations;
+    };
+
+    struct SequenceVerificationEvent : public VerificationEvent {
+
+        ~SequenceVerificationEvent() = default;
+
+        SequenceVerificationEvent(VerificationType aVerificationType,
+                                  std::vector<Sequence *> &anExpectedPattern,
+                                  std::vector<Invocation *> &anActualSequence,
+                                  int anExpectedCount,
+                                  int anActualCount) :
+                VerificationEvent(aVerificationType),
+                _expectedPattern(anExpectedPattern),
+                _actualSequence(anActualSequence),
+                _expectedCount(anExpectedCount),
+                _actualCount(anActualCount)
+        {
+        }
+
+        const std::vector<Sequence *> &expectedPattern() const {
+            return _expectedPattern;
+        }
+
+        const std::vector<Invocation *> &actualSequence() const {
+            return _actualSequence;
+        }
+
+        int expectedCount() const {
+            return _expectedCount;
+        }
+
+        int actualCount() const {
+            return _actualCount;
+        }
+
+    private:
+        const std::vector<Sequence *> _expectedPattern;
+        const std::vector<Invocation *> _actualSequence;
+        const int _expectedCount;
+        const int _actualCount;
+    };
+
+    struct UnexpectedMethodCallEvent {
+        UnexpectedMethodCallEvent(UnexpectedType unexpectedType, const Invocation &invocation) :
+                _unexpectedType(unexpectedType), _invocation(invocation) {
+        }
+
+        const Invocation &getInvocation() const {
+            return _invocation;
+        }
+
+        UnexpectedType getUnexpectedType() const {
+            return _unexpectedType;
+        }
+
+        const UnexpectedType _unexpectedType;
+        const Invocation &_invocation;
+    };
+
+}
+
+namespace fakeit {
+
+    struct VerificationEventHandler {
+        virtual void handle(const SequenceVerificationEvent &e) = 0;
+
+        virtual void handle(const NoMoreInvocationsVerificationEvent &e) = 0;
+    };
+
+    struct EventHandler : public VerificationEventHandler {
+        using VerificationEventHandler::handle;
+
+        virtual void handle(const UnexpectedMethodCallEvent &e) = 0;
+    };
+
+}
+#include <vector>
+#include <string>
+
+namespace fakeit {
+
+    struct UnexpectedMethodCallEvent;
+    struct SequenceVerificationEvent;
+    struct NoMoreInvocationsVerificationEvent;
+
+    struct EventFormatter {
+
+        virtual std::string format(const fakeit::UnexpectedMethodCallEvent &e) = 0;
+
+        virtual std::string format(const fakeit::SequenceVerificationEvent &e) = 0;
+
+        virtual std::string format(const fakeit::NoMoreInvocationsVerificationEvent &e) = 0;
+
+    };
+
+}
+
+namespace fakeit {
+
+    struct FakeitContext : public EventHandler, protected EventFormatter {
+
+        virtual ~FakeitContext() = default;
+
+        void handle(const UnexpectedMethodCallEvent &e) override {
+            fireEvent(e);
+            auto &eh = getTestingFrameworkAdapter();
+            #ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+            assert(!"Unexpected method invocation");
+            #endif
+            eh.handle(e);
+        }
+
+        void handle(const SequenceVerificationEvent &e) override {
+            fireEvent(e);
+            auto &eh = getTestingFrameworkAdapter();
+            return eh.handle(e);
+        }
+
+        void handle(const NoMoreInvocationsVerificationEvent &e) override {
+            fireEvent(e);
+            auto &eh = getTestingFrameworkAdapter();
+            return eh.handle(e);
+        }
+
+        std::string format(const UnexpectedMethodCallEvent &e) override {
+            auto &eventFormatter = getEventFormatter();
+            return eventFormatter.format(e);
+        }
+
+        std::string format(const SequenceVerificationEvent &e) override {
+            auto &eventFormatter = getEventFormatter();
+            return eventFormatter.format(e);
+        }
+
+        std::string format(const NoMoreInvocationsVerificationEvent &e) override {
+            auto &eventFormatter = getEventFormatter();
+            return eventFormatter.format(e);
+        }
+
+        void addEventHandler(EventHandler &eventListener) {
+            _eventListeners.push_back(&eventListener);
+        }
+
+        void clearEventHandlers() {
+            _eventListeners.clear();
+        }
+
+    protected:
+        virtual EventHandler &getTestingFrameworkAdapter() = 0;
+
+        virtual EventFormatter &getEventFormatter() = 0;
+
+    private:
+        std::vector<EventHandler *> _eventListeners;
+
+        void fireEvent(const NoMoreInvocationsVerificationEvent &evt) {
+            for (auto listener : _eventListeners)
+                listener->handle(evt);
+        }
+
+        void fireEvent(const UnexpectedMethodCallEvent &evt) {
+            for (auto listener : _eventListeners)
+                listener->handle(evt);
+        }
+
+        void fireEvent(const SequenceVerificationEvent &evt) {
+            for (auto listener : _eventListeners)
+                listener->handle(evt);
+        }
+
+    };
+
+}
+#include <iostream>
+#include <iosfwd>
+
+namespace fakeit {
+
+    struct DefaultEventFormatter : public EventFormatter {
+
+        virtual std::string format(const UnexpectedMethodCallEvent &e) override {
+            std::ostringstream out;
+            out << "Unexpected method invocation: ";
+            out << e.getInvocation().format() << std::endl;
+            if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
+                out << "  Could not find Any recorded behavior to support this method call.";
+            } else {
+                out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
+            }
+            return out.str();
+        }
+
+
+        virtual std::string format(const SequenceVerificationEvent &e) override {
+            std::ostringstream out;
+            out << "Verification error" << std::endl;
+
+            out << "Expected pattern: ";
+            const std::vector<fakeit::Sequence *> expectedPattern = e.expectedPattern();
+            out << formatExpectedPattern(expectedPattern) << std::endl;
+
+            out << "Expected matches: ";
+            formatExpectedCount(out, e.verificationType(), e.expectedCount());
+            out << std::endl;
+
+            out << "Actual matches  : " << e.actualCount() << std::endl;
+
+            auto actualSequence = e.actualSequence();
+            out << "Actual sequence : total of " << actualSequence.size() << " actual invocations";
+            if (actualSequence.size() == 0) {
+                out << ".";
+            } else {
+                out << ":" << std::endl;
+            }
+            formatInvocationList(out, actualSequence);
+
+            return out.str();
+        }
+
+        virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
+            std::ostringstream out;
+            out << "Verification error" << std::endl;
+            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            formatInvocationList(out, e.unverifedIvocations());
+            return out.str();
+        }
+
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
+    private:
+
+        static std::string formatSequence(const Sequence &val) {
+            const ConcatenatedSequence *cs = dynamic_cast<const ConcatenatedSequence *>(&val);
+            if (cs) {
+                return format(*cs);
+            }
+            const RepeatedSequence *rs = dynamic_cast<const RepeatedSequence *>(&val);
+            if (rs) {
+                return format(*rs);
+            }
+
+
+            std::vector<Invocation::Matcher *> vec;
+            val.getExpectedSequence(vec);
+            return vec[0]->format();
+        }
+
+        static void formatExpectedCount(std::ostream &out, fakeit::VerificationType verificationType,
+                                        int expectedCount) {
+            if (verificationType == fakeit::VerificationType::Exact)
+                out << "exactly ";
+
+            if (verificationType == fakeit::VerificationType::AtLeast)
+                out << "at least ";
+
+            out << expectedCount;
+        }
+
+        static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
+            size_t max_size = actualSequence.size();
+            if (max_size > 5)
+                max_size = 5;
+
+            for (unsigned int i = 0; i < max_size; i++) {
+                out << "  ";
+                auto invocation = actualSequence[i];
+                out << invocation->format();
+                if (i < max_size - 1)
+                    out << std::endl;
+            }
+
+            if (actualSequence.size() > max_size)
+                out << std::endl << "  ...";
+        }
+
+        static std::string format(const ConcatenatedSequence &val) {
+            std::ostringstream out;
+            out << formatSequence(val.getLeft()) << " + " << formatSequence(val.getRight());
+            return out.str();
+        }
+
+        static std::string format(const RepeatedSequence &val) {
+            std::ostringstream out;
+            const ConcatenatedSequence *cs = dynamic_cast<const ConcatenatedSequence *>(&val.getSequence());
+            const RepeatedSequence *rs = dynamic_cast<const RepeatedSequence *>(&val.getSequence());
+            if (rs || cs)
+                out << '(';
+            out << formatSequence(val.getSequence());
+            if (rs || cs)
+                out << ')';
+
+            out << " * " << val.getTimes();
+            return out.str();
+        }
+    };
+}
+namespace fakeit {
+
+    struct FakeitException {
+        std::exception err;
+
+        virtual ~FakeitException() = default;
+
+        virtual std::string what() const = 0;
+
+        friend std::ostream &operator<<(std::ostream &os, const FakeitException &val) {
+            os << val.what();
+            return os;
+        }
+    };
+
+
+
+
+    struct UnexpectedMethodCallException : public FakeitException {
+
+        UnexpectedMethodCallException(std::string format) :
+                _format(format) {
+        }
+
+        virtual std::string what() const override {
+            return _format;
+        }
+
+    private:
+        std::string _format;
+    };
+
+}
+
+namespace fakeit {
+
+    struct DefaultEventLogger : public fakeit::EventHandler {
+
+        DefaultEventLogger(EventFormatter &formatter) : _formatter(formatter), _out(std::cout) { }
+
+        virtual void handle(const UnexpectedMethodCallEvent &e) override {
+            _out << _formatter.format(e) << std::endl;
+        }
+
+        virtual void handle(const SequenceVerificationEvent &e) override {
+            _out << _formatter.format(e) << std::endl;
+        }
+
+        virtual void handle(const NoMoreInvocationsVerificationEvent &e) override {
+            _out << _formatter.format(e) << std::endl;
+        }
+
+    private:
+        EventFormatter &_formatter;
+        std::ostream &_out;
+    };
+
+}
+
+namespace fakeit {
+
+    class AbstractFakeit : public FakeitContext {
+    public:
+        virtual ~AbstractFakeit() = default;
+
+    protected:
+
+        virtual fakeit::EventHandler &accessTestingFrameworkAdapter() = 0;
+
+        virtual EventFormatter &accessEventFormatter() = 0;
+    };
+
+    class DefaultFakeit : public AbstractFakeit {
+        DefaultEventFormatter _formatter;
+        fakeit::EventFormatter *_customFormatter;
+        fakeit::EventHandler *_testingFrameworkAdapter;
+
+    public:
+
+        DefaultFakeit() : _formatter(),
+                          _customFormatter(nullptr),
+                          _testingFrameworkAdapter(nullptr) {
+        }
+
+        virtual ~DefaultFakeit() = default;
+
+        void setCustomEventFormatter(fakeit::EventFormatter &customEventFormatter) {
+            _customFormatter = &customEventFormatter;
+        }
+
+        void resetCustomEventFormatter() {
+            _customFormatter = nullptr;
+        }
+
+        void setTestingFrameworkAdapter(fakeit::EventHandler &testingFrameforkAdapter) {
+            _testingFrameworkAdapter = &testingFrameforkAdapter;
+        }
+
+        void resetTestingFrameworkAdapter() {
+            _testingFrameworkAdapter = nullptr;
+        }
+
+    protected:
+
+        fakeit::EventHandler &getTestingFrameworkAdapter() override {
+            if (_testingFrameworkAdapter)
+                return *_testingFrameworkAdapter;
+            return accessTestingFrameworkAdapter();
+        }
+
+        EventFormatter &getEventFormatter() override {
+            if (_customFormatter)
+                return *_customFormatter;
+            return accessEventFormatter();
+        }
+
+        EventFormatter &accessEventFormatter() override {
+            return _formatter;
+        }
+
+    };
+}
+
+namespace fakeit {
+
+	struct NUnitAdapter : public EventHandler {
+		virtual ~NUnitAdapter() = default;
+
+        NUnitAdapter(EventFormatter &formatter)
+			: _formatter(formatter) {
+		}
+
+		virtual void handle(const UnexpectedMethodCallEvent &evt) override {
+			std::string format = _formatter.format(evt);
+            NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+        }
+
+		virtual void handle(const SequenceVerificationEvent &evt) override {
+			std::string format(_formatter.format(evt));
+
+
+            NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+        }
+
+		virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {
+			std::string format = _formatter.format(evt);
+
+
+            NUnit::Framework::Assert::Fail(gcnew String(format.c_str()));
+        }
+
+	private:
+		EventFormatter &_formatter;
+	};
+
+    class NUnitFakeit : public DefaultFakeit {
+
+    public:
+        virtual ~NUnitFakeit() = default;
+
+        NUnitFakeit(): _nUnitAdapter(*this) {
+        }
+
+        static NUnitFakeit &getInstance() {
+            static NUnitFakeit instance;
+            return instance;
+        }
+
+    protected:
+
+        fakeit::EventHandler &accessTestingFrameworkAdapter() override {
+            return _nUnitAdapter;
+        }
+
+    private:
+
+        NUnitAdapter _nUnitAdapter;
+    };
+}
+
+
+static fakeit::DefaultFakeit& Fakeit = fakeit::NUnitFakeit::getInstance();
+
+
+static fakeit::MethodInfo& scopeFixer = fakeit::UnknownMethod::instance();
+
+
+#include <type_traits>
+#include <unordered_set>
+
+#include <memory>
+#include <functional>
+#include <type_traits>
+#include <vector>
+#include <array>
+#include <new>
+
+#include <functional>
+#include <type_traits>
+namespace fakeit {
+
+    struct VirtualOffsetSelector {
+
+        unsigned int offset;
+
+        virtual unsigned int offset0(int) {
+            return offset = 0;
+        }
+
+        virtual unsigned int offset1(int) {
+            return offset = 1;
+        }
+
+        virtual unsigned int offset2(int) {
+            return offset = 2;
+        }
+
+        virtual unsigned int offset3(int) {
+            return offset = 3;
+        }
+
+        virtual unsigned int offset4(int) {
+            return offset = 4;
+        }
+
+        virtual unsigned int offset5(int) {
+            return offset = 5;
+        }
+
+        virtual unsigned int offset6(int) {
+            return offset = 6;
+        }
+
+        virtual unsigned int offset7(int) {
+            return offset = 7;
+        }
+
+        virtual unsigned int offset8(int) {
+            return offset = 8;
+        }
+
+        virtual unsigned int offset9(int) {
+            return offset = 9;
+        }
+
+        virtual unsigned int offset10(int) {
+            return offset = 10;
+        }
+
+        virtual unsigned int offset11(int) {
+            return offset = 11;
+        }
+
+        virtual unsigned int offset12(int) {
+            return offset = 12;
+        }
+
+        virtual unsigned int offset13(int) {
+            return offset = 13;
+        }
+
+        virtual unsigned int offset14(int) {
+            return offset = 14;
+        }
+
+        virtual unsigned int offset15(int) {
+            return offset = 15;
+        }
+
+        virtual unsigned int offset16(int) {
+            return offset = 16;
+        }
+
+        virtual unsigned int offset17(int) {
+            return offset = 17;
+        }
+
+        virtual unsigned int offset18(int) {
+            return offset = 18;
+        }
+
+        virtual unsigned int offset19(int) {
+            return offset = 19;
+        }
+
+        virtual unsigned int offset20(int) {
+            return offset = 20;
+        }
+
+        virtual unsigned int offset21(int) {
+            return offset = 21;
+        }
+
+        virtual unsigned int offset22(int) {
+            return offset = 22;
+        }
+
+        virtual unsigned int offset23(int) {
+            return offset = 23;
+        }
+
+        virtual unsigned int offset24(int) {
+            return offset = 24;
+        }
+
+        virtual unsigned int offset25(int) {
+            return offset = 25;
+        }
+
+        virtual unsigned int offset26(int) {
+            return offset = 26;
+        }
+
+        virtual unsigned int offset27(int) {
+            return offset = 27;
+        }
+
+        virtual unsigned int offset28(int) {
+            return offset = 28;
+        }
+
+        virtual unsigned int offset29(int) {
+            return offset = 29;
+        }
+
+        virtual unsigned int offset30(int) {
+            return offset = 30;
+        }
+
+        virtual unsigned int offset31(int) {
+            return offset = 31;
+        }
+
+        virtual unsigned int offset32(int) {
+            return offset = 32;
+        }
+
+        virtual unsigned int offset33(int) {
+            return offset = 33;
+        }
+
+        virtual unsigned int offset34(int) {
+            return offset = 34;
+        }
+
+        virtual unsigned int offset35(int) {
+            return offset = 35;
+        }
+
+        virtual unsigned int offset36(int) {
+            return offset = 36;
+        }
+
+        virtual unsigned int offset37(int) {
+            return offset = 37;
+        }
+
+        virtual unsigned int offset38(int) {
+            return offset = 38;
+        }
+
+        virtual unsigned int offset39(int) {
+            return offset = 39;
+        }
+
+        virtual unsigned int offset40(int) {
+            return offset = 40;
+        }
+
+        virtual unsigned int offset41(int) {
+            return offset = 41;
+        }
+
+        virtual unsigned int offset42(int) {
+            return offset = 42;
+        }
+
+        virtual unsigned int offset43(int) {
+            return offset = 43;
+        }
+
+        virtual unsigned int offset44(int) {
+            return offset = 44;
+        }
+
+        virtual unsigned int offset45(int) {
+            return offset = 45;
+        }
+
+        virtual unsigned int offset46(int) {
+            return offset = 46;
+        }
+
+        virtual unsigned int offset47(int) {
+            return offset = 47;
+        }
+
+        virtual unsigned int offset48(int) {
+            return offset = 48;
+        }
+
+        virtual unsigned int offset49(int) {
+            return offset = 49;
+        }
+
+        virtual unsigned int offset50(int) {
+            return offset = 50;
+        }
+
+        virtual unsigned int offset51(int) {
+            return offset = 51;
+        }
+
+        virtual unsigned int offset52(int) {
+            return offset = 52;
+        }
+
+        virtual unsigned int offset53(int) {
+            return offset = 53;
+        }
+
+        virtual unsigned int offset54(int) {
+            return offset = 54;
+        }
+
+        virtual unsigned int offset55(int) {
+            return offset = 55;
+        }
+
+        virtual unsigned int offset56(int) {
+            return offset = 56;
+        }
+
+        virtual unsigned int offset57(int) {
+            return offset = 57;
+        }
+
+        virtual unsigned int offset58(int) {
+            return offset = 58;
+        }
+
+        virtual unsigned int offset59(int) {
+            return offset = 59;
+        }
+
+        virtual unsigned int offset60(int) {
+            return offset = 60;
+        }
+
+        virtual unsigned int offset61(int) {
+            return offset = 61;
+        }
+
+        virtual unsigned int offset62(int) {
+            return offset = 62;
+        }
+
+        virtual unsigned int offset63(int) {
+            return offset = 63;
+        }
+
+        virtual unsigned int offset64(int) {
+            return offset = 64;
+        }
+
+        virtual unsigned int offset65(int) {
+            return offset = 65;
+        }
+
+        virtual unsigned int offset66(int) {
+            return offset = 66;
+        }
+
+        virtual unsigned int offset67(int) {
+            return offset = 67;
+        }
+
+        virtual unsigned int offset68(int) {
+            return offset = 68;
+        }
+
+        virtual unsigned int offset69(int) {
+            return offset = 69;
+        }
+
+        virtual unsigned int offset70(int) {
+            return offset = 70;
+        }
+
+        virtual unsigned int offset71(int) {
+            return offset = 71;
+        }
+
+        virtual unsigned int offset72(int) {
+            return offset = 72;
+        }
+
+        virtual unsigned int offset73(int) {
+            return offset = 73;
+        }
+
+        virtual unsigned int offset74(int) {
+            return offset = 74;
+        }
+
+        virtual unsigned int offset75(int) {
+            return offset = 75;
+        }
+
+        virtual unsigned int offset76(int) {
+            return offset = 76;
+        }
+
+        virtual unsigned int offset77(int) {
+            return offset = 77;
+        }
+
+        virtual unsigned int offset78(int) {
+            return offset = 78;
+        }
+
+        virtual unsigned int offset79(int) {
+            return offset = 79;
+        }
+
+        virtual unsigned int offset80(int) {
+            return offset = 80;
+        }
+
+        virtual unsigned int offset81(int) {
+            return offset = 81;
+        }
+
+        virtual unsigned int offset82(int) {
+            return offset = 82;
+        }
+
+        virtual unsigned int offset83(int) {
+            return offset = 83;
+        }
+
+        virtual unsigned int offset84(int) {
+            return offset = 84;
+        }
+
+        virtual unsigned int offset85(int) {
+            return offset = 85;
+        }
+
+        virtual unsigned int offset86(int) {
+            return offset = 86;
+        }
+
+        virtual unsigned int offset87(int) {
+            return offset = 87;
+        }
+
+        virtual unsigned int offset88(int) {
+            return offset = 88;
+        }
+
+        virtual unsigned int offset89(int) {
+            return offset = 89;
+        }
+
+        virtual unsigned int offset90(int) {
+            return offset = 90;
+        }
+
+        virtual unsigned int offset91(int) {
+            return offset = 91;
+        }
+
+        virtual unsigned int offset92(int) {
+            return offset = 92;
+        }
+
+        virtual unsigned int offset93(int) {
+            return offset = 93;
+        }
+
+        virtual unsigned int offset94(int) {
+            return offset = 94;
+        }
+
+        virtual unsigned int offset95(int) {
+            return offset = 95;
+        }
+
+        virtual unsigned int offset96(int) {
+            return offset = 96;
+        }
+
+        virtual unsigned int offset97(int) {
+            return offset = 97;
+        }
+
+        virtual unsigned int offset98(int) {
+            return offset = 98;
+        }
+
+        virtual unsigned int offset99(int) {
+            return offset = 99;
+        }
+
+        virtual unsigned int offset100(int) {
+            return offset = 100;
+        }
+
+        virtual unsigned int offset101(int) {
+            return offset = 101;
+        }
+
+        virtual unsigned int offset102(int) {
+            return offset = 102;
+        }
+
+        virtual unsigned int offset103(int) {
+            return offset = 103;
+        }
+
+        virtual unsigned int offset104(int) {
+            return offset = 104;
+        }
+
+        virtual unsigned int offset105(int) {
+            return offset = 105;
+        }
+
+        virtual unsigned int offset106(int) {
+            return offset = 106;
+        }
+
+        virtual unsigned int offset107(int) {
+            return offset = 107;
+        }
+
+        virtual unsigned int offset108(int) {
+            return offset = 108;
+        }
+
+        virtual unsigned int offset109(int) {
+            return offset = 109;
+        }
+
+        virtual unsigned int offset110(int) {
+            return offset = 110;
+        }
+
+        virtual unsigned int offset111(int) {
+            return offset = 111;
+        }
+
+        virtual unsigned int offset112(int) {
+            return offset = 112;
+        }
+
+        virtual unsigned int offset113(int) {
+            return offset = 113;
+        }
+
+        virtual unsigned int offset114(int) {
+            return offset = 114;
+        }
+
+        virtual unsigned int offset115(int) {
+            return offset = 115;
+        }
+
+        virtual unsigned int offset116(int) {
+            return offset = 116;
+        }
+
+        virtual unsigned int offset117(int) {
+            return offset = 117;
+        }
+
+        virtual unsigned int offset118(int) {
+            return offset = 118;
+        }
+
+        virtual unsigned int offset119(int) {
+            return offset = 119;
+        }
+
+        virtual unsigned int offset120(int) {
+            return offset = 120;
+        }
+
+        virtual unsigned int offset121(int) {
+            return offset = 121;
+        }
+
+        virtual unsigned int offset122(int) {
+            return offset = 122;
+        }
+
+        virtual unsigned int offset123(int) {
+            return offset = 123;
+        }
+
+        virtual unsigned int offset124(int) {
+            return offset = 124;
+        }
+
+        virtual unsigned int offset125(int) {
+            return offset = 125;
+        }
+
+        virtual unsigned int offset126(int) {
+            return offset = 126;
+        }
+
+        virtual unsigned int offset127(int) {
+            return offset = 127;
+        }
+
+        virtual unsigned int offset128(int) {
+            return offset = 128;
+        }
+
+        virtual unsigned int offset129(int) {
+            return offset = 129;
+        }
+
+        virtual unsigned int offset130(int) {
+            return offset = 130;
+        }
+
+        virtual unsigned int offset131(int) {
+            return offset = 131;
+        }
+
+        virtual unsigned int offset132(int) {
+            return offset = 132;
+        }
+
+        virtual unsigned int offset133(int) {
+            return offset = 133;
+        }
+
+        virtual unsigned int offset134(int) {
+            return offset = 134;
+        }
+
+        virtual unsigned int offset135(int) {
+            return offset = 135;
+        }
+
+        virtual unsigned int offset136(int) {
+            return offset = 136;
+        }
+
+        virtual unsigned int offset137(int) {
+            return offset = 137;
+        }
+
+        virtual unsigned int offset138(int) {
+            return offset = 138;
+        }
+
+        virtual unsigned int offset139(int) {
+            return offset = 139;
+        }
+
+        virtual unsigned int offset140(int) {
+            return offset = 140;
+        }
+
+        virtual unsigned int offset141(int) {
+            return offset = 141;
+        }
+
+        virtual unsigned int offset142(int) {
+            return offset = 142;
+        }
+
+        virtual unsigned int offset143(int) {
+            return offset = 143;
+        }
+
+        virtual unsigned int offset144(int) {
+            return offset = 144;
+        }
+
+        virtual unsigned int offset145(int) {
+            return offset = 145;
+        }
+
+        virtual unsigned int offset146(int) {
+            return offset = 146;
+        }
+
+        virtual unsigned int offset147(int) {
+            return offset = 147;
+        }
+
+        virtual unsigned int offset148(int) {
+            return offset = 148;
+        }
+
+        virtual unsigned int offset149(int) {
+            return offset = 149;
+        }
+
+        virtual unsigned int offset150(int) {
+            return offset = 150;
+        }
+
+        virtual unsigned int offset151(int) {
+            return offset = 151;
+        }
+
+        virtual unsigned int offset152(int) {
+            return offset = 152;
+        }
+
+        virtual unsigned int offset153(int) {
+            return offset = 153;
+        }
+
+        virtual unsigned int offset154(int) {
+            return offset = 154;
+        }
+
+        virtual unsigned int offset155(int) {
+            return offset = 155;
+        }
+
+        virtual unsigned int offset156(int) {
+            return offset = 156;
+        }
+
+        virtual unsigned int offset157(int) {
+            return offset = 157;
+        }
+
+        virtual unsigned int offset158(int) {
+            return offset = 158;
+        }
+
+        virtual unsigned int offset159(int) {
+            return offset = 159;
+        }
+
+        virtual unsigned int offset160(int) {
+            return offset = 160;
+        }
+
+        virtual unsigned int offset161(int) {
+            return offset = 161;
+        }
+
+        virtual unsigned int offset162(int) {
+            return offset = 162;
+        }
+
+        virtual unsigned int offset163(int) {
+            return offset = 163;
+        }
+
+        virtual unsigned int offset164(int) {
+            return offset = 164;
+        }
+
+        virtual unsigned int offset165(int) {
+            return offset = 165;
+        }
+
+        virtual unsigned int offset166(int) {
+            return offset = 166;
+        }
+
+        virtual unsigned int offset167(int) {
+            return offset = 167;
+        }
+
+        virtual unsigned int offset168(int) {
+            return offset = 168;
+        }
+
+        virtual unsigned int offset169(int) {
+            return offset = 169;
+        }
+
+        virtual unsigned int offset170(int) {
+            return offset = 170;
+        }
+
+        virtual unsigned int offset171(int) {
+            return offset = 171;
+        }
+
+        virtual unsigned int offset172(int) {
+            return offset = 172;
+        }
+
+        virtual unsigned int offset173(int) {
+            return offset = 173;
+        }
+
+        virtual unsigned int offset174(int) {
+            return offset = 174;
+        }
+
+        virtual unsigned int offset175(int) {
+            return offset = 175;
+        }
+
+        virtual unsigned int offset176(int) {
+            return offset = 176;
+        }
+
+        virtual unsigned int offset177(int) {
+            return offset = 177;
+        }
+
+        virtual unsigned int offset178(int) {
+            return offset = 178;
+        }
+
+        virtual unsigned int offset179(int) {
+            return offset = 179;
+        }
+
+        virtual unsigned int offset180(int) {
+            return offset = 180;
+        }
+
+        virtual unsigned int offset181(int) {
+            return offset = 181;
+        }
+
+        virtual unsigned int offset182(int) {
+            return offset = 182;
+        }
+
+        virtual unsigned int offset183(int) {
+            return offset = 183;
+        }
+
+        virtual unsigned int offset184(int) {
+            return offset = 184;
+        }
+
+        virtual unsigned int offset185(int) {
+            return offset = 185;
+        }
+
+        virtual unsigned int offset186(int) {
+            return offset = 186;
+        }
+
+        virtual unsigned int offset187(int) {
+            return offset = 187;
+        }
+
+        virtual unsigned int offset188(int) {
+            return offset = 188;
+        }
+
+        virtual unsigned int offset189(int) {
+            return offset = 189;
+        }
+
+        virtual unsigned int offset190(int) {
+            return offset = 190;
+        }
+
+        virtual unsigned int offset191(int) {
+            return offset = 191;
+        }
+
+        virtual unsigned int offset192(int) {
+            return offset = 192;
+        }
+
+        virtual unsigned int offset193(int) {
+            return offset = 193;
+        }
+
+        virtual unsigned int offset194(int) {
+            return offset = 194;
+        }
+
+        virtual unsigned int offset195(int) {
+            return offset = 195;
+        }
+
+        virtual unsigned int offset196(int) {
+            return offset = 196;
+        }
+
+        virtual unsigned int offset197(int) {
+            return offset = 197;
+        }
+
+        virtual unsigned int offset198(int) {
+            return offset = 198;
+        }
+
+        virtual unsigned int offset199(int) {
+            return offset = 199;
+        }
+
+
+        virtual unsigned int offset200(int) {
+            return offset = 200;
+        }
+
+        virtual unsigned int offset201(int) {
+            return offset = 201;
+        }
+
+        virtual unsigned int offset202(int) {
+            return offset = 202;
+        }
+
+        virtual unsigned int offset203(int) {
+            return offset = 203;
+        }
+
+        virtual unsigned int offset204(int) {
+            return offset = 204;
+        }
+
+        virtual unsigned int offset205(int) {
+            return offset = 205;
+        }
+
+        virtual unsigned int offset206(int) {
+            return offset = 206;
+        }
+
+        virtual unsigned int offset207(int) {
+            return offset = 207;
+        }
+
+        virtual unsigned int offset208(int) {
+            return offset = 208;
+        }
+
+        virtual unsigned int offset209(int) {
+            return offset = 209;
+        }
+
+        virtual unsigned int offset210(int) {
+            return offset = 210;
+        }
+
+        virtual unsigned int offset211(int) {
+            return offset = 211;
+        }
+
+        virtual unsigned int offset212(int) {
+            return offset = 212;
+        }
+
+        virtual unsigned int offset213(int) {
+            return offset = 213;
+        }
+
+        virtual unsigned int offset214(int) {
+            return offset = 214;
+        }
+
+        virtual unsigned int offset215(int) {
+            return offset = 215;
+        }
+
+        virtual unsigned int offset216(int) {
+            return offset = 216;
+        }
+
+        virtual unsigned int offset217(int) {
+            return offset = 217;
+        }
+
+        virtual unsigned int offset218(int) {
+            return offset = 218;
+        }
+
+        virtual unsigned int offset219(int) {
+            return offset = 219;
+        }
+
+        virtual unsigned int offset220(int) {
+            return offset = 220;
+        }
+
+        virtual unsigned int offset221(int) {
+            return offset = 221;
+        }
+
+        virtual unsigned int offset222(int) {
+            return offset = 222;
+        }
+
+        virtual unsigned int offset223(int) {
+            return offset = 223;
+        }
+
+        virtual unsigned int offset224(int) {
+            return offset = 224;
+        }
+
+        virtual unsigned int offset225(int) {
+            return offset = 225;
+        }
+
+        virtual unsigned int offset226(int) {
+            return offset = 226;
+        }
+
+        virtual unsigned int offset227(int) {
+            return offset = 227;
+        }
+
+        virtual unsigned int offset228(int) {
+            return offset = 228;
+        }
+
+        virtual unsigned int offset229(int) {
+            return offset = 229;
+        }
+
+        virtual unsigned int offset230(int) {
+            return offset = 230;
+        }
+
+        virtual unsigned int offset231(int) {
+            return offset = 231;
+        }
+
+        virtual unsigned int offset232(int) {
+            return offset = 232;
+        }
+
+        virtual unsigned int offset233(int) {
+            return offset = 233;
+        }
+
+        virtual unsigned int offset234(int) {
+            return offset = 234;
+        }
+
+        virtual unsigned int offset235(int) {
+            return offset = 235;
+        }
+
+        virtual unsigned int offset236(int) {
+            return offset = 236;
+        }
+
+        virtual unsigned int offset237(int) {
+            return offset = 237;
+        }
+
+        virtual unsigned int offset238(int) {
+            return offset = 238;
+        }
+
+        virtual unsigned int offset239(int) {
+            return offset = 239;
+        }
+
+        virtual unsigned int offset240(int) {
+            return offset = 240;
+        }
+
+        virtual unsigned int offset241(int) {
+            return offset = 241;
+        }
+
+        virtual unsigned int offset242(int) {
+            return offset = 242;
+        }
+
+        virtual unsigned int offset243(int) {
+            return offset = 243;
+        }
+
+        virtual unsigned int offset244(int) {
+            return offset = 244;
+        }
+
+        virtual unsigned int offset245(int) {
+            return offset = 245;
+        }
+
+        virtual unsigned int offset246(int) {
+            return offset = 246;
+        }
+
+        virtual unsigned int offset247(int) {
+            return offset = 247;
+        }
+
+        virtual unsigned int offset248(int) {
+            return offset = 248;
+        }
+
+        virtual unsigned int offset249(int) {
+            return offset = 249;
+        }
+
+        virtual unsigned int offset250(int) {
+            return offset = 250;
+        }
+
+        virtual unsigned int offset251(int) {
+            return offset = 251;
+        }
+
+        virtual unsigned int offset252(int) {
+            return offset = 252;
+        }
+
+        virtual unsigned int offset253(int) {
+            return offset = 253;
+        }
+
+        virtual unsigned int offset254(int) {
+            return offset = 254;
+        }
+
+        virtual unsigned int offset255(int) {
+            return offset = 255;
+        }
+
+        virtual unsigned int offset256(int) {
+            return offset = 256;
+        }
+
+        virtual unsigned int offset257(int) {
+            return offset = 257;
+        }
+
+        virtual unsigned int offset258(int) {
+            return offset = 258;
+        }
+
+        virtual unsigned int offset259(int) {
+            return offset = 259;
+        }
+
+        virtual unsigned int offset260(int) {
+            return offset = 260;
+        }
+
+        virtual unsigned int offset261(int) {
+            return offset = 261;
+        }
+
+        virtual unsigned int offset262(int) {
+            return offset = 262;
+        }
+
+        virtual unsigned int offset263(int) {
+            return offset = 263;
+        }
+
+        virtual unsigned int offset264(int) {
+            return offset = 264;
+        }
+
+        virtual unsigned int offset265(int) {
+            return offset = 265;
+        }
+
+        virtual unsigned int offset266(int) {
+            return offset = 266;
+        }
+
+        virtual unsigned int offset267(int) {
+            return offset = 267;
+        }
+
+        virtual unsigned int offset268(int) {
+            return offset = 268;
+        }
+
+        virtual unsigned int offset269(int) {
+            return offset = 269;
+        }
+
+        virtual unsigned int offset270(int) {
+            return offset = 270;
+        }
+
+        virtual unsigned int offset271(int) {
+            return offset = 271;
+        }
+
+        virtual unsigned int offset272(int) {
+            return offset = 272;
+        }
+
+        virtual unsigned int offset273(int) {
+            return offset = 273;
+        }
+
+        virtual unsigned int offset274(int) {
+            return offset = 274;
+        }
+
+        virtual unsigned int offset275(int) {
+            return offset = 275;
+        }
+
+        virtual unsigned int offset276(int) {
+            return offset = 276;
+        }
+
+        virtual unsigned int offset277(int) {
+            return offset = 277;
+        }
+
+        virtual unsigned int offset278(int) {
+            return offset = 278;
+        }
+
+        virtual unsigned int offset279(int) {
+            return offset = 279;
+        }
+
+        virtual unsigned int offset280(int) {
+            return offset = 280;
+        }
+
+        virtual unsigned int offset281(int) {
+            return offset = 281;
+        }
+
+        virtual unsigned int offset282(int) {
+            return offset = 282;
+        }
+
+        virtual unsigned int offset283(int) {
+            return offset = 283;
+        }
+
+        virtual unsigned int offset284(int) {
+            return offset = 284;
+        }
+
+        virtual unsigned int offset285(int) {
+            return offset = 285;
+        }
+
+        virtual unsigned int offset286(int) {
+            return offset = 286;
+        }
+
+        virtual unsigned int offset287(int) {
+            return offset = 287;
+        }
+
+        virtual unsigned int offset288(int) {
+            return offset = 288;
+        }
+
+        virtual unsigned int offset289(int) {
+            return offset = 289;
+        }
+
+        virtual unsigned int offset290(int) {
+            return offset = 290;
+        }
+
+        virtual unsigned int offset291(int) {
+            return offset = 291;
+        }
+
+        virtual unsigned int offset292(int) {
+            return offset = 292;
+        }
+
+        virtual unsigned int offset293(int) {
+            return offset = 293;
+        }
+
+        virtual unsigned int offset294(int) {
+            return offset = 294;
+        }
+
+        virtual unsigned int offset295(int) {
+            return offset = 295;
+        }
+
+        virtual unsigned int offset296(int) {
+            return offset = 296;
+        }
+
+        virtual unsigned int offset297(int) {
+            return offset = 297;
+        }
+
+        virtual unsigned int offset298(int) {
+            return offset = 298;
+        }
+
+        virtual unsigned int offset299(int) {
+            return offset = 299;
+        }
+
+
+        virtual unsigned int offset300(int) {
+            return offset = 300;
+        }
+
+        virtual unsigned int offset301(int) {
+            return offset = 301;
+        }
+
+        virtual unsigned int offset302(int) {
+            return offset = 302;
+        }
+
+        virtual unsigned int offset303(int) {
+            return offset = 303;
+        }
+
+        virtual unsigned int offset304(int) {
+            return offset = 304;
+        }
+
+        virtual unsigned int offset305(int) {
+            return offset = 305;
+        }
+
+        virtual unsigned int offset306(int) {
+            return offset = 306;
+        }
+
+        virtual unsigned int offset307(int) {
+            return offset = 307;
+        }
+
+        virtual unsigned int offset308(int) {
+            return offset = 308;
+        }
+
+        virtual unsigned int offset309(int) {
+            return offset = 309;
+        }
+
+        virtual unsigned int offset310(int) {
+            return offset = 310;
+        }
+
+        virtual unsigned int offset311(int) {
+            return offset = 311;
+        }
+
+        virtual unsigned int offset312(int) {
+            return offset = 312;
+        }
+
+        virtual unsigned int offset313(int) {
+            return offset = 313;
+        }
+
+        virtual unsigned int offset314(int) {
+            return offset = 314;
+        }
+
+        virtual unsigned int offset315(int) {
+            return offset = 315;
+        }
+
+        virtual unsigned int offset316(int) {
+            return offset = 316;
+        }
+
+        virtual unsigned int offset317(int) {
+            return offset = 317;
+        }
+
+        virtual unsigned int offset318(int) {
+            return offset = 318;
+        }
+
+        virtual unsigned int offset319(int) {
+            return offset = 319;
+        }
+
+        virtual unsigned int offset320(int) {
+            return offset = 320;
+        }
+
+        virtual unsigned int offset321(int) {
+            return offset = 321;
+        }
+
+        virtual unsigned int offset322(int) {
+            return offset = 322;
+        }
+
+        virtual unsigned int offset323(int) {
+            return offset = 323;
+        }
+
+        virtual unsigned int offset324(int) {
+            return offset = 324;
+        }
+
+        virtual unsigned int offset325(int) {
+            return offset = 325;
+        }
+
+        virtual unsigned int offset326(int) {
+            return offset = 326;
+        }
+
+        virtual unsigned int offset327(int) {
+            return offset = 327;
+        }
+
+        virtual unsigned int offset328(int) {
+            return offset = 328;
+        }
+
+        virtual unsigned int offset329(int) {
+            return offset = 329;
+        }
+
+        virtual unsigned int offset330(int) {
+            return offset = 330;
+        }
+
+        virtual unsigned int offset331(int) {
+            return offset = 331;
+        }
+
+        virtual unsigned int offset332(int) {
+            return offset = 332;
+        }
+
+        virtual unsigned int offset333(int) {
+            return offset = 333;
+        }
+
+        virtual unsigned int offset334(int) {
+            return offset = 334;
+        }
+
+        virtual unsigned int offset335(int) {
+            return offset = 335;
+        }
+
+        virtual unsigned int offset336(int) {
+            return offset = 336;
+        }
+
+        virtual unsigned int offset337(int) {
+            return offset = 337;
+        }
+
+        virtual unsigned int offset338(int) {
+            return offset = 338;
+        }
+
+        virtual unsigned int offset339(int) {
+            return offset = 339;
+        }
+
+        virtual unsigned int offset340(int) {
+            return offset = 340;
+        }
+
+        virtual unsigned int offset341(int) {
+            return offset = 341;
+        }
+
+        virtual unsigned int offset342(int) {
+            return offset = 342;
+        }
+
+        virtual unsigned int offset343(int) {
+            return offset = 343;
+        }
+
+        virtual unsigned int offset344(int) {
+            return offset = 344;
+        }
+
+        virtual unsigned int offset345(int) {
+            return offset = 345;
+        }
+
+        virtual unsigned int offset346(int) {
+            return offset = 346;
+        }
+
+        virtual unsigned int offset347(int) {
+            return offset = 347;
+        }
+
+        virtual unsigned int offset348(int) {
+            return offset = 348;
+        }
+
+        virtual unsigned int offset349(int) {
+            return offset = 349;
+        }
+
+        virtual unsigned int offset350(int) {
+            return offset = 350;
+        }
+
+        virtual unsigned int offset351(int) {
+            return offset = 351;
+        }
+
+        virtual unsigned int offset352(int) {
+            return offset = 352;
+        }
+
+        virtual unsigned int offset353(int) {
+            return offset = 353;
+        }
+
+        virtual unsigned int offset354(int) {
+            return offset = 354;
+        }
+
+        virtual unsigned int offset355(int) {
+            return offset = 355;
+        }
+
+        virtual unsigned int offset356(int) {
+            return offset = 356;
+        }
+
+        virtual unsigned int offset357(int) {
+            return offset = 357;
+        }
+
+        virtual unsigned int offset358(int) {
+            return offset = 358;
+        }
+
+        virtual unsigned int offset359(int) {
+            return offset = 359;
+        }
+
+        virtual unsigned int offset360(int) {
+            return offset = 360;
+        }
+
+        virtual unsigned int offset361(int) {
+            return offset = 361;
+        }
+
+        virtual unsigned int offset362(int) {
+            return offset = 362;
+        }
+
+        virtual unsigned int offset363(int) {
+            return offset = 363;
+        }
+
+        virtual unsigned int offset364(int) {
+            return offset = 364;
+        }
+
+        virtual unsigned int offset365(int) {
+            return offset = 365;
+        }
+
+        virtual unsigned int offset366(int) {
+            return offset = 366;
+        }
+
+        virtual unsigned int offset367(int) {
+            return offset = 367;
+        }
+
+        virtual unsigned int offset368(int) {
+            return offset = 368;
+        }
+
+        virtual unsigned int offset369(int) {
+            return offset = 369;
+        }
+
+        virtual unsigned int offset370(int) {
+            return offset = 370;
+        }
+
+        virtual unsigned int offset371(int) {
+            return offset = 371;
+        }
+
+        virtual unsigned int offset372(int) {
+            return offset = 372;
+        }
+
+        virtual unsigned int offset373(int) {
+            return offset = 373;
+        }
+
+        virtual unsigned int offset374(int) {
+            return offset = 374;
+        }
+
+        virtual unsigned int offset375(int) {
+            return offset = 375;
+        }
+
+        virtual unsigned int offset376(int) {
+            return offset = 376;
+        }
+
+        virtual unsigned int offset377(int) {
+            return offset = 377;
+        }
+
+        virtual unsigned int offset378(int) {
+            return offset = 378;
+        }
+
+        virtual unsigned int offset379(int) {
+            return offset = 379;
+        }
+
+        virtual unsigned int offset380(int) {
+            return offset = 380;
+        }
+
+        virtual unsigned int offset381(int) {
+            return offset = 381;
+        }
+
+        virtual unsigned int offset382(int) {
+            return offset = 382;
+        }
+
+        virtual unsigned int offset383(int) {
+            return offset = 383;
+        }
+
+        virtual unsigned int offset384(int) {
+            return offset = 384;
+        }
+
+        virtual unsigned int offset385(int) {
+            return offset = 385;
+        }
+
+        virtual unsigned int offset386(int) {
+            return offset = 386;
+        }
+
+        virtual unsigned int offset387(int) {
+            return offset = 387;
+        }
+
+        virtual unsigned int offset388(int) {
+            return offset = 388;
+        }
+
+        virtual unsigned int offset389(int) {
+            return offset = 389;
+        }
+
+        virtual unsigned int offset390(int) {
+            return offset = 390;
+        }
+
+        virtual unsigned int offset391(int) {
+            return offset = 391;
+        }
+
+        virtual unsigned int offset392(int) {
+            return offset = 392;
+        }
+
+        virtual unsigned int offset393(int) {
+            return offset = 393;
+        }
+
+        virtual unsigned int offset394(int) {
+            return offset = 394;
+        }
+
+        virtual unsigned int offset395(int) {
+            return offset = 395;
+        }
+
+        virtual unsigned int offset396(int) {
+            return offset = 396;
+        }
+
+        virtual unsigned int offset397(int) {
+            return offset = 397;
+        }
+
+        virtual unsigned int offset398(int) {
+            return offset = 398;
+        }
+
+        virtual unsigned int offset399(int) {
+            return offset = 399;
+        }
+
+
+        virtual unsigned int offset400(int) {
+            return offset = 400;
+        }
+
+        virtual unsigned int offset401(int) {
+            return offset = 401;
+        }
+
+        virtual unsigned int offset402(int) {
+            return offset = 402;
+        }
+
+        virtual unsigned int offset403(int) {
+            return offset = 403;
+        }
+
+        virtual unsigned int offset404(int) {
+            return offset = 404;
+        }
+
+        virtual unsigned int offset405(int) {
+            return offset = 405;
+        }
+
+        virtual unsigned int offset406(int) {
+            return offset = 406;
+        }
+
+        virtual unsigned int offset407(int) {
+            return offset = 407;
+        }
+
+        virtual unsigned int offset408(int) {
+            return offset = 408;
+        }
+
+        virtual unsigned int offset409(int) {
+            return offset = 409;
+        }
+
+        virtual unsigned int offset410(int) {
+            return offset = 410;
+        }
+
+        virtual unsigned int offset411(int) {
+            return offset = 411;
+        }
+
+        virtual unsigned int offset412(int) {
+            return offset = 412;
+        }
+
+        virtual unsigned int offset413(int) {
+            return offset = 413;
+        }
+
+        virtual unsigned int offset414(int) {
+            return offset = 414;
+        }
+
+        virtual unsigned int offset415(int) {
+            return offset = 415;
+        }
+
+        virtual unsigned int offset416(int) {
+            return offset = 416;
+        }
+
+        virtual unsigned int offset417(int) {
+            return offset = 417;
+        }
+
+        virtual unsigned int offset418(int) {
+            return offset = 418;
+        }
+
+        virtual unsigned int offset419(int) {
+            return offset = 419;
+        }
+
+        virtual unsigned int offset420(int) {
+            return offset = 420;
+        }
+
+        virtual unsigned int offset421(int) {
+            return offset = 421;
+        }
+
+        virtual unsigned int offset422(int) {
+            return offset = 422;
+        }
+
+        virtual unsigned int offset423(int) {
+            return offset = 423;
+        }
+
+        virtual unsigned int offset424(int) {
+            return offset = 424;
+        }
+
+        virtual unsigned int offset425(int) {
+            return offset = 425;
+        }
+
+        virtual unsigned int offset426(int) {
+            return offset = 426;
+        }
+
+        virtual unsigned int offset427(int) {
+            return offset = 427;
+        }
+
+        virtual unsigned int offset428(int) {
+            return offset = 428;
+        }
+
+        virtual unsigned int offset429(int) {
+            return offset = 429;
+        }
+
+        virtual unsigned int offset430(int) {
+            return offset = 430;
+        }
+
+        virtual unsigned int offset431(int) {
+            return offset = 431;
+        }
+
+        virtual unsigned int offset432(int) {
+            return offset = 432;
+        }
+
+        virtual unsigned int offset433(int) {
+            return offset = 433;
+        }
+
+        virtual unsigned int offset434(int) {
+            return offset = 434;
+        }
+
+        virtual unsigned int offset435(int) {
+            return offset = 435;
+        }
+
+        virtual unsigned int offset436(int) {
+            return offset = 436;
+        }
+
+        virtual unsigned int offset437(int) {
+            return offset = 437;
+        }
+
+        virtual unsigned int offset438(int) {
+            return offset = 438;
+        }
+
+        virtual unsigned int offset439(int) {
+            return offset = 439;
+        }
+
+        virtual unsigned int offset440(int) {
+            return offset = 440;
+        }
+
+        virtual unsigned int offset441(int) {
+            return offset = 441;
+        }
+
+        virtual unsigned int offset442(int) {
+            return offset = 442;
+        }
+
+        virtual unsigned int offset443(int) {
+            return offset = 443;
+        }
+
+        virtual unsigned int offset444(int) {
+            return offset = 444;
+        }
+
+        virtual unsigned int offset445(int) {
+            return offset = 445;
+        }
+
+        virtual unsigned int offset446(int) {
+            return offset = 446;
+        }
+
+        virtual unsigned int offset447(int) {
+            return offset = 447;
+        }
+
+        virtual unsigned int offset448(int) {
+            return offset = 448;
+        }
+
+        virtual unsigned int offset449(int) {
+            return offset = 449;
+        }
+
+        virtual unsigned int offset450(int) {
+            return offset = 450;
+        }
+
+        virtual unsigned int offset451(int) {
+            return offset = 451;
+        }
+
+        virtual unsigned int offset452(int) {
+            return offset = 452;
+        }
+
+        virtual unsigned int offset453(int) {
+            return offset = 453;
+        }
+
+        virtual unsigned int offset454(int) {
+            return offset = 454;
+        }
+
+        virtual unsigned int offset455(int) {
+            return offset = 455;
+        }
+
+        virtual unsigned int offset456(int) {
+            return offset = 456;
+        }
+
+        virtual unsigned int offset457(int) {
+            return offset = 457;
+        }
+
+        virtual unsigned int offset458(int) {
+            return offset = 458;
+        }
+
+        virtual unsigned int offset459(int) {
+            return offset = 459;
+        }
+
+        virtual unsigned int offset460(int) {
+            return offset = 460;
+        }
+
+        virtual unsigned int offset461(int) {
+            return offset = 461;
+        }
+
+        virtual unsigned int offset462(int) {
+            return offset = 462;
+        }
+
+        virtual unsigned int offset463(int) {
+            return offset = 463;
+        }
+
+        virtual unsigned int offset464(int) {
+            return offset = 464;
+        }
+
+        virtual unsigned int offset465(int) {
+            return offset = 465;
+        }
+
+        virtual unsigned int offset466(int) {
+            return offset = 466;
+        }
+
+        virtual unsigned int offset467(int) {
+            return offset = 467;
+        }
+
+        virtual unsigned int offset468(int) {
+            return offset = 468;
+        }
+
+        virtual unsigned int offset469(int) {
+            return offset = 469;
+        }
+
+        virtual unsigned int offset470(int) {
+            return offset = 470;
+        }
+
+        virtual unsigned int offset471(int) {
+            return offset = 471;
+        }
+
+        virtual unsigned int offset472(int) {
+            return offset = 472;
+        }
+
+        virtual unsigned int offset473(int) {
+            return offset = 473;
+        }
+
+        virtual unsigned int offset474(int) {
+            return offset = 474;
+        }
+
+        virtual unsigned int offset475(int) {
+            return offset = 475;
+        }
+
+        virtual unsigned int offset476(int) {
+            return offset = 476;
+        }
+
+        virtual unsigned int offset477(int) {
+            return offset = 477;
+        }
+
+        virtual unsigned int offset478(int) {
+            return offset = 478;
+        }
+
+        virtual unsigned int offset479(int) {
+            return offset = 479;
+        }
+
+        virtual unsigned int offset480(int) {
+            return offset = 480;
+        }
+
+        virtual unsigned int offset481(int) {
+            return offset = 481;
+        }
+
+        virtual unsigned int offset482(int) {
+            return offset = 482;
+        }
+
+        virtual unsigned int offset483(int) {
+            return offset = 483;
+        }
+
+        virtual unsigned int offset484(int) {
+            return offset = 484;
+        }
+
+        virtual unsigned int offset485(int) {
+            return offset = 485;
+        }
+
+        virtual unsigned int offset486(int) {
+            return offset = 486;
+        }
+
+        virtual unsigned int offset487(int) {
+            return offset = 487;
+        }
+
+        virtual unsigned int offset488(int) {
+            return offset = 488;
+        }
+
+        virtual unsigned int offset489(int) {
+            return offset = 489;
+        }
+
+        virtual unsigned int offset490(int) {
+            return offset = 490;
+        }
+
+        virtual unsigned int offset491(int) {
+            return offset = 491;
+        }
+
+        virtual unsigned int offset492(int) {
+            return offset = 492;
+        }
+
+        virtual unsigned int offset493(int) {
+            return offset = 493;
+        }
+
+        virtual unsigned int offset494(int) {
+            return offset = 494;
+        }
+
+        virtual unsigned int offset495(int) {
+            return offset = 495;
+        }
+
+        virtual unsigned int offset496(int) {
+            return offset = 496;
+        }
+
+        virtual unsigned int offset497(int) {
+            return offset = 497;
+        }
+
+        virtual unsigned int offset498(int) {
+            return offset = 498;
+        }
+
+        virtual unsigned int offset499(int) {
+            return offset = 499;
+        }
+
+
+        virtual unsigned int offset500(int) {
+            return offset = 500;
+        }
+
+        virtual unsigned int offset501(int) {
+            return offset = 501;
+        }
+
+        virtual unsigned int offset502(int) {
+            return offset = 502;
+        }
+
+        virtual unsigned int offset503(int) {
+            return offset = 503;
+        }
+
+        virtual unsigned int offset504(int) {
+            return offset = 504;
+        }
+
+        virtual unsigned int offset505(int) {
+            return offset = 505;
+        }
+
+        virtual unsigned int offset506(int) {
+            return offset = 506;
+        }
+
+        virtual unsigned int offset507(int) {
+            return offset = 507;
+        }
+
+        virtual unsigned int offset508(int) {
+            return offset = 508;
+        }
+
+        virtual unsigned int offset509(int) {
+            return offset = 509;
+        }
+
+        virtual unsigned int offset510(int) {
+            return offset = 510;
+        }
+
+        virtual unsigned int offset511(int) {
+            return offset = 511;
+        }
+
+        virtual unsigned int offset512(int) {
+            return offset = 512;
+        }
+
+        virtual unsigned int offset513(int) {
+            return offset = 513;
+        }
+
+        virtual unsigned int offset514(int) {
+            return offset = 514;
+        }
+
+        virtual unsigned int offset515(int) {
+            return offset = 515;
+        }
+
+        virtual unsigned int offset516(int) {
+            return offset = 516;
+        }
+
+        virtual unsigned int offset517(int) {
+            return offset = 517;
+        }
+
+        virtual unsigned int offset518(int) {
+            return offset = 518;
+        }
+
+        virtual unsigned int offset519(int) {
+            return offset = 519;
+        }
+
+        virtual unsigned int offset520(int) {
+            return offset = 520;
+        }
+
+        virtual unsigned int offset521(int) {
+            return offset = 521;
+        }
+
+        virtual unsigned int offset522(int) {
+            return offset = 522;
+        }
+
+        virtual unsigned int offset523(int) {
+            return offset = 523;
+        }
+
+        virtual unsigned int offset524(int) {
+            return offset = 524;
+        }
+
+        virtual unsigned int offset525(int) {
+            return offset = 525;
+        }
+
+        virtual unsigned int offset526(int) {
+            return offset = 526;
+        }
+
+        virtual unsigned int offset527(int) {
+            return offset = 527;
+        }
+
+        virtual unsigned int offset528(int) {
+            return offset = 528;
+        }
+
+        virtual unsigned int offset529(int) {
+            return offset = 529;
+        }
+
+        virtual unsigned int offset530(int) {
+            return offset = 530;
+        }
+
+        virtual unsigned int offset531(int) {
+            return offset = 531;
+        }
+
+        virtual unsigned int offset532(int) {
+            return offset = 532;
+        }
+
+        virtual unsigned int offset533(int) {
+            return offset = 533;
+        }
+
+        virtual unsigned int offset534(int) {
+            return offset = 534;
+        }
+
+        virtual unsigned int offset535(int) {
+            return offset = 535;
+        }
+
+        virtual unsigned int offset536(int) {
+            return offset = 536;
+        }
+
+        virtual unsigned int offset537(int) {
+            return offset = 537;
+        }
+
+        virtual unsigned int offset538(int) {
+            return offset = 538;
+        }
+
+        virtual unsigned int offset539(int) {
+            return offset = 539;
+        }
+
+        virtual unsigned int offset540(int) {
+            return offset = 540;
+        }
+
+        virtual unsigned int offset541(int) {
+            return offset = 541;
+        }
+
+        virtual unsigned int offset542(int) {
+            return offset = 542;
+        }
+
+        virtual unsigned int offset543(int) {
+            return offset = 543;
+        }
+
+        virtual unsigned int offset544(int) {
+            return offset = 544;
+        }
+
+        virtual unsigned int offset545(int) {
+            return offset = 545;
+        }
+
+        virtual unsigned int offset546(int) {
+            return offset = 546;
+        }
+
+        virtual unsigned int offset547(int) {
+            return offset = 547;
+        }
+
+        virtual unsigned int offset548(int) {
+            return offset = 548;
+        }
+
+        virtual unsigned int offset549(int) {
+            return offset = 549;
+        }
+
+        virtual unsigned int offset550(int) {
+            return offset = 550;
+        }
+
+        virtual unsigned int offset551(int) {
+            return offset = 551;
+        }
+
+        virtual unsigned int offset552(int) {
+            return offset = 552;
+        }
+
+        virtual unsigned int offset553(int) {
+            return offset = 553;
+        }
+
+        virtual unsigned int offset554(int) {
+            return offset = 554;
+        }
+
+        virtual unsigned int offset555(int) {
+            return offset = 555;
+        }
+
+        virtual unsigned int offset556(int) {
+            return offset = 556;
+        }
+
+        virtual unsigned int offset557(int) {
+            return offset = 557;
+        }
+
+        virtual unsigned int offset558(int) {
+            return offset = 558;
+        }
+
+        virtual unsigned int offset559(int) {
+            return offset = 559;
+        }
+
+        virtual unsigned int offset560(int) {
+            return offset = 560;
+        }
+
+        virtual unsigned int offset561(int) {
+            return offset = 561;
+        }
+
+        virtual unsigned int offset562(int) {
+            return offset = 562;
+        }
+
+        virtual unsigned int offset563(int) {
+            return offset = 563;
+        }
+
+        virtual unsigned int offset564(int) {
+            return offset = 564;
+        }
+
+        virtual unsigned int offset565(int) {
+            return offset = 565;
+        }
+
+        virtual unsigned int offset566(int) {
+            return offset = 566;
+        }
+
+        virtual unsigned int offset567(int) {
+            return offset = 567;
+        }
+
+        virtual unsigned int offset568(int) {
+            return offset = 568;
+        }
+
+        virtual unsigned int offset569(int) {
+            return offset = 569;
+        }
+
+        virtual unsigned int offset570(int) {
+            return offset = 570;
+        }
+
+        virtual unsigned int offset571(int) {
+            return offset = 571;
+        }
+
+        virtual unsigned int offset572(int) {
+            return offset = 572;
+        }
+
+        virtual unsigned int offset573(int) {
+            return offset = 573;
+        }
+
+        virtual unsigned int offset574(int) {
+            return offset = 574;
+        }
+
+        virtual unsigned int offset575(int) {
+            return offset = 575;
+        }
+
+        virtual unsigned int offset576(int) {
+            return offset = 576;
+        }
+
+        virtual unsigned int offset577(int) {
+            return offset = 577;
+        }
+
+        virtual unsigned int offset578(int) {
+            return offset = 578;
+        }
+
+        virtual unsigned int offset579(int) {
+            return offset = 579;
+        }
+
+        virtual unsigned int offset580(int) {
+            return offset = 580;
+        }
+
+        virtual unsigned int offset581(int) {
+            return offset = 581;
+        }
+
+        virtual unsigned int offset582(int) {
+            return offset = 582;
+        }
+
+        virtual unsigned int offset583(int) {
+            return offset = 583;
+        }
+
+        virtual unsigned int offset584(int) {
+            return offset = 584;
+        }
+
+        virtual unsigned int offset585(int) {
+            return offset = 585;
+        }
+
+        virtual unsigned int offset586(int) {
+            return offset = 586;
+        }
+
+        virtual unsigned int offset587(int) {
+            return offset = 587;
+        }
+
+        virtual unsigned int offset588(int) {
+            return offset = 588;
+        }
+
+        virtual unsigned int offset589(int) {
+            return offset = 589;
+        }
+
+        virtual unsigned int offset590(int) {
+            return offset = 590;
+        }
+
+        virtual unsigned int offset591(int) {
+            return offset = 591;
+        }
+
+        virtual unsigned int offset592(int) {
+            return offset = 592;
+        }
+
+        virtual unsigned int offset593(int) {
+            return offset = 593;
+        }
+
+        virtual unsigned int offset594(int) {
+            return offset = 594;
+        }
+
+        virtual unsigned int offset595(int) {
+            return offset = 595;
+        }
+
+        virtual unsigned int offset596(int) {
+            return offset = 596;
+        }
+
+        virtual unsigned int offset597(int) {
+            return offset = 597;
+        }
+
+        virtual unsigned int offset598(int) {
+            return offset = 598;
+        }
+
+        virtual unsigned int offset599(int) {
+            return offset = 599;
+        }
+
+
+        virtual unsigned int offset600(int) {
+            return offset = 600;
+        }
+
+        virtual unsigned int offset601(int) {
+            return offset = 601;
+        }
+
+        virtual unsigned int offset602(int) {
+            return offset = 602;
+        }
+
+        virtual unsigned int offset603(int) {
+            return offset = 603;
+        }
+
+        virtual unsigned int offset604(int) {
+            return offset = 604;
+        }
+
+        virtual unsigned int offset605(int) {
+            return offset = 605;
+        }
+
+        virtual unsigned int offset606(int) {
+            return offset = 606;
+        }
+
+        virtual unsigned int offset607(int) {
+            return offset = 607;
+        }
+
+        virtual unsigned int offset608(int) {
+            return offset = 608;
+        }
+
+        virtual unsigned int offset609(int) {
+            return offset = 609;
+        }
+
+        virtual unsigned int offset610(int) {
+            return offset = 610;
+        }
+
+        virtual unsigned int offset611(int) {
+            return offset = 611;
+        }
+
+        virtual unsigned int offset612(int) {
+            return offset = 612;
+        }
+
+        virtual unsigned int offset613(int) {
+            return offset = 613;
+        }
+
+        virtual unsigned int offset614(int) {
+            return offset = 614;
+        }
+
+        virtual unsigned int offset615(int) {
+            return offset = 615;
+        }
+
+        virtual unsigned int offset616(int) {
+            return offset = 616;
+        }
+
+        virtual unsigned int offset617(int) {
+            return offset = 617;
+        }
+
+        virtual unsigned int offset618(int) {
+            return offset = 618;
+        }
+
+        virtual unsigned int offset619(int) {
+            return offset = 619;
+        }
+
+        virtual unsigned int offset620(int) {
+            return offset = 620;
+        }
+
+        virtual unsigned int offset621(int) {
+            return offset = 621;
+        }
+
+        virtual unsigned int offset622(int) {
+            return offset = 622;
+        }
+
+        virtual unsigned int offset623(int) {
+            return offset = 623;
+        }
+
+        virtual unsigned int offset624(int) {
+            return offset = 624;
+        }
+
+        virtual unsigned int offset625(int) {
+            return offset = 625;
+        }
+
+        virtual unsigned int offset626(int) {
+            return offset = 626;
+        }
+
+        virtual unsigned int offset627(int) {
+            return offset = 627;
+        }
+
+        virtual unsigned int offset628(int) {
+            return offset = 628;
+        }
+
+        virtual unsigned int offset629(int) {
+            return offset = 629;
+        }
+
+        virtual unsigned int offset630(int) {
+            return offset = 630;
+        }
+
+        virtual unsigned int offset631(int) {
+            return offset = 631;
+        }
+
+        virtual unsigned int offset632(int) {
+            return offset = 632;
+        }
+
+        virtual unsigned int offset633(int) {
+            return offset = 633;
+        }
+
+        virtual unsigned int offset634(int) {
+            return offset = 634;
+        }
+
+        virtual unsigned int offset635(int) {
+            return offset = 635;
+        }
+
+        virtual unsigned int offset636(int) {
+            return offset = 636;
+        }
+
+        virtual unsigned int offset637(int) {
+            return offset = 637;
+        }
+
+        virtual unsigned int offset638(int) {
+            return offset = 638;
+        }
+
+        virtual unsigned int offset639(int) {
+            return offset = 639;
+        }
+
+        virtual unsigned int offset640(int) {
+            return offset = 640;
+        }
+
+        virtual unsigned int offset641(int) {
+            return offset = 641;
+        }
+
+        virtual unsigned int offset642(int) {
+            return offset = 642;
+        }
+
+        virtual unsigned int offset643(int) {
+            return offset = 643;
+        }
+
+        virtual unsigned int offset644(int) {
+            return offset = 644;
+        }
+
+        virtual unsigned int offset645(int) {
+            return offset = 645;
+        }
+
+        virtual unsigned int offset646(int) {
+            return offset = 646;
+        }
+
+        virtual unsigned int offset647(int) {
+            return offset = 647;
+        }
+
+        virtual unsigned int offset648(int) {
+            return offset = 648;
+        }
+
+        virtual unsigned int offset649(int) {
+            return offset = 649;
+        }
+
+        virtual unsigned int offset650(int) {
+            return offset = 650;
+        }
+
+        virtual unsigned int offset651(int) {
+            return offset = 651;
+        }
+
+        virtual unsigned int offset652(int) {
+            return offset = 652;
+        }
+
+        virtual unsigned int offset653(int) {
+            return offset = 653;
+        }
+
+        virtual unsigned int offset654(int) {
+            return offset = 654;
+        }
+
+        virtual unsigned int offset655(int) {
+            return offset = 655;
+        }
+
+        virtual unsigned int offset656(int) {
+            return offset = 656;
+        }
+
+        virtual unsigned int offset657(int) {
+            return offset = 657;
+        }
+
+        virtual unsigned int offset658(int) {
+            return offset = 658;
+        }
+
+        virtual unsigned int offset659(int) {
+            return offset = 659;
+        }
+
+        virtual unsigned int offset660(int) {
+            return offset = 660;
+        }
+
+        virtual unsigned int offset661(int) {
+            return offset = 661;
+        }
+
+        virtual unsigned int offset662(int) {
+            return offset = 662;
+        }
+
+        virtual unsigned int offset663(int) {
+            return offset = 663;
+        }
+
+        virtual unsigned int offset664(int) {
+            return offset = 664;
+        }
+
+        virtual unsigned int offset665(int) {
+            return offset = 665;
+        }
+
+        virtual unsigned int offset666(int) {
+            return offset = 666;
+        }
+
+        virtual unsigned int offset667(int) {
+            return offset = 667;
+        }
+
+        virtual unsigned int offset668(int) {
+            return offset = 668;
+        }
+
+        virtual unsigned int offset669(int) {
+            return offset = 669;
+        }
+
+        virtual unsigned int offset670(int) {
+            return offset = 670;
+        }
+
+        virtual unsigned int offset671(int) {
+            return offset = 671;
+        }
+
+        virtual unsigned int offset672(int) {
+            return offset = 672;
+        }
+
+        virtual unsigned int offset673(int) {
+            return offset = 673;
+        }
+
+        virtual unsigned int offset674(int) {
+            return offset = 674;
+        }
+
+        virtual unsigned int offset675(int) {
+            return offset = 675;
+        }
+
+        virtual unsigned int offset676(int) {
+            return offset = 676;
+        }
+
+        virtual unsigned int offset677(int) {
+            return offset = 677;
+        }
+
+        virtual unsigned int offset678(int) {
+            return offset = 678;
+        }
+
+        virtual unsigned int offset679(int) {
+            return offset = 679;
+        }
+
+        virtual unsigned int offset680(int) {
+            return offset = 680;
+        }
+
+        virtual unsigned int offset681(int) {
+            return offset = 681;
+        }
+
+        virtual unsigned int offset682(int) {
+            return offset = 682;
+        }
+
+        virtual unsigned int offset683(int) {
+            return offset = 683;
+        }
+
+        virtual unsigned int offset684(int) {
+            return offset = 684;
+        }
+
+        virtual unsigned int offset685(int) {
+            return offset = 685;
+        }
+
+        virtual unsigned int offset686(int) {
+            return offset = 686;
+        }
+
+        virtual unsigned int offset687(int) {
+            return offset = 687;
+        }
+
+        virtual unsigned int offset688(int) {
+            return offset = 688;
+        }
+
+        virtual unsigned int offset689(int) {
+            return offset = 689;
+        }
+
+        virtual unsigned int offset690(int) {
+            return offset = 690;
+        }
+
+        virtual unsigned int offset691(int) {
+            return offset = 691;
+        }
+
+        virtual unsigned int offset692(int) {
+            return offset = 692;
+        }
+
+        virtual unsigned int offset693(int) {
+            return offset = 693;
+        }
+
+        virtual unsigned int offset694(int) {
+            return offset = 694;
+        }
+
+        virtual unsigned int offset695(int) {
+            return offset = 695;
+        }
+
+        virtual unsigned int offset696(int) {
+            return offset = 696;
+        }
+
+        virtual unsigned int offset697(int) {
+            return offset = 697;
+        }
+
+        virtual unsigned int offset698(int) {
+            return offset = 698;
+        }
+
+        virtual unsigned int offset699(int) {
+            return offset = 699;
+        }
+
+
+        virtual unsigned int offset700(int) {
+            return offset = 700;
+        }
+
+        virtual unsigned int offset701(int) {
+            return offset = 701;
+        }
+
+        virtual unsigned int offset702(int) {
+            return offset = 702;
+        }
+
+        virtual unsigned int offset703(int) {
+            return offset = 703;
+        }
+
+        virtual unsigned int offset704(int) {
+            return offset = 704;
+        }
+
+        virtual unsigned int offset705(int) {
+            return offset = 705;
+        }
+
+        virtual unsigned int offset706(int) {
+            return offset = 706;
+        }
+
+        virtual unsigned int offset707(int) {
+            return offset = 707;
+        }
+
+        virtual unsigned int offset708(int) {
+            return offset = 708;
+        }
+
+        virtual unsigned int offset709(int) {
+            return offset = 709;
+        }
+
+        virtual unsigned int offset710(int) {
+            return offset = 710;
+        }
+
+        virtual unsigned int offset711(int) {
+            return offset = 711;
+        }
+
+        virtual unsigned int offset712(int) {
+            return offset = 712;
+        }
+
+        virtual unsigned int offset713(int) {
+            return offset = 713;
+        }
+
+        virtual unsigned int offset714(int) {
+            return offset = 714;
+        }
+
+        virtual unsigned int offset715(int) {
+            return offset = 715;
+        }
+
+        virtual unsigned int offset716(int) {
+            return offset = 716;
+        }
+
+        virtual unsigned int offset717(int) {
+            return offset = 717;
+        }
+
+        virtual unsigned int offset718(int) {
+            return offset = 718;
+        }
+
+        virtual unsigned int offset719(int) {
+            return offset = 719;
+        }
+
+        virtual unsigned int offset720(int) {
+            return offset = 720;
+        }
+
+        virtual unsigned int offset721(int) {
+            return offset = 721;
+        }
+
+        virtual unsigned int offset722(int) {
+            return offset = 722;
+        }
+
+        virtual unsigned int offset723(int) {
+            return offset = 723;
+        }
+
+        virtual unsigned int offset724(int) {
+            return offset = 724;
+        }
+
+        virtual unsigned int offset725(int) {
+            return offset = 725;
+        }
+
+        virtual unsigned int offset726(int) {
+            return offset = 726;
+        }
+
+        virtual unsigned int offset727(int) {
+            return offset = 727;
+        }
+
+        virtual unsigned int offset728(int) {
+            return offset = 728;
+        }
+
+        virtual unsigned int offset729(int) {
+            return offset = 729;
+        }
+
+        virtual unsigned int offset730(int) {
+            return offset = 730;
+        }
+
+        virtual unsigned int offset731(int) {
+            return offset = 731;
+        }
+
+        virtual unsigned int offset732(int) {
+            return offset = 732;
+        }
+
+        virtual unsigned int offset733(int) {
+            return offset = 733;
+        }
+
+        virtual unsigned int offset734(int) {
+            return offset = 734;
+        }
+
+        virtual unsigned int offset735(int) {
+            return offset = 735;
+        }
+
+        virtual unsigned int offset736(int) {
+            return offset = 736;
+        }
+
+        virtual unsigned int offset737(int) {
+            return offset = 737;
+        }
+
+        virtual unsigned int offset738(int) {
+            return offset = 738;
+        }
+
+        virtual unsigned int offset739(int) {
+            return offset = 739;
+        }
+
+        virtual unsigned int offset740(int) {
+            return offset = 740;
+        }
+
+        virtual unsigned int offset741(int) {
+            return offset = 741;
+        }
+
+        virtual unsigned int offset742(int) {
+            return offset = 742;
+        }
+
+        virtual unsigned int offset743(int) {
+            return offset = 743;
+        }
+
+        virtual unsigned int offset744(int) {
+            return offset = 744;
+        }
+
+        virtual unsigned int offset745(int) {
+            return offset = 745;
+        }
+
+        virtual unsigned int offset746(int) {
+            return offset = 746;
+        }
+
+        virtual unsigned int offset747(int) {
+            return offset = 747;
+        }
+
+        virtual unsigned int offset748(int) {
+            return offset = 748;
+        }
+
+        virtual unsigned int offset749(int) {
+            return offset = 749;
+        }
+
+        virtual unsigned int offset750(int) {
+            return offset = 750;
+        }
+
+        virtual unsigned int offset751(int) {
+            return offset = 751;
+        }
+
+        virtual unsigned int offset752(int) {
+            return offset = 752;
+        }
+
+        virtual unsigned int offset753(int) {
+            return offset = 753;
+        }
+
+        virtual unsigned int offset754(int) {
+            return offset = 754;
+        }
+
+        virtual unsigned int offset755(int) {
+            return offset = 755;
+        }
+
+        virtual unsigned int offset756(int) {
+            return offset = 756;
+        }
+
+        virtual unsigned int offset757(int) {
+            return offset = 757;
+        }
+
+        virtual unsigned int offset758(int) {
+            return offset = 758;
+        }
+
+        virtual unsigned int offset759(int) {
+            return offset = 759;
+        }
+
+        virtual unsigned int offset760(int) {
+            return offset = 760;
+        }
+
+        virtual unsigned int offset761(int) {
+            return offset = 761;
+        }
+
+        virtual unsigned int offset762(int) {
+            return offset = 762;
+        }
+
+        virtual unsigned int offset763(int) {
+            return offset = 763;
+        }
+
+        virtual unsigned int offset764(int) {
+            return offset = 764;
+        }
+
+        virtual unsigned int offset765(int) {
+            return offset = 765;
+        }
+
+        virtual unsigned int offset766(int) {
+            return offset = 766;
+        }
+
+        virtual unsigned int offset767(int) {
+            return offset = 767;
+        }
+
+        virtual unsigned int offset768(int) {
+            return offset = 768;
+        }
+
+        virtual unsigned int offset769(int) {
+            return offset = 769;
+        }
+
+        virtual unsigned int offset770(int) {
+            return offset = 770;
+        }
+
+        virtual unsigned int offset771(int) {
+            return offset = 771;
+        }
+
+        virtual unsigned int offset772(int) {
+            return offset = 772;
+        }
+
+        virtual unsigned int offset773(int) {
+            return offset = 773;
+        }
+
+        virtual unsigned int offset774(int) {
+            return offset = 774;
+        }
+
+        virtual unsigned int offset775(int) {
+            return offset = 775;
+        }
+
+        virtual unsigned int offset776(int) {
+            return offset = 776;
+        }
+
+        virtual unsigned int offset777(int) {
+            return offset = 777;
+        }
+
+        virtual unsigned int offset778(int) {
+            return offset = 778;
+        }
+
+        virtual unsigned int offset779(int) {
+            return offset = 779;
+        }
+
+        virtual unsigned int offset780(int) {
+            return offset = 780;
+        }
+
+        virtual unsigned int offset781(int) {
+            return offset = 781;
+        }
+
+        virtual unsigned int offset782(int) {
+            return offset = 782;
+        }
+
+        virtual unsigned int offset783(int) {
+            return offset = 783;
+        }
+
+        virtual unsigned int offset784(int) {
+            return offset = 784;
+        }
+
+        virtual unsigned int offset785(int) {
+            return offset = 785;
+        }
+
+        virtual unsigned int offset786(int) {
+            return offset = 786;
+        }
+
+        virtual unsigned int offset787(int) {
+            return offset = 787;
+        }
+
+        virtual unsigned int offset788(int) {
+            return offset = 788;
+        }
+
+        virtual unsigned int offset789(int) {
+            return offset = 789;
+        }
+
+        virtual unsigned int offset790(int) {
+            return offset = 790;
+        }
+
+        virtual unsigned int offset791(int) {
+            return offset = 791;
+        }
+
+        virtual unsigned int offset792(int) {
+            return offset = 792;
+        }
+
+        virtual unsigned int offset793(int) {
+            return offset = 793;
+        }
+
+        virtual unsigned int offset794(int) {
+            return offset = 794;
+        }
+
+        virtual unsigned int offset795(int) {
+            return offset = 795;
+        }
+
+        virtual unsigned int offset796(int) {
+            return offset = 796;
+        }
+
+        virtual unsigned int offset797(int) {
+            return offset = 797;
+        }
+
+        virtual unsigned int offset798(int) {
+            return offset = 798;
+        }
+
+        virtual unsigned int offset799(int) {
+            return offset = 799;
+        }
+
+
+        virtual unsigned int offset800(int) {
+            return offset = 800;
+        }
+
+        virtual unsigned int offset801(int) {
+            return offset = 801;
+        }
+
+        virtual unsigned int offset802(int) {
+            return offset = 802;
+        }
+
+        virtual unsigned int offset803(int) {
+            return offset = 803;
+        }
+
+        virtual unsigned int offset804(int) {
+            return offset = 804;
+        }
+
+        virtual unsigned int offset805(int) {
+            return offset = 805;
+        }
+
+        virtual unsigned int offset806(int) {
+            return offset = 806;
+        }
+
+        virtual unsigned int offset807(int) {
+            return offset = 807;
+        }
+
+        virtual unsigned int offset808(int) {
+            return offset = 808;
+        }
+
+        virtual unsigned int offset809(int) {
+            return offset = 809;
+        }
+
+        virtual unsigned int offset810(int) {
+            return offset = 810;
+        }
+
+        virtual unsigned int offset811(int) {
+            return offset = 811;
+        }
+
+        virtual unsigned int offset812(int) {
+            return offset = 812;
+        }
+
+        virtual unsigned int offset813(int) {
+            return offset = 813;
+        }
+
+        virtual unsigned int offset814(int) {
+            return offset = 814;
+        }
+
+        virtual unsigned int offset815(int) {
+            return offset = 815;
+        }
+
+        virtual unsigned int offset816(int) {
+            return offset = 816;
+        }
+
+        virtual unsigned int offset817(int) {
+            return offset = 817;
+        }
+
+        virtual unsigned int offset818(int) {
+            return offset = 818;
+        }
+
+        virtual unsigned int offset819(int) {
+            return offset = 819;
+        }
+
+        virtual unsigned int offset820(int) {
+            return offset = 820;
+        }
+
+        virtual unsigned int offset821(int) {
+            return offset = 821;
+        }
+
+        virtual unsigned int offset822(int) {
+            return offset = 822;
+        }
+
+        virtual unsigned int offset823(int) {
+            return offset = 823;
+        }
+
+        virtual unsigned int offset824(int) {
+            return offset = 824;
+        }
+
+        virtual unsigned int offset825(int) {
+            return offset = 825;
+        }
+
+        virtual unsigned int offset826(int) {
+            return offset = 826;
+        }
+
+        virtual unsigned int offset827(int) {
+            return offset = 827;
+        }
+
+        virtual unsigned int offset828(int) {
+            return offset = 828;
+        }
+
+        virtual unsigned int offset829(int) {
+            return offset = 829;
+        }
+
+        virtual unsigned int offset830(int) {
+            return offset = 830;
+        }
+
+        virtual unsigned int offset831(int) {
+            return offset = 831;
+        }
+
+        virtual unsigned int offset832(int) {
+            return offset = 832;
+        }
+
+        virtual unsigned int offset833(int) {
+            return offset = 833;
+        }
+
+        virtual unsigned int offset834(int) {
+            return offset = 834;
+        }
+
+        virtual unsigned int offset835(int) {
+            return offset = 835;
+        }
+
+        virtual unsigned int offset836(int) {
+            return offset = 836;
+        }
+
+        virtual unsigned int offset837(int) {
+            return offset = 837;
+        }
+
+        virtual unsigned int offset838(int) {
+            return offset = 838;
+        }
+
+        virtual unsigned int offset839(int) {
+            return offset = 839;
+        }
+
+        virtual unsigned int offset840(int) {
+            return offset = 840;
+        }
+
+        virtual unsigned int offset841(int) {
+            return offset = 841;
+        }
+
+        virtual unsigned int offset842(int) {
+            return offset = 842;
+        }
+
+        virtual unsigned int offset843(int) {
+            return offset = 843;
+        }
+
+        virtual unsigned int offset844(int) {
+            return offset = 844;
+        }
+
+        virtual unsigned int offset845(int) {
+            return offset = 845;
+        }
+
+        virtual unsigned int offset846(int) {
+            return offset = 846;
+        }
+
+        virtual unsigned int offset847(int) {
+            return offset = 847;
+        }
+
+        virtual unsigned int offset848(int) {
+            return offset = 848;
+        }
+
+        virtual unsigned int offset849(int) {
+            return offset = 849;
+        }
+
+        virtual unsigned int offset850(int) {
+            return offset = 850;
+        }
+
+        virtual unsigned int offset851(int) {
+            return offset = 851;
+        }
+
+        virtual unsigned int offset852(int) {
+            return offset = 852;
+        }
+
+        virtual unsigned int offset853(int) {
+            return offset = 853;
+        }
+
+        virtual unsigned int offset854(int) {
+            return offset = 854;
+        }
+
+        virtual unsigned int offset855(int) {
+            return offset = 855;
+        }
+
+        virtual unsigned int offset856(int) {
+            return offset = 856;
+        }
+
+        virtual unsigned int offset857(int) {
+            return offset = 857;
+        }
+
+        virtual unsigned int offset858(int) {
+            return offset = 858;
+        }
+
+        virtual unsigned int offset859(int) {
+            return offset = 859;
+        }
+
+        virtual unsigned int offset860(int) {
+            return offset = 860;
+        }
+
+        virtual unsigned int offset861(int) {
+            return offset = 861;
+        }
+
+        virtual unsigned int offset862(int) {
+            return offset = 862;
+        }
+
+        virtual unsigned int offset863(int) {
+            return offset = 863;
+        }
+
+        virtual unsigned int offset864(int) {
+            return offset = 864;
+        }
+
+        virtual unsigned int offset865(int) {
+            return offset = 865;
+        }
+
+        virtual unsigned int offset866(int) {
+            return offset = 866;
+        }
+
+        virtual unsigned int offset867(int) {
+            return offset = 867;
+        }
+
+        virtual unsigned int offset868(int) {
+            return offset = 868;
+        }
+
+        virtual unsigned int offset869(int) {
+            return offset = 869;
+        }
+
+        virtual unsigned int offset870(int) {
+            return offset = 870;
+        }
+
+        virtual unsigned int offset871(int) {
+            return offset = 871;
+        }
+
+        virtual unsigned int offset872(int) {
+            return offset = 872;
+        }
+
+        virtual unsigned int offset873(int) {
+            return offset = 873;
+        }
+
+        virtual unsigned int offset874(int) {
+            return offset = 874;
+        }
+
+        virtual unsigned int offset875(int) {
+            return offset = 875;
+        }
+
+        virtual unsigned int offset876(int) {
+            return offset = 876;
+        }
+
+        virtual unsigned int offset877(int) {
+            return offset = 877;
+        }
+
+        virtual unsigned int offset878(int) {
+            return offset = 878;
+        }
+
+        virtual unsigned int offset879(int) {
+            return offset = 879;
+        }
+
+        virtual unsigned int offset880(int) {
+            return offset = 880;
+        }
+
+        virtual unsigned int offset881(int) {
+            return offset = 881;
+        }
+
+        virtual unsigned int offset882(int) {
+            return offset = 882;
+        }
+
+        virtual unsigned int offset883(int) {
+            return offset = 883;
+        }
+
+        virtual unsigned int offset884(int) {
+            return offset = 884;
+        }
+
+        virtual unsigned int offset885(int) {
+            return offset = 885;
+        }
+
+        virtual unsigned int offset886(int) {
+            return offset = 886;
+        }
+
+        virtual unsigned int offset887(int) {
+            return offset = 887;
+        }
+
+        virtual unsigned int offset888(int) {
+            return offset = 888;
+        }
+
+        virtual unsigned int offset889(int) {
+            return offset = 889;
+        }
+
+        virtual unsigned int offset890(int) {
+            return offset = 890;
+        }
+
+        virtual unsigned int offset891(int) {
+            return offset = 891;
+        }
+
+        virtual unsigned int offset892(int) {
+            return offset = 892;
+        }
+
+        virtual unsigned int offset893(int) {
+            return offset = 893;
+        }
+
+        virtual unsigned int offset894(int) {
+            return offset = 894;
+        }
+
+        virtual unsigned int offset895(int) {
+            return offset = 895;
+        }
+
+        virtual unsigned int offset896(int) {
+            return offset = 896;
+        }
+
+        virtual unsigned int offset897(int) {
+            return offset = 897;
+        }
+
+        virtual unsigned int offset898(int) {
+            return offset = 898;
+        }
+
+        virtual unsigned int offset899(int) {
+            return offset = 899;
+        }
+
+
+        virtual unsigned int offset900(int) {
+            return offset = 900;
+        }
+
+        virtual unsigned int offset901(int) {
+            return offset = 901;
+        }
+
+        virtual unsigned int offset902(int) {
+            return offset = 902;
+        }
+
+        virtual unsigned int offset903(int) {
+            return offset = 903;
+        }
+
+        virtual unsigned int offset904(int) {
+            return offset = 904;
+        }
+
+        virtual unsigned int offset905(int) {
+            return offset = 905;
+        }
+
+        virtual unsigned int offset906(int) {
+            return offset = 906;
+        }
+
+        virtual unsigned int offset907(int) {
+            return offset = 907;
+        }
+
+        virtual unsigned int offset908(int) {
+            return offset = 908;
+        }
+
+        virtual unsigned int offset909(int) {
+            return offset = 909;
+        }
+
+        virtual unsigned int offset910(int) {
+            return offset = 910;
+        }
+
+        virtual unsigned int offset911(int) {
+            return offset = 911;
+        }
+
+        virtual unsigned int offset912(int) {
+            return offset = 912;
+        }
+
+        virtual unsigned int offset913(int) {
+            return offset = 913;
+        }
+
+        virtual unsigned int offset914(int) {
+            return offset = 914;
+        }
+
+        virtual unsigned int offset915(int) {
+            return offset = 915;
+        }
+
+        virtual unsigned int offset916(int) {
+            return offset = 916;
+        }
+
+        virtual unsigned int offset917(int) {
+            return offset = 917;
+        }
+
+        virtual unsigned int offset918(int) {
+            return offset = 918;
+        }
+
+        virtual unsigned int offset919(int) {
+            return offset = 919;
+        }
+
+        virtual unsigned int offset920(int) {
+            return offset = 920;
+        }
+
+        virtual unsigned int offset921(int) {
+            return offset = 921;
+        }
+
+        virtual unsigned int offset922(int) {
+            return offset = 922;
+        }
+
+        virtual unsigned int offset923(int) {
+            return offset = 923;
+        }
+
+        virtual unsigned int offset924(int) {
+            return offset = 924;
+        }
+
+        virtual unsigned int offset925(int) {
+            return offset = 925;
+        }
+
+        virtual unsigned int offset926(int) {
+            return offset = 926;
+        }
+
+        virtual unsigned int offset927(int) {
+            return offset = 927;
+        }
+
+        virtual unsigned int offset928(int) {
+            return offset = 928;
+        }
+
+        virtual unsigned int offset929(int) {
+            return offset = 929;
+        }
+
+        virtual unsigned int offset930(int) {
+            return offset = 930;
+        }
+
+        virtual unsigned int offset931(int) {
+            return offset = 931;
+        }
+
+        virtual unsigned int offset932(int) {
+            return offset = 932;
+        }
+
+        virtual unsigned int offset933(int) {
+            return offset = 933;
+        }
+
+        virtual unsigned int offset934(int) {
+            return offset = 934;
+        }
+
+        virtual unsigned int offset935(int) {
+            return offset = 935;
+        }
+
+        virtual unsigned int offset936(int) {
+            return offset = 936;
+        }
+
+        virtual unsigned int offset937(int) {
+            return offset = 937;
+        }
+
+        virtual unsigned int offset938(int) {
+            return offset = 938;
+        }
+
+        virtual unsigned int offset939(int) {
+            return offset = 939;
+        }
+
+        virtual unsigned int offset940(int) {
+            return offset = 940;
+        }
+
+        virtual unsigned int offset941(int) {
+            return offset = 941;
+        }
+
+        virtual unsigned int offset942(int) {
+            return offset = 942;
+        }
+
+        virtual unsigned int offset943(int) {
+            return offset = 943;
+        }
+
+        virtual unsigned int offset944(int) {
+            return offset = 944;
+        }
+
+        virtual unsigned int offset945(int) {
+            return offset = 945;
+        }
+
+        virtual unsigned int offset946(int) {
+            return offset = 946;
+        }
+
+        virtual unsigned int offset947(int) {
+            return offset = 947;
+        }
+
+        virtual unsigned int offset948(int) {
+            return offset = 948;
+        }
+
+        virtual unsigned int offset949(int) {
+            return offset = 949;
+        }
+
+        virtual unsigned int offset950(int) {
+            return offset = 950;
+        }
+
+        virtual unsigned int offset951(int) {
+            return offset = 951;
+        }
+
+        virtual unsigned int offset952(int) {
+            return offset = 952;
+        }
+
+        virtual unsigned int offset953(int) {
+            return offset = 953;
+        }
+
+        virtual unsigned int offset954(int) {
+            return offset = 954;
+        }
+
+        virtual unsigned int offset955(int) {
+            return offset = 955;
+        }
+
+        virtual unsigned int offset956(int) {
+            return offset = 956;
+        }
+
+        virtual unsigned int offset957(int) {
+            return offset = 957;
+        }
+
+        virtual unsigned int offset958(int) {
+            return offset = 958;
+        }
+
+        virtual unsigned int offset959(int) {
+            return offset = 959;
+        }
+
+        virtual unsigned int offset960(int) {
+            return offset = 960;
+        }
+
+        virtual unsigned int offset961(int) {
+            return offset = 961;
+        }
+
+        virtual unsigned int offset962(int) {
+            return offset = 962;
+        }
+
+        virtual unsigned int offset963(int) {
+            return offset = 963;
+        }
+
+        virtual unsigned int offset964(int) {
+            return offset = 964;
+        }
+
+        virtual unsigned int offset965(int) {
+            return offset = 965;
+        }
+
+        virtual unsigned int offset966(int) {
+            return offset = 966;
+        }
+
+        virtual unsigned int offset967(int) {
+            return offset = 967;
+        }
+
+        virtual unsigned int offset968(int) {
+            return offset = 968;
+        }
+
+        virtual unsigned int offset969(int) {
+            return offset = 969;
+        }
+
+        virtual unsigned int offset970(int) {
+            return offset = 970;
+        }
+
+        virtual unsigned int offset971(int) {
+            return offset = 971;
+        }
+
+        virtual unsigned int offset972(int) {
+            return offset = 972;
+        }
+
+        virtual unsigned int offset973(int) {
+            return offset = 973;
+        }
+
+        virtual unsigned int offset974(int) {
+            return offset = 974;
+        }
+
+        virtual unsigned int offset975(int) {
+            return offset = 975;
+        }
+
+        virtual unsigned int offset976(int) {
+            return offset = 976;
+        }
+
+        virtual unsigned int offset977(int) {
+            return offset = 977;
+        }
+
+        virtual unsigned int offset978(int) {
+            return offset = 978;
+        }
+
+        virtual unsigned int offset979(int) {
+            return offset = 979;
+        }
+
+        virtual unsigned int offset980(int) {
+            return offset = 980;
+        }
+
+        virtual unsigned int offset981(int) {
+            return offset = 981;
+        }
+
+        virtual unsigned int offset982(int) {
+            return offset = 982;
+        }
+
+        virtual unsigned int offset983(int) {
+            return offset = 983;
+        }
+
+        virtual unsigned int offset984(int) {
+            return offset = 984;
+        }
+
+        virtual unsigned int offset985(int) {
+            return offset = 985;
+        }
+
+        virtual unsigned int offset986(int) {
+            return offset = 986;
+        }
+
+        virtual unsigned int offset987(int) {
+            return offset = 987;
+        }
+
+        virtual unsigned int offset988(int) {
+            return offset = 988;
+        }
+
+        virtual unsigned int offset989(int) {
+            return offset = 989;
+        }
+
+        virtual unsigned int offset990(int) {
+            return offset = 990;
+        }
+
+        virtual unsigned int offset991(int) {
+            return offset = 991;
+        }
+
+        virtual unsigned int offset992(int) {
+            return offset = 992;
+        }
+
+        virtual unsigned int offset993(int) {
+            return offset = 993;
+        }
+
+        virtual unsigned int offset994(int) {
+            return offset = 994;
+        }
+
+        virtual unsigned int offset995(int) {
+            return offset = 995;
+        }
+
+        virtual unsigned int offset996(int) {
+            return offset = 996;
+        }
+
+        virtual unsigned int offset997(int) {
+            return offset = 997;
+        }
+
+        virtual unsigned int offset998(int) {
+            return offset = 998;
+        }
+
+        virtual unsigned int offset999(int) {
+            return offset = 999;
+        }
+
+        virtual unsigned int offset1000(int) {
+            return offset = 1000;
+        }
+
+    };
+}
+namespace fakeit {
+
+    template<typename TARGET, typename SOURCE>
+    TARGET union_cast(SOURCE source) {
+
+        union {
+            SOURCE source;
+            TARGET target;
+        } u;
+        u.source = source;
+        return u.target;
+    }
+
+}
+
+namespace fakeit {
+    class NoVirtualDtor {
+    };
+
+    class VTUtils {
+    public:
+
+        template<typename C, typename R, typename ... arglist>
+        static unsigned int getOffset(R (C::*vMethod)(arglist...)) {
+            auto sMethod = reinterpret_cast<unsigned int (VirtualOffsetSelector::*)(int)>(vMethod);
+            VirtualOffsetSelector offsetSelctor;
+            return (offsetSelctor.*sMethod)(0);
+        }
+
+        template<typename C>
+        static typename std::enable_if<std::has_virtual_destructor<C>::value, unsigned int>::type
+        getDestructorOffset() {
+            VirtualOffsetSelector offsetSelctor;
+            union_cast<C *>(&offsetSelctor)->~C();
+            return offsetSelctor.offset;
+        }
+
+        template<typename C>
+        static typename std::enable_if<!std::has_virtual_destructor<C>::value, unsigned int>::type
+        getDestructorOffset() {
+            throw NoVirtualDtor();
+        }
+
+        template<typename C>
+        static unsigned int getVTSize() {
+            struct Derrived : public C {
+                virtual void endOfVt() {
+                }
+            };
+
+            unsigned int vtSize = getOffset(&Derrived::endOfVt);
+            return vtSize;
+        }
+    };
+
+
+}
+#ifdef _MSC_VER
+namespace fakeit {
+
+    typedef unsigned long dword_;
+
+    struct TypeDescriptor {
+        TypeDescriptor() :
+                ptrToVTable(0), spare(0) {
+
+            int **tiVFTPtr = (int **) (&typeid(void));
+            int *i = (int *) tiVFTPtr[0];
+			char *type_info_vft_ptr = (char *) i;
+            ptrToVTable = type_info_vft_ptr;
+        }
+
+		char *ptrToVTable;
+        dword_ spare;
+        char name[8];
+    };
+
+    struct PMD {
+
+
+
+        int mdisp;
+
+        int pdisp;
+        int vdisp;
+
+        PMD() :
+                mdisp(0), pdisp(-1), vdisp(0) {
+        }
+    };
+
+    struct RTTIBaseClassDescriptor {
+        RTTIBaseClassDescriptor() :
+                pTypeDescriptor(nullptr), numContainedBases(0), attributes(0) {
+        }
+
+        const std::type_info *pTypeDescriptor;
+        dword_ numContainedBases;
+        struct PMD where;
+        dword_ attributes;
+    };
+
+    template<typename C, typename... baseclasses>
+    struct RTTIClassHierarchyDescriptor {
+        RTTIClassHierarchyDescriptor() :
+                signature(0),
+                attributes(0),
+                numBaseClasses(0),
+                pBaseClassArray(nullptr) {
+            pBaseClassArray = new RTTIBaseClassDescriptor *[1 + sizeof...(baseclasses)];
+            addBaseClass < C, baseclasses...>();
+        }
+
+        ~RTTIClassHierarchyDescriptor() {
+            for (int i = 0; i < 1 + sizeof...(baseclasses); i++) {
+                RTTIBaseClassDescriptor *desc = pBaseClassArray[i];
+                delete desc;
+            }
+            delete[] pBaseClassArray;
+        }
+
+        dword_ signature;
+        dword_ attributes;
+        dword_ numBaseClasses;
+        RTTIBaseClassDescriptor **pBaseClassArray;
+
+        template<typename BaseType>
+        void addBaseClass() {
+            static_assert(std::is_base_of<BaseType, C>::value, "C must be a derived class of BaseType");
+            RTTIBaseClassDescriptor *desc = new RTTIBaseClassDescriptor();
+            desc->pTypeDescriptor = &typeid(BaseType);
+            pBaseClassArray[numBaseClasses] = desc;
+            for (unsigned int i = 0; i < numBaseClasses; i++) {
+                pBaseClassArray[i]->numContainedBases++;
+            }
+            numBaseClasses++;
+        }
+
+        template<typename head, typename B1, typename... tail>
+        void addBaseClass() {
+            static_assert(std::is_base_of<B1, head>::value, "invalid inheritance list");
+            addBaseClass<head>();
+            addBaseClass<B1, tail...>();
+        }
+
+    };
+
+	template<typename C, typename... baseclasses>
+	struct RTTICompleteObjectLocator {
+#ifdef _WIN64
+		RTTICompleteObjectLocator(const std::type_info &unused) :
+			signature(0), offset(0), cdOffset(0),
+			typeDescriptorOffset(0), classDescriptorOffset(0)
+		{
+		}
+
+		dword_ signature;
+		dword_ offset;
+		dword_ cdOffset;
+		dword_ typeDescriptorOffset;
+		dword_ classDescriptorOffset;
+#else
+		RTTICompleteObjectLocator(const std::type_info &info) :
+			signature(0), offset(0), cdOffset(0),
+			pTypeDescriptor(&info),
+			pClassDescriptor(new RTTIClassHierarchyDescriptor<C, baseclasses...>()) {
+		}
+
+		~RTTICompleteObjectLocator() {
+			delete pClassDescriptor;
+		}
+
+		dword_ signature;
+		dword_ offset;
+		dword_ cdOffset;
+		const std::type_info *pTypeDescriptor;
+		struct RTTIClassHierarchyDescriptor<C, baseclasses...> *pClassDescriptor;
+#endif
+	};
+
+
+    struct VirtualTableBase {
+
+        static VirtualTableBase &getVTable(void *instance) {
+            fakeit::VirtualTableBase *vt = (fakeit::VirtualTableBase *) (instance);
+            return *vt;
+        }
+
+        VirtualTableBase(void **firstMethod) : _firstMethod(firstMethod) { }
+
+        void *getCookie(int index) {
+            return _firstMethod[-2 - index];
+        }
+
+        void setCookie(int index, void *value) {
+            _firstMethod[-2 - index] = value;
+        }
+
+        void *getMethod(unsigned int index) const {
+            return _firstMethod[index];
+        }
+
+        void setMethod(unsigned int index, void *method) {
+            _firstMethod[index] = method;
+        }
+
+    protected:
+        void **_firstMethod;
+    };
+
+    template<class C, class... baseclasses>
+    struct VirtualTable : public VirtualTableBase {
+
+        class Handle {
+
+            friend struct VirtualTable<C, baseclasses...>;
+
+            void **firstMethod;
+
+            Handle(void **method) : firstMethod(method) { }
+
+        public:
+
+            VirtualTable<C, baseclasses...> &restore() {
+                VirtualTable<C, baseclasses...> *vt = (VirtualTable<C, baseclasses...> *) this;
+                return *vt;
+            }
+        };
+
+        static VirtualTable<C, baseclasses...> &getVTable(C &instance) {
+            fakeit::VirtualTable<C, baseclasses...> *vt = (fakeit::VirtualTable<C, baseclasses...> *) (&instance);
+            return *vt;
+        }
+
+        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+            unsigned int size = VTUtils::getVTSize<C>();
+            for (unsigned int i = 0; i < size; i++) {
+                _firstMethod[i] = from.getMethod(i);
+            }
+        }
+
+        VirtualTable() : VirtualTable(buildVTArray()) {
+        }
+
+        ~VirtualTable() {
+
+        }
+
+        void dispose() {
+            _firstMethod--;
+            RTTICompleteObjectLocator<C, baseclasses...> *locator = (RTTICompleteObjectLocator<C, baseclasses...> *) _firstMethod[0];
+            delete locator;
+            _firstMethod -= numOfCookies;
+            delete[] _firstMethod;
+        }
+
+
+        unsigned int dtor(int) {
+            C *c = (C *) this;
+            C &cRef = *c;
+            auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
+            void *dtorPtr = vt.getCookie(numOfCookies - 1);
+            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
+            method(c);
+            return 0;
+        }
+
+        void setDtor(void *method) {
+
+
+
+
+
+            void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
+            unsigned int index = VTUtils::getDestructorOffset<C>();
+            _firstMethod[index] = dtorPtr;
+            setCookie(numOfCookies - 1, method);
+        }
+
+        unsigned int getSize() {
+            return VTUtils::getVTSize<C>();
+        }
+
+        void initAll(void *value) {
+            auto size = getSize();
+            for (unsigned int i = 0; i < size; i++) {
+                setMethod(i, value);
+            }
+        }
+
+        Handle createHandle() {
+            Handle h(_firstMethod);
+            return h;
+        }
+
+    private:
+
+        class SimpleType {
+        };
+
+        static_assert(sizeof(unsigned int (SimpleType::*)()) == sizeof(unsigned int (C::*)()),
+            "Can't mock a type with multiple inheritance or with non-polymorphic base class");
+        static const unsigned int numOfCookies = 3;
+
+        static void **buildVTArray() {
+            int vtSize = VTUtils::getVTSize<C>();
+            auto array = new void *[vtSize + numOfCookies + 1]{};
+            RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
+                    typeid(C));
+            array += numOfCookies;
+            array[0] = objectLocator;
+            array++;
+            return array;
+        }
+
+        VirtualTable(void **firstMethod) : VirtualTableBase(firstMethod) {
+        }
+    };
+}
+#else
+#ifndef __clang__
+#include <type_traits>
+#include <tr2/type_traits>
+
+namespace fakeit {
+    template<typename ... T1>
+    class has_one_base {
+    };
+
+    template<typename T1, typename T2, typename ... types>
+    class has_one_base<std::tr2::__reflection_typelist<T1, T2, types...>> : public std::false_type {
+    };
+
+    template<typename T1>
+    class has_one_base<std::tr2::__reflection_typelist<T1>>
+            : public has_one_base<typename std::tr2::direct_bases<T1>::type> {
+    };
+
+    template<>
+    class has_one_base<std::tr2::__reflection_typelist<>> : public std::true_type {
+    };
+
+    template<typename T>
+    class is_simple_inheritance_layout : public has_one_base<typename std::tr2::direct_bases<T>::type> {
+    };
+}
+
+#endif
+
+namespace fakeit {
+
+    struct VirtualTableBase {
+
+        static VirtualTableBase &getVTable(void *instance) {
+            fakeit::VirtualTableBase *vt = (fakeit::VirtualTableBase *) (instance);
+            return *vt;
+        }
+
+        VirtualTableBase(void **firstMethod) : _firstMethod(firstMethod) { }
+
+        void *getCookie(int index) {
+            return _firstMethod[-3 - index];
+        }
+
+        void setCookie(int index, void *value) {
+            _firstMethod[-3 - index] = value;
+        }
+
+        void *getMethod(unsigned int index) const {
+            return _firstMethod[index];
+        }
+
+        void setMethod(unsigned int index, void *method) {
+            _firstMethod[index] = method;
+        }
+
+    protected:
+        void **_firstMethod;
+    };
+
+    template<class C, class ... baseclasses>
+    struct VirtualTable : public VirtualTableBase {
+
+#ifndef __clang__
+        static_assert(is_simple_inheritance_layout<C>::value, "Can't mock a type with multiple inheritance");
+#endif
+
+        class Handle {
+
+            friend struct VirtualTable<C, baseclasses...>;
+            void **firstMethod;
+
+            Handle(void **method) :
+                    firstMethod(method) {
+            }
+
+        public:
+
+            VirtualTable<C, baseclasses...> &restore() {
+                VirtualTable<C, baseclasses...> *vt = (VirtualTable<C, baseclasses...> *) this;
+                return *vt;
+            }
+        };
+
+        static VirtualTable<C, baseclasses...> &getVTable(C &instance) {
+            fakeit::VirtualTable<C, baseclasses...> *vt = (fakeit::VirtualTable<C, baseclasses...> *) (&instance);
+            return *vt;
+        }
+
+        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+            unsigned int size = VTUtils::getVTSize<C>();
+
+            for (size_t i = 0; i < size; ++i) {
+                _firstMethod[i] = from.getMethod(i);
+            }
+        }
+
+        VirtualTable() :
+                VirtualTable(buildVTArray()) {
+        }
+
+        void dispose() {
+            _firstMethod--;
+            _firstMethod--;
+            _firstMethod -= numOfCookies;
+            delete[] _firstMethod;
+        }
+
+        unsigned int dtor(int) {
+            C *c = (C *) this;
+            C &cRef = *c;
+            auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
+            unsigned int index = VTUtils::getDestructorOffset<C>();
+            void *dtorPtr = vt.getMethod(index);
+            void(*method)(C *) = union_cast<void (*)(C *)>(dtorPtr);
+            method(c);
+            return 0;
+        }
+
+
+        void setDtor(void *method) {
+            unsigned int index = VTUtils::getDestructorOffset<C>();
+            void *dtorPtr = union_cast<void *>(&VirtualTable<C, baseclasses...>::dtor);
+
+
+            _firstMethod[index] = method;
+
+            _firstMethod[index + 1] = dtorPtr;
+        }
+
+
+        unsigned int getSize() {
+            return VTUtils::getVTSize<C>();
+        }
+
+        void initAll(void *value) {
+            unsigned int size = getSize();
+            for (unsigned int i = 0; i < size; i++) {
+                setMethod(i, value);
+            }
+        }
+
+        const std::type_info *getTypeId() {
+            return (const std::type_info *) (_firstMethod[-1]);
+        }
+
+        Handle createHandle() {
+            Handle h(_firstMethod);
+            return h;
+        }
+
+    private:
+        static const unsigned int numOfCookies = 2;
+
+        static void **buildVTArray() {
+            int size = VTUtils::getVTSize<C>();
+            auto array = new void *[size + 2 + numOfCookies]{};
+            array += numOfCookies;
+            array++;
+            array[0] = const_cast<std::type_info *>(&typeid(C));
+            array++;
+            return array;
+        }
+
+        VirtualTable(void **firstMethod) : VirtualTableBase(firstMethod) {
+        }
+
+    };
+}
+#endif
+namespace fakeit {
+
+    struct NoMoreRecordedActionException {
+    };
+
+    template<typename R, typename ... arglist>
+    struct MethodInvocationHandler : Destructible {
+        virtual R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) = 0;
+    };
+
+}
+#include <new>
+
+namespace fakeit {
+
+#ifdef __GNUG__
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#endif
+
+
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4200 )
+#endif
+
+
+    template<typename C, typename ... baseclasses>
+    class FakeObject {
+
+        VirtualTable<C, baseclasses...> vtable;
+
+        static const size_t SIZE = sizeof(C) - sizeof(VirtualTable<C, baseclasses...>);
+        char instanceArea[SIZE ? SIZE : 0];
+
+        FakeObject(FakeObject const &) = delete;
+        FakeObject &operator=(FakeObject const &) = delete;
+
+    public:
+
+        FakeObject() : vtable() {
+            initializeDataMembersArea();
+        }
+
+        ~FakeObject() {
+            vtable.dispose();
+        }
+
+        void initializeDataMembersArea() {
+            for (size_t i = 0; i < SIZE; ++i) instanceArea[i] = (char) 0;
+        }
+
+        void setMethod(unsigned int index, void *method) {
+            vtable.setMethod(index, method);
+        }
+
+        VirtualTable<C, baseclasses...> &getVirtualTable() {
+            return vtable;
+        }
+
+        void setVirtualTable(VirtualTable<C, baseclasses...> &t) {
+            vtable = t;
+        }
+
+        void setDtor(void *dtor) {
+            vtable.setDtor(dtor);
+        }
+    };
+
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
+
+#ifdef __GNUG__
+#ifndef __clang__
+#pragma GCC diagnostic pop
+#endif
+#endif
+
+}
+namespace fakeit {
+
+    struct MethodProxy {
+
+        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+                _id(id),
+                _offset(offset),
+                _vMethod(vMethod) {
+        }
+
+        unsigned int getOffset() const {
+            return _offset;
+        }
+
+        unsigned int getId() const {
+            return _id;
+        }
+
+        void *getProxy() const {
+            return union_cast<void *>(_vMethod);
+        }
+
+    private:
+        unsigned int _id;
+        unsigned int _offset;
+        void *_vMethod;
+    };
+}
+#include <utility>
+
+
+namespace fakeit {
+
+    struct InvocationHandlerCollection {
+        static const unsigned int VT_COOKIE_INDEX = 0;
+
+        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+
+        static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
+            VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
+            InvocationHandlerCollection *invocationHandlerCollection = (InvocationHandlerCollection *) vt.getCookie(
+                    InvocationHandlerCollection::VT_COOKIE_INDEX);
+            return invocationHandlerCollection;
+        }
+    };
+
+
+    template<typename R, typename ... arglist>
+    class MethodProxyCreator {
+
+
+
+    public:
+
+        template<unsigned int id>
+        MethodProxy createMethodProxy(unsigned int offset) {
+            return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
+        }
+
+    protected:
+
+        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+            InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
+                    this);
+            MethodInvocationHandler<R, arglist...> *invocationHandler =
+                    (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
+                            id);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+
+        template<int id>
+        R methodProxyX(arglist ... args) {
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+    };
+}
+
+namespace fakeit {
+
+    class InvocationHandlers : public InvocationHandlerCollection {
+        std::vector<std::shared_ptr<Destructible>> &_methodMocks;
+        std::vector<unsigned int> &_offsets;
+
+        unsigned int getOffset(unsigned int id) const
+        {
+            unsigned int offset = 0;
+            for (; offset < _offsets.size(); offset++) {
+                if (_offsets[offset] == id) {
+                    break;
+                }
+            }
+            return offset;
+        }
+
+    public:
+        InvocationHandlers(
+                std::vector<std::shared_ptr<Destructible>> &methodMocks,
+                std::vector<unsigned int> &offsets) :
+                _methodMocks(methodMocks), _offsets(offsets) {
+        }
+
+        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+            unsigned int offset = getOffset(id);
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get();
+        }
+
+    };
+
+    template<typename C, typename ... baseclasses>
+    struct DynamicProxy {
+
+        static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
+
+        DynamicProxy(C &inst) :
+                instance(inst),
+                originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
+                _methodMocks(VTUtils::getVTSize<C>()),
+                _offsets(VTUtils::getVTSize<C>()),
+                _invocationHandlers(_methodMocks, _offsets) {
+            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.setCookie(InvocationHandlerCollection::VT_COOKIE_INDEX, &_invocationHandlers);
+            getFake().setVirtualTable(_cloneVt);
+        }
+
+        void detach() {
+            getFake().setVirtualTable(originalVtHandle.restore());
+        }
+
+        ~DynamicProxy() {
+            _cloneVt.dispose();
+        }
+
+        C &get() {
+            return instance;
+        }
+
+        void Reset() {
+			_methodMocks = {};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
+            _members = {};
+			_offsets = {};
+            _offsets.resize(VTUtils::getVTSize<C>());
+            _cloneVt.copyFrom(originalVtHandle.restore());
+        }
+
+		void Clear()
+        {
+        }
+
+        template<int id, typename R, typename ... arglist>
+        void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
+            auto offset = VTUtils::getOffset(vMethod);
+            MethodProxyCreator<R, arglist...> creator;
+            bind(creator.template createMethodProxy<id + 1>(offset), methodInvocationHandler);
+        }
+
+        void stubDtor(MethodInvocationHandler<void> *methodInvocationHandler) {
+            auto offset = VTUtils::getDestructorOffset<C>();
+            MethodProxyCreator<void> creator;
+            bindDtor(creator.createMethodProxy<0>(offset), methodInvocationHandler);
+        }
+
+        template<typename R, typename ... arglist>
+        bool isMethodStubbed(R(C::*vMethod)(arglist...)) {
+            unsigned int offset = VTUtils::getOffset(vMethod);
+            return isBinded(offset);
+        }
+
+        bool isDtorStubbed() {
+            unsigned int offset = VTUtils::getDestructorOffset<C>();
+            return isBinded(offset);
+        }
+
+        template<typename R, typename ... arglist>
+        Destructible *getMethodMock(R(C::*vMethod)(arglist...)) {
+            auto offset = VTUtils::getOffset(vMethod);
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get();
+        }
+
+        Destructible *getDtorMock() {
+            auto offset = VTUtils::getDestructorOffset<C>();
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get();
+        }
+
+        template<typename DATA_TYPE, typename ... arglist>
+        void stubDataMember(DATA_TYPE C::*member, const arglist &... initargs) {
+            DATA_TYPE C::*theMember = (DATA_TYPE C::*) member;
+            C &mock = get();
+            DATA_TYPE *memberPtr = &(mock.*theMember);
+            _members.push_back(
+                    std::shared_ptr<DataMemeberWrapper < DATA_TYPE, arglist...> >
+                    {new DataMemeberWrapper < DATA_TYPE, arglist...>(memberPtr,
+                    initargs...)});
+        }
+
+        template<typename DATA_TYPE>
+        void getMethodMocks(std::vector<DATA_TYPE> &into) const {
+            for (std::shared_ptr<Destructible> ptr : _methodMocks) {
+                DATA_TYPE p = dynamic_cast<DATA_TYPE>(ptr.get());
+                if (p) {
+                    into.push_back(p);
+                }
+            }
+        }
+
+        VirtualTable<C, baseclasses...> &getOriginalVT() {
+            VirtualTable<C, baseclasses...> &vt = originalVtHandle.restore();
+            return vt;
+        }
+
+    private:
+
+        template<typename DATA_TYPE, typename ... arglist>
+        class DataMemeberWrapper : public Destructible {
+        private:
+            DATA_TYPE *dataMember;
+        public:
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
+                new(dataMember) DATA_TYPE{initargs ...};
+            }
+
+            ~DataMemeberWrapper() override
+            {
+                dataMember->~DATA_TYPE();
+            }
+        };
+
+        static_assert(sizeof(C) == sizeof(FakeObject<C, baseclasses...>), "This is a problem");
+
+        C &instance;
+        typename VirtualTable<C, baseclasses...>::Handle originalVtHandle;
+        VirtualTable<C, baseclasses...> _cloneVt;
+
+        std::vector<std::shared_ptr<Destructible>> _methodMocks;
+        std::vector<std::shared_ptr<Destructible>> _members;
+        std::vector<unsigned int> _offsets;
+        InvocationHandlers _invocationHandlers;
+
+        FakeObject<C, baseclasses...> &getFake() {
+            return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
+        }
+
+        void bind(const MethodProxy &methodProxy, Destructible *invocationHandler) {
+            getFake().setMethod(methodProxy.getOffset(), methodProxy.getProxy());
+            _methodMocks[methodProxy.getOffset()].reset(invocationHandler);
+            _offsets[methodProxy.getOffset()] = methodProxy.getId();
+        }
+
+        void bindDtor(const MethodProxy &methodProxy, Destructible *invocationHandler) {
+            getFake().setDtor(methodProxy.getProxy());
+            _methodMocks[methodProxy.getOffset()].reset(invocationHandler);
+            _offsets[methodProxy.getOffset()] = methodProxy.getId();
+        }
+
+        template<typename DATA_TYPE>
+        DATA_TYPE getMethodMock(unsigned int offset) {
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return dynamic_cast<DATA_TYPE>(ptr.get());
+        }
+
+        template<typename BaseClass>
+        void checkMultipleInheritance() {
+            C *ptr = (C *) (unsigned int) 1;
+            BaseClass *basePtr = ptr;
+            int delta = (unsigned long) basePtr - (unsigned long) ptr;
+            if (delta > 0) {
+
+
+                throw std::invalid_argument(std::string("multiple inheritance is not supported"));
+            }
+        }
+
+        bool isBinded(unsigned int offset) {
+            std::shared_ptr<Destructible> ptr = _methodMocks[offset];
+            return ptr.get() != nullptr;
+        }
+
+    };
+}
+#include <functional>
+#include <type_traits>
+#include <memory>
+#include <iosfwd>
+#include <vector>
+#include <functional>
+#include <tuple>
+#include <tuple>
+
+namespace fakeit {
+
+    template<int N>
+    struct apply_func {
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
+        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t, Args &... args) {
+            return apply_func<N - 1>::template applyTuple(f, t, std::get<N - 1>(t), args...);
+        }
+    };
+
+    template<>
+    struct apply_func < 0 > {
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
+        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> & , Args &... args) {
+            return f(args...);
+        }
+    };
+
+    struct TupleDispatcher {
+
+        template<typename R, typename ... ArgsF, typename ... ArgsT>
+        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t) {
+            return apply_func<sizeof...(ArgsT)>::template applyTuple(f, t);
+        }
+
+        template<typename R, typename ...arglist>
+        static R invoke(std::function<R(arglist &...)> func, const std::tuple<arglist...> &arguments) {
+            std::tuple<arglist...> &args = const_cast<std::tuple<arglist...> &>(arguments);
+            return applyTuple(func, args);
+        }
+
+        template<typename TupleType, typename FunctionType>
+        static void for_each(TupleType &&, FunctionType &,
+            std::integral_constant<size_t, std::tuple_size<typename std::remove_reference<TupleType>::type>::value>) {
+        }
+
+        template<std::size_t I, typename TupleType, typename FunctionType, typename = typename std::enable_if<
+            I != std::tuple_size<typename std::remove_reference<TupleType>::type>::value>::type>
+            static void for_each(TupleType &&t, FunctionType &f, std::integral_constant<size_t, I>) {
+            f(I, std::get < I >(t));
+            for_each(std::forward < TupleType >(t), f, std::integral_constant<size_t, I + 1>());
+        }
+
+        template<typename TupleType, typename FunctionType>
+        static void for_each(TupleType &&t, FunctionType &f) {
+            for_each(std::forward < TupleType >(t), f, std::integral_constant<size_t, 0>());
+        }
+
+        template<typename TupleType1, typename TupleType2, typename FunctionType>
+        static void for_each(TupleType1 &&, TupleType2 &&, FunctionType &,
+            std::integral_constant<size_t, std::tuple_size<typename std::remove_reference<TupleType1>::type>::value>) {
+        }
+
+        template<std::size_t I, typename TupleType1, typename TupleType2, typename FunctionType, typename = typename std::enable_if<
+            I != std::tuple_size<typename std::remove_reference<TupleType1>::type>::value>::type>
+            static void for_each(TupleType1 &&t, TupleType2 &&t2, FunctionType &f, std::integral_constant<size_t, I>) {
+            f(I, std::get < I >(t), std::get < I >(t2));
+            for_each(std::forward < TupleType1 >(t), std::forward < TupleType2 >(t2), f, std::integral_constant<size_t, I + 1>());
+        }
+
+        template<typename TupleType1, typename TupleType2, typename FunctionType>
+        static void for_each(TupleType1 &&t, TupleType2 &&t2, FunctionType &f) {
+            for_each(std::forward < TupleType1 >(t), std::forward < TupleType2 >(t2), f, std::integral_constant<size_t, 0>());
+        }
+    };
+}
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    struct ActualInvocationHandler : Destructible {
+        virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) = 0;
+    };
+
+}
+#include <functional>
+#include <tuple>
+#include <string>
+#include <iosfwd>
+#include <type_traits>
+#include <typeinfo>
+
+namespace fakeit {
+
+    struct DefaultValueInstatiationException {
+        virtual ~DefaultValueInstatiationException() = default;
+
+        virtual std::string what() const = 0;
+    };
+
+
+    template<class C>
+    struct is_constructible_type {
+        static const bool value =
+                std::is_default_constructible<typename naked_type<C>::type>::value
+                && !std::is_abstract<typename naked_type<C>::type>::value;
+    };
+
+    template<class C, class Enable = void>
+    struct DefaultValue;
+
+    template<class C>
+    struct DefaultValue<C, typename std::enable_if<!is_constructible_type<C>::value>::type> {
+        static C &value() {
+            if (std::is_reference<C>::value) {
+                typename naked_type<C>::type *ptr = nullptr;
+                return *ptr;
+            }
+
+            class Exception : public DefaultValueInstatiationException {
+                virtual std::string what() const
+
+                override {
+                    return (std::string("Type ") + std::string(typeid(C).name())
+                            + std::string(
+                            " is not default constructible. Could not instantiate a default return value")).c_str();
+                }
+            };
+
+            throw Exception();
+        }
+    };
+
+    template<class C>
+    struct DefaultValue<C, typename std::enable_if<is_constructible_type<C>::value>::type> {
+        static C &value() {
+            static typename naked_type<C>::type val{};
+            return val;
+        }
+    };
+
+
+    template<>
+    struct DefaultValue<void> {
+        static void value() {
+            return;
+        }
+    };
+
+    template<>
+    struct DefaultValue<bool> {
+        static bool &value() {
+            static bool value{false};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<char> {
+        static char &value() {
+            static char value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<char16_t> {
+        static char16_t &value() {
+            static char16_t value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<char32_t> {
+        static char32_t &value() {
+            static char32_t value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<wchar_t> {
+        static wchar_t &value() {
+            static wchar_t value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<short> {
+        static short &value() {
+            static short value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<int> {
+        static int &value() {
+            static int value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<long> {
+        static long &value() {
+            static long value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<long long> {
+        static long long &value() {
+            static long long value{0};
+            return value;
+        }
+    };
+
+    template<>
+    struct DefaultValue<std::string> {
+        static std::string &value() {
+            static std::string value{};
+            return value;
+        }
+    };
+
+}
+namespace fakeit {
+
+    struct IMatcher : Destructible {
+        ~IMatcher() = default;
+        virtual std::string format() const = 0;
+    };
+
+    template<typename T>
+    struct TypedMatcher : IMatcher {
+        virtual bool matches(const T &actual) const = 0;
+    };
+
+    template<typename T>
+    struct TypedMatcherCreator {
+
+        virtual ~TypedMatcherCreator() = default;
+
+        virtual TypedMatcher<T> *createMatcher() const = 0;
+    };
+
+    template<typename T>
+    struct ComparisonMatcherCreator : public TypedMatcherCreator<T> {
+
+        virtual ~ComparisonMatcherCreator() = default;
+
+        ComparisonMatcherCreator(const T &arg)
+                : _expected(arg) {
+        }
+
+        struct Matcher : public TypedMatcher<T> {
+            Matcher(const T &expected)
+                    : _expected(expected) {
+            }
+
+            const T _expected;
+        };
+
+        const T &_expected;
+    };
+
+    namespace internal {
+        template<typename T>
+        struct TypedAnyMatcher : public TypedMatcherCreator<T> {
+
+            virtual ~TypedAnyMatcher() = default;
+
+            TypedAnyMatcher() {
+            }
+
+            struct Matcher : public TypedMatcher<T> {
+                virtual bool matches(const T &) const override {
+                    return true;
+                }
+
+                virtual std::string format() const override {
+                    return "Any";
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher();
+            }
+
+        };
+
+        template<typename T>
+        struct EqMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~EqMatcherCreator() = default;
+
+            EqMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual std::string format() const override {
+                    return TypeFormatter<T>::format(this->_expected);
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual == this->_expected;
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const {
+                return new Matcher(this->_expected);
+            }
+
+        };
+
+        template<typename T>
+        struct GtMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~GtMatcherCreator() = default;
+
+            GtMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual > this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string(">") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+        };
+
+        template<typename T>
+        struct GeMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~GeMatcherCreator() = default;
+
+            GeMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual >= this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string(">=") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+        };
+
+        template<typename T>
+        struct LtMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~LtMatcherCreator() = default;
+
+            LtMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual < this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string("<") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+
+        };
+
+        template<typename T>
+        struct LeMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~LeMatcherCreator() = default;
+
+            LeMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual <= this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string("<=") + TypeFormatter<T>::format(this->_expected);
+                }
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+
+        };
+
+        template<typename T>
+        struct NeMatcherCreator : public ComparisonMatcherCreator<T> {
+
+            virtual ~NeMatcherCreator() = default;
+
+            NeMatcherCreator(const T &expected)
+                    : ComparisonMatcherCreator<T>(expected) {
+            }
+
+            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
+                Matcher(const T &expected)
+                        : ComparisonMatcherCreator<T>::Matcher(expected) {
+                }
+
+                virtual bool matches(const T &actual) const override {
+                    return actual != this->_expected;
+                }
+
+                virtual std::string format() const override {
+                    return std::string("!=") + TypeFormatter<T>::format(this->_expected);
+                }
+
+            };
+
+            virtual TypedMatcher<T> *createMatcher() const override {
+                return new Matcher(this->_expected);
+            }
+
+        };
+    }
+
+    struct AnyMatcher {
+    } static _;
+
+    template<typename T>
+    internal::TypedAnyMatcher<T> Any() {
+        internal::TypedAnyMatcher<T> rv;
+        return rv;
+    }
+
+    template<typename T>
+    internal::EqMatcherCreator<T> Eq(const T &arg) {
+        internal::EqMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::GtMatcherCreator<T> Gt(const T &arg) {
+        internal::GtMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::GeMatcherCreator<T> Ge(const T &arg) {
+        internal::GeMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::LtMatcherCreator<T> Lt(const T &arg) {
+        internal::LtMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::LeMatcherCreator<T> Le(const T &arg) {
+        internal::LeMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+    template<typename T>
+    internal::NeMatcherCreator<T> Ne(const T &arg) {
+        internal::NeMatcherCreator<T> rv(arg);
+        return rv;
+    }
+
+}
+
+namespace fakeit {
+
+    template<typename ... arglist>
+    struct ArgumentsMatcherInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
+
+        virtual ~ArgumentsMatcherInvocationMatcher() {
+            for (unsigned int i = 0; i < _matchers.size(); i++)
+                delete _matchers[i];
+        }
+
+        ArgumentsMatcherInvocationMatcher(const std::vector<Destructible *> &args)
+                : _matchers(args) {
+        }
+
+        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+            if (invocation.getActualMatcher() == this)
+                return true;
+            return matches(invocation.getActualArguments());
+        }
+
+        virtual std::string format() const override {
+            std::ostringstream out;
+            out << "(";
+            for (unsigned int i = 0; i < _matchers.size(); i++) {
+                if (i > 0) out << ", ";
+                IMatcher *m = dynamic_cast<IMatcher *>(_matchers[i]);
+                out << m->format();
+            }
+            out << ")";
+            return out.str();
+        }
+
+    private:
+
+        struct MatchingLambda {
+            MatchingLambda(const std::vector<Destructible *> &matchers)
+                    : _matchers(matchers) {
+            }
+
+            template<typename A>
+            void operator()(int index, A &actualArg) {
+                TypedMatcher<typename naked_type<A>::type> *matcher =
+                        dynamic_cast<TypedMatcher<typename naked_type<A>::type> *>(_matchers[index]);
+                if (_matching)
+                    _matching = matcher->matches(actualArg);
+            }
+
+            bool isMatching() {
+                return _matching;
+            }
+
+        private:
+            bool _matching = true;
+            const std::vector<Destructible *> &_matchers;
+        };
+
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            MatchingLambda l(_matchers);
+            fakeit::TupleDispatcher::for_each(actualArguments, l);
+            return l.isMatching();
+        }
+
+        const std::vector<Destructible *> _matchers;
+    };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    template<typename ... arglist>
+    struct UserDefinedInvocationMatcher : ActualInvocation<arglist...>::Matcher {
+        virtual ~UserDefinedInvocationMatcher() = default;
+
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
+        }
+
+        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+            if (invocation.getActualMatcher() == this)
+                return true;
+            return matches(invocation.getActualArguments());
+        }
+
+        virtual std::string format() const override {
+            return {"( user defined matcher )"};
+        }
+
+    private:
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            return TupleDispatcher::invoke<bool, typename tuple_arg<arglist>::type...>(matcher, actualArguments);
+        }
+
+        const std::function<bool(arglist &...)> matcher;
+    };
+
+    template<typename ... arglist>
+    struct DefaultInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
+
+        virtual ~DefaultInvocationMatcher() = default;
+
+        DefaultInvocationMatcher() {
+        }
+
+        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+            return matches(invocation.getActualArguments());
+        }
+
+        virtual std::string format() const override {
+            return {"( Any arguments )"};
+        }
+
+    private:
+
+        virtual bool matches(const ArgumentsTuple<arglist...>&) {
+            return true;
+        }
+    };
+
+}
+
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    class RecordedMethodBody : public MethodInvocationHandler<R, arglist...>, public ActualInvocationsSource, public ActualInvocationsContainer {
+
+        struct MatchedInvocationHandler : ActualInvocationHandler<R, arglist...> {
+
+            virtual ~MatchedInvocationHandler() = default;
+
+            MatchedInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) :
+                    _matcher{matcher}, _invocationHandler{invocationHandler} {
+            }
+
+            virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
+            {
+                Destructible &destructable = *_invocationHandler;
+                ActualInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<ActualInvocationHandler<R, arglist...> &>(destructable);
+                return invocationHandler.handleMethodInvocation(args);
+            }
+
+            typename ActualInvocation<arglist...>::Matcher &getMatcher() const {
+                Destructible &destructable = *_matcher;
+                typename ActualInvocation<arglist...>::Matcher &matcher = dynamic_cast<typename ActualInvocation<arglist...>::Matcher &>(destructable);
+                return matcher;
+            }
+
+        private:
+            std::shared_ptr<Destructible> _matcher;
+            std::shared_ptr<Destructible> _invocationHandler;
+        };
+
+
+        FakeitContext &_fakeit;
+        MethodInfo _method;
+
+        std::vector<std::shared_ptr<Destructible>> _invocationHandlers;
+        std::vector<std::shared_ptr<Destructible>> _actualInvocations;
+
+        MatchedInvocationHandler *buildMatchedInvocationHandler(
+                typename ActualInvocation<arglist...>::Matcher *invocationMatcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) {
+            return new MatchedInvocationHandler(invocationMatcher, invocationHandler);
+        }
+
+        MatchedInvocationHandler *getInvocationHandlerForActualArgs(ActualInvocation<arglist...> &invocation) {
+            for (auto i = _invocationHandlers.rbegin(); i != _invocationHandlers.rend(); ++i) {
+                std::shared_ptr<Destructible> curr = *i;
+                Destructible &destructable = *curr;
+                MatchedInvocationHandler &im = asMatchedInvocationHandler(destructable);
+                if (im.getMatcher().matches(invocation)) {
+                    return &im;
+                }
+            }
+            return nullptr;
+        }
+
+        MatchedInvocationHandler &asMatchedInvocationHandler(Destructible &destructable) {
+            MatchedInvocationHandler &im = dynamic_cast<MatchedInvocationHandler &>(destructable);
+            return im;
+        }
+
+        ActualInvocation<arglist...> &asActualInvocation(Destructible &destructable) const {
+            ActualInvocation<arglist...> &invocation = dynamic_cast<ActualInvocation<arglist...> &>(destructable);
+            return invocation;
+        }
+
+    public:
+
+        RecordedMethodBody(FakeitContext &fakeit, std::string name) :
+                _fakeit(fakeit), _method{MethodInfo::nextMethodOrdinal(), name} { }
+
+        virtual ~RecordedMethodBody() NO_THROWS {
+        }
+
+        MethodInfo &getMethod() {
+            return _method;
+        }
+
+        bool isOfMethod(MethodInfo &method) {
+
+            return method.id() == _method.id();
+        }
+
+        void addMethodInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+            ActualInvocationHandler<R, arglist...> *invocationHandler) {
+            ActualInvocationHandler<R, arglist...> *mock = buildMatchedInvocationHandler(matcher, invocationHandler);
+            std::shared_ptr<Destructible> destructable{mock};
+            _invocationHandlers.push_back(destructable);
+        }
+
+        void reset() {
+            _invocationHandlers.clear();
+            _actualInvocations.clear();
+        }
+
+		void clear() override {
+			_actualInvocations.clear();
+		}
+
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
+            unsigned int ordinal = Invocation::nextInvocationOrdinal();
+            MethodInfo &method = this->getMethod();
+            auto actualInvocation = new ActualInvocation<arglist...>(ordinal, method, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+
+
+            std::shared_ptr<Destructible> actualInvocationDtor{actualInvocation};
+
+            auto invocationHandler = getInvocationHandlerForActualArgs(*actualInvocation);
+            if (invocationHandler) {
+                auto &matcher = invocationHandler->getMatcher();
+                actualInvocation->setActualMatcher(&matcher);
+                _actualInvocations.push_back(actualInvocationDtor);
+                try {
+                    return invocationHandler->handleMethodInvocation(actualInvocation->getActualArguments());
+                } catch (NoMoreRecordedActionException &) {
+                }
+            }
+
+            UnexpectedMethodCallEvent event(UnexpectedType::Unmatched, *actualInvocation);
+            _fakeit.handle(event);
+            std::string format{_fakeit.format(event)};
+            UnexpectedMethodCallException e(format);
+            throw e;
+        }
+
+        void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) {
+            for (auto destructablePtr : _actualInvocations) {
+                ActualInvocation<arglist...> &invocation = asActualInvocation(*destructablePtr);
+                scanner(invocation);
+            }
+        }
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            for (auto destructablePtr : _actualInvocations) {
+                Invocation &invocation = asActualInvocation(*destructablePtr);
+                into.insert(&invocation);
+            }
+        }
+
+        void setMethodDetails(const std::string &mockName, const std::string &methodName) {
+            const std::string fullName{mockName + "." + methodName};
+            _method.setName(fullName);
+        }
+
+    };
+
+}
+#include <functional>
+#include <type_traits>
+#include <stdexcept>
+#include <utility>
+#include <functional>
+#include <type_traits>
+
+namespace fakeit {
+
+    struct Quantity {
+        Quantity(const int q) :
+                quantity(q) {
+        }
+
+        const int quantity;
+    } static Once(1);
+
+    template<typename R>
+    struct Quantifier : public Quantity {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
+        }
+
+        const R &value;
+    };
+
+    template<>
+    struct Quantifier<void> : public Quantity {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
+        }
+    };
+
+    struct QuantifierFunctor : public Quantifier<void> {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
+        }
+
+        template<typename R>
+        Quantifier<R> operator()(const R &value) {
+            return Quantifier<R>(quantity, value);
+        }
+    };
+
+    template<int q>
+    struct Times : public Quantity {
+
+        Times<q>() : Quantity(q) { }
+
+        template<typename R>
+        static Quantifier<R> of(const R &value) {
+            return Quantifier<R>(q, value);
+        }
+
+        static Quantifier<void> Void() {
+            return Quantifier<void>(q);
+        }
+    };
+
+#if defined (__GNUG__) || (_MSC_VER >= 1900)
+
+    inline QuantifierFunctor operator
+    ""
+
+    _Times(unsigned long long n) {
+        return QuantifierFunctor((int) n);
+    }
+
+    inline QuantifierFunctor operator
+    ""
+
+    _Time(unsigned long long n) {
+        if (n != 1)
+            throw std::invalid_argument("Only 1_Time is supported. Use X_Times (with s) if X is bigger than 1");
+        return QuantifierFunctor((int) n);
+    }
+
+#endif
+
+}
+#include <functional>
+#include <atomic>
+#include <tuple>
+#include <type_traits>
+
+
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    struct Action : Destructible {
+        virtual R invoke(const ArgumentsTuple<arglist...> &) = 0;
+
+        virtual bool isDone() = 0;
+    };
+
+    template<typename R, typename ... arglist>
+    struct Repeat : Action<R, arglist...> {
+        virtual ~Repeat() = default;
+
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func), times(1) {
+        }
+
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
+        }
+
+        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+            times--;
+            return TupleDispatcher::invoke<R, arglist...>(f, args);
+        }
+
+        virtual bool isDone() override {
+            return times == 0;
+        }
+
+    private:
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
+        long times;
+    };
+
+    template<typename R, typename ... arglist>
+    struct RepeatForever : public Action<R, arglist...> {
+
+        virtual ~RepeatForever() = default;
+
+        RepeatForever(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func) {
+        }
+
+        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+            return TupleDispatcher::invoke<R, arglist...>(f, args);
+        }
+
+        virtual bool isDone() override {
+            return false;
+        }
+
+    private:
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
+    };
+
+    template<typename R, typename ... arglist>
+    struct ReturnDefaultValue : public Action<R, arglist...> {
+        virtual ~ReturnDefaultValue() = default;
+
+        virtual R invoke(const ArgumentsTuple<arglist...> &) override {
+            return DefaultValue<R>::value();
+        }
+
+        virtual bool isDone() override {
+            return false;
+        }
+    };
+
+    template<typename R, typename ... arglist>
+    struct ReturnDelegateValue : public Action<R, arglist...> {
+
+        ReturnDelegateValue(std::function<R(const typename fakeit::test_arg<arglist>::type...)> delegate) : _delegate(delegate) { }
+
+        virtual ~ReturnDelegateValue() = default;
+
+        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+            return TupleDispatcher::invoke<R, arglist...>(_delegate, args);
+        }
+
+        virtual bool isDone() override {
+            return false;
+        }
+
+    private:
+        std::function<R(const typename fakeit::test_arg<arglist>::type...)> _delegate;
+    };
+
+}
+
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    struct MethodStubbingProgress {
+
+        virtual ~MethodStubbingProgress() THROWS {
+        }
+
+        template<typename U = R>
+        typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
+        Return(const R &r) {
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        template<typename U = R>
+        typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
+        Return(const R &r) {
+            return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        MethodStubbingProgress<R, arglist...> &
+        Return(const Quantifier<R> &q) {
+            const R &value = q.value;
+            auto method = [value](const arglist &...) -> R { return value; };
+            return DoImpl(new Repeat<R, arglist...>(method, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<R, arglist...> &
+        Return(const first &f, const second &s, const tail &... t) {
+            Return(f);
+            return Return(s, t...);
+        }
+
+
+        template<typename U = R>
+        typename std::enable_if<!std::is_reference<U>::value, void>::type
+        AlwaysReturn(const R &r) {
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        template<typename U = R>
+        typename std::enable_if<std::is_reference<U>::value, void>::type
+        AlwaysReturn(const R &r) {
+            return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        MethodStubbingProgress<R, arglist...> &
+        Return() {
+            return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
+        }
+
+        void AlwaysReturn() {
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
+        }
+
+        template<typename E>
+        MethodStubbingProgress<R, arglist...> &Throw(const E &e) {
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
+        }
+
+        template<typename E>
+        MethodStubbingProgress<R, arglist...> &
+        Throw(const Quantifier<E> &q) {
+            const E &value = q.value;
+            auto method = [value](const arglist &...) -> R { throw value; };
+            return DoImpl(new Repeat<R, arglist...>(method, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<R, arglist...> &
+        Throw(const first &f, const second &s, const tail &... t) {
+            Throw(f);
+            return Throw(s, t...);
+        }
+
+        template<typename E>
+        void AlwaysThrow(const E &e) {
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
+        }
+
+        virtual MethodStubbingProgress<R, arglist...> &
+            Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<R, arglist...>(method));
+        }
+
+        template<typename F>
+        MethodStubbingProgress<R, arglist...> &
+        Do(const Quantifier<F> &q) {
+            return DoImpl(new Repeat<R, arglist...>(q.value, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<R, arglist...> &
+        Do(const first &f, const second &s, const tail &... t) {
+            Do(f);
+            return Do(s, t...);
+        }
+
+        virtual void AlwaysDo(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+            DoImpl(new RepeatForever<R, arglist...>(method));
+        }
+
+    protected:
+
+        virtual MethodStubbingProgress<R, arglist...> &DoImpl(Action<R, arglist...> *action) = 0;
+
+    private:
+        MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+    };
+
+
+    template<typename ... arglist>
+    struct MethodStubbingProgress<void, arglist...> {
+
+        virtual ~MethodStubbingProgress() THROWS {
+        }
+
+        MethodStubbingProgress<void, arglist...> &Return() {
+            auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
+                return DefaultValue<void>::value();
+            };
+            return Do(lambda);
+        }
+
+        virtual MethodStubbingProgress<void, arglist...> &Do(
+            std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<void, arglist...>(method));
+        }
+
+
+        void AlwaysReturn() {
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> void { return DefaultValue<void>::value(); });
+        }
+
+        MethodStubbingProgress<void, arglist...> &
+        Return(const Quantifier<void> &q) {
+            auto method = [](const arglist &...) -> void { return DefaultValue<void>::value(); };
+            return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
+        }
+
+        template<typename E>
+        MethodStubbingProgress<void, arglist...> &Throw(const E &e) {
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
+        }
+
+        template<typename E>
+        MethodStubbingProgress<void, arglist...> &
+        Throw(const Quantifier<E> &q) {
+            const E &value = q.value;
+            auto method = [value](const typename fakeit::test_arg<arglist>::type...) -> void { throw value; };
+            return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<void, arglist...> &
+        Throw(const first &f, const second &s, const tail &... t) {
+            Throw(f);
+            return Throw(s, t...);
+        }
+
+        template<typename E>
+        void AlwaysThrow(const E e) {
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
+        }
+
+           template<typename F>
+        MethodStubbingProgress<void, arglist...> &
+        Do(const Quantifier<F> &q) {
+            return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
+        }
+
+        template<typename first, typename second, typename ... tail>
+        MethodStubbingProgress<void, arglist...> &
+        Do(const first &f, const second &s, const tail &... t) {
+            Do(f);
+            return Do(s, t...);
+        }
+
+        virtual void AlwaysDo(std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            DoImpl(new RepeatForever<void, arglist...>(method));
+        }
+
+    protected:
+
+        virtual MethodStubbingProgress<void, arglist...> &DoImpl(Action<void, arglist...> *action) = 0;
+
+    private:
+        MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+    };
+
+
+}
+#include <vector>
+#include <functional>
+
+namespace fakeit {
+
+    class Finally {
+    private:
+        std::function<void()> _finallyClause;
+
+        Finally(const Finally &);
+
+        Finally &operator=(const Finally &);
+
+    public:
+        explicit Finally(std::function<void()> f) :
+                _finallyClause(f) {
+        }
+
+        ~Finally() {
+            _finallyClause();
+        }
+    };
+}
+
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    struct ActionSequence : ActualInvocationHandler<R,arglist...> {
+
+        ActionSequence() {
+            clear();
+        }
+
+        void AppendDo(Action<R, arglist...> *action) {
+            append(action);
+        }
+
+        virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
+        {
+            std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
+            Destructible &destructable = *destructablePtr;
+            Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
+            std::function<void()> finallyClause = [&]() -> void {
+                if (action.isDone())
+                    _recordedActions.erase(_recordedActions.begin());
+            };
+            Finally onExit(finallyClause);
+            return action.invoke(args);
+        }
+
+    private:
+
+        struct NoMoreRecordedAction : Action<R, arglist...> {
+
+
+
+
+
+
+
+            virtual R invoke(const ArgumentsTuple<arglist...> &) override {
+                throw NoMoreRecordedActionException();
+            }
+
+            virtual bool isDone() override {
+                return false;
+            }
+        };
+
+        void append(Action<R, arglist...> *action) {
+            std::shared_ptr<Destructible> destructable{action};
+            _recordedActions.insert(_recordedActions.end() - 1, destructable);
+        }
+
+        void clear() {
+            _recordedActions.clear();
+            auto actionPtr = std::shared_ptr<Destructible> {new NoMoreRecordedAction()};
+            _recordedActions.push_back(actionPtr);
+        }
+
+        std::vector<std::shared_ptr<Destructible>> _recordedActions;
+    };
+
+}
+
+namespace fakeit {
+
+    template<typename C, typename DATA_TYPE>
+    class DataMemberStubbingRoot {
+    private:
+
+    public:
+        DataMemberStubbingRoot(const DataMemberStubbingRoot &) = default;
+
+        DataMemberStubbingRoot() = default;
+
+        void operator=(const DATA_TYPE&) {
+        }
+    };
+
+}
+#include <functional>
+#include <utility>
+#include <type_traits>
+#include <tuple>
+#include <memory>
+#include <vector>
+#include <unordered_set>
+#include <set>
+#include <iosfwd>
+
+namespace fakeit {
+
+    struct Xaction {
+        virtual void commit() = 0;
+    };
+}
+
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    struct SpyingContext : Xaction {
+        virtual void appendAction(Action<R, arglist...> *action) = 0;
+
+        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
+    };
+}
+namespace fakeit {
+
+
+    template<typename R, typename ... arglist>
+    struct StubbingContext : public Xaction {
+        virtual void appendAction(Action<R, arglist...> *action) = 0;
+    };
+}
+#include <functional>
+#include <type_traits>
+#include <tuple>
+#include <memory>
+#include <vector>
+#include <unordered_set>
+
+
+namespace fakeit {
+
+    template<unsigned int index, typename ... arglist>
+    class MatchersCollector {
+
+        std::vector<Destructible *> &_matchers;
+
+    public:
+
+
+        template<std::size_t N>
+        using ArgType = typename std::tuple_element<N, std::tuple<arglist...>>::type;
+
+        template<std::size_t N>
+        using NakedArgType = typename naked_type<ArgType<index>>::type;
+
+        template<std::size_t N>
+        using ArgMatcherCreatorType = decltype(std::declval<TypedMatcherCreator<NakedArgType<N>>>());
+
+        MatchersCollector(std::vector<Destructible *> &matchers)
+                : _matchers(matchers) {
+        }
+
+        void CollectMatchers() {
+        }
+
+        template<typename Head>
+        typename std::enable_if<
+                std::is_constructible<NakedArgType<index>, Head>::value, void>
+        ::type CollectMatchers(const Head &value) {
+
+            TypedMatcher<NakedArgType<index>> *d = Eq<NakedArgType<index>>(value).createMatcher();
+            _matchers.push_back(d);
+        }
+
+        template<typename Head, typename ...Tail>
+        typename std::enable_if<
+                std::is_constructible<NakedArgType<index>, Head>::value
+                , void>
+        ::type CollectMatchers(const Head &head, const Tail &... tail) {
+            CollectMatchers(head);
+            MatchersCollector<index + 1, arglist...> c(_matchers);
+            c.CollectMatchers(tail...);
+        }
+
+        template<typename Head>
+        typename std::enable_if<
+                std::is_base_of<TypedMatcherCreator<NakedArgType<index>>, Head>::value, void>
+        ::type CollectMatchers(const Head &creator) {
+            TypedMatcher<NakedArgType<index>> *d = creator.createMatcher();
+            _matchers.push_back(d);
+        }
+
+        template<typename Head, typename ...Tail>
+
+        typename std::enable_if<
+                std::is_base_of<TypedMatcherCreator<NakedArgType<index>>, Head>::value, void>
+        ::type CollectMatchers(const Head &head, const Tail &... tail) {
+            CollectMatchers(head);
+            MatchersCollector<index + 1, arglist...> c(_matchers);
+            c.CollectMatchers(tail...);
+        }
+
+        template<typename Head>
+        typename std::enable_if<
+                std::is_same<AnyMatcher, Head>::value, void>
+        ::type CollectMatchers(const Head &) {
+            TypedMatcher<NakedArgType<index>> *d = Any<NakedArgType<index>>().createMatcher();
+            _matchers.push_back(d);
+        }
+
+        template<typename Head, typename ...Tail>
+        typename std::enable_if<
+                std::is_same<AnyMatcher, Head>::value, void>
+        ::type CollectMatchers(const Head &head, const Tail &... tail) {
+            CollectMatchers(head);
+            MatchersCollector<index + 1, arglist...> c(_matchers);
+            c.CollectMatchers(tail...);
+        }
+
+    };
+
+}
+
+namespace fakeit {
+
+    template<typename R, typename ... arglist>
+    class MethodMockingContext :
+            public Sequence,
+            public ActualInvocationsSource,
+            public virtual StubbingContext<R, arglist...>,
+            public virtual SpyingContext<R, arglist...>,
+            private Invocation::Matcher {
+    public:
+
+        struct Context : Destructible {
+
+
+            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
+
+            virtual std::string getMethodName() = 0;
+
+            virtual void addMethodInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) = 0;
+
+            virtual void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) = 0;
+
+            virtual void setMethodDetails(std::string mockName, std::string methodName) = 0;
+
+            virtual bool isOfMethod(MethodInfo &method) = 0;
+
+            virtual ActualInvocationsSource &getInvolvedMock() = 0;
+        };
+
+    private:
+        class Implementation {
+
+            Context *_stubbingContext;
+            ActionSequence<R, arglist...> *_recordedActionSequence;
+            typename ActualInvocation<arglist...>::Matcher *_invocationMatcher;
+            bool _commited;
+
+            Context &getStubbingContext() const {
+                return *_stubbingContext;
+            }
+
+        public:
+
+            Implementation(Context *stubbingContext)
+                    : _stubbingContext(stubbingContext),
+                      _recordedActionSequence(new ActionSequence<R, arglist...>()),
+                      _invocationMatcher
+                              {
+                                      new DefaultInvocationMatcher<arglist...>()}, _commited(false) {
+            }
+
+            ~Implementation() {
+                delete _stubbingContext;
+                if (!_commited) {
+
+                    delete _recordedActionSequence;
+                    delete _invocationMatcher;
+                }
+            }
+
+            ActionSequence<R, arglist...> &getRecordedActionSequence() {
+                return *_recordedActionSequence;
+            }
+
+            std::string format() const {
+                std::string s = getStubbingContext().getMethodName();
+                s += _invocationMatcher->format();
+                return s;
+            }
+
+            void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+                auto scanner = [&](ActualInvocation<arglist...> &a) {
+                    if (_invocationMatcher->matches(a)) {
+                        into.insert(&a);
+                    }
+                };
+                getStubbingContext().scanActualInvocations(scanner);
+            }
+
+
+            bool matches(Invocation &invocation) {
+                MethodInfo &actualMethod = invocation.getMethod();
+                if (!getStubbingContext().isOfMethod(actualMethod)) {
+                    return false;
+                }
+
+                ActualInvocation<arglist...> &actualInvocation = dynamic_cast<ActualInvocation<arglist...> &>(invocation);
+                return _invocationMatcher->matches(actualInvocation);
+            }
+
+            void commit() {
+                getStubbingContext().addMethodInvocationHandler(_invocationMatcher, _recordedActionSequence);
+                _commited = true;
+            }
+
+            void appendAction(Action<R, arglist...> *action) {
+                getRecordedActionSequence().AppendDo(action);
+            }
+
+            void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+                appendAction(new RepeatForever<R, arglist...>(method));
+                commit();
+            }
+
+            void setMethodDetails(std::string mockName, std::string methodName) {
+                getStubbingContext().setMethodDetails(mockName, methodName);
+            }
+
+            void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const {
+                into.push_back(&getStubbingContext().getInvolvedMock());
+            }
+
+            typename std::function<R(arglist &...)> getOriginalMethod() {
+                return getStubbingContext().getOriginalMethod();
+            }
+
+            void setInvocationMatcher(typename ActualInvocation<arglist...>::Matcher *matcher) {
+                delete _invocationMatcher;
+                _invocationMatcher = matcher;
+            }
+        };
+
+    protected:
+
+        MethodMockingContext(Context *stubbingContext)
+                : _impl{new Implementation(stubbingContext)} {
+        }
+
+        MethodMockingContext(MethodMockingContext &) = default;
+
+
+
+        MethodMockingContext(MethodMockingContext &&other)
+                : _impl(std::move(other._impl)) {
+        }
+
+        virtual ~MethodMockingContext() NO_THROWS { }
+
+        std::string format() const override {
+            return _impl->format();
+        }
+
+        unsigned int size() const override {
+            return 1;
+        }
+
+
+        void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
+            _impl->getInvolvedMocks(into);
+        }
+
+        void getExpectedSequence(std::vector<Invocation::Matcher *> &into) const override {
+            const Invocation::Matcher *b = this;
+            Invocation::Matcher *c = const_cast<Invocation::Matcher *>(b);
+            into.push_back(c);
+        }
+
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            _impl->getActualInvocations(into);
+        }
+
+
+        bool matches(Invocation &invocation) override {
+            return _impl->matches(invocation);
+        }
+
+        void commit() override {
+            _impl->commit();
+        }
+
+        void setMethodDetails(std::string mockName, std::string methodName) {
+            _impl->setMethodDetails(mockName, methodName);
+        }
+
+        void setMatchingCriteria(std::function<bool(arglist &...)> predicate) {
+            typename ActualInvocation<arglist...>::Matcher *matcher{
+                    new UserDefinedInvocationMatcher<arglist...>(predicate)};
+            _impl->setInvocationMatcher(matcher);
+        }
+
+        void setMatchingCriteria(const std::vector<Destructible *> &matchers) {
+            typename ActualInvocation<arglist...>::Matcher *matcher{
+                    new ArgumentsMatcherInvocationMatcher<arglist...>(matchers)};
+            _impl->setInvocationMatcher(matcher);
+        }
+
+
+        void appendAction(Action<R, arglist...> *action) override {
+            _impl->appendAction(action);
+        }
+
+        void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
+            _impl->setMethodBodyByAssignment(method);
+        }
+
+        template<class ...matcherCreators, class = typename std::enable_if<
+                sizeof...(matcherCreators) == sizeof...(arglist)>::type>
+        void setMatchingCriteria(const matcherCreators &... matcherCreator) {
+            std::vector<Destructible *> matchers;
+
+            MatchersCollector<0, arglist...> c(matchers);
+            c.CollectMatchers(matcherCreator...);
+
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(matchers);
+        }
+
+    private:
+
+        typename std::function<R(arglist&...)> getOriginalMethod() override {
+            return _impl->getOriginalMethod();
+        }
+
+        std::shared_ptr<Implementation> _impl;
+    };
+
+    template<typename R, typename ... arglist>
+    class MockingContext :
+            public MethodMockingContext<R, arglist...> {
+        MockingContext &operator=(const MockingContext &) = delete;
+
+    public:
+
+        MockingContext(typename MethodMockingContext<R, arglist...>::Context *stubbingContext)
+                : MethodMockingContext<R, arglist...>(stubbingContext) {
+        }
+
+        MockingContext(MockingContext &) = default;
+
+        MockingContext(MockingContext &&other)
+                : MethodMockingContext<R, arglist...>(std::move(other)) {
+        }
+
+        MockingContext<R, arglist...> &setMethodDetails(std::string mockName, std::string methodName) {
+            MethodMockingContext<R, arglist...>::setMethodDetails(mockName, methodName);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &Using(const arglist &... args) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        template<class ...arg_matcher>
+        MockingContext<R, arglist...> &Using(const arg_matcher &... arg_matchers) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(arg_matchers...);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &operator()(const arglist &... args) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        MockingContext<R, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        void operator=(std::function<R(arglist &...)> method) {
+            MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
+        }
+
+        template<typename U = R>
+        typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R &r) {
+            auto method = [r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
+            MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
+        }
+
+        template<typename U = R>
+        typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R &r) {
+            auto method = [&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
+            MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
+        }
+    };
+
+    template<typename ... arglist>
+    class MockingContext<void, arglist...> :
+            public MethodMockingContext<void, arglist...> {
+        MockingContext &operator=(const MockingContext &) = delete;
+
+    public:
+
+        MockingContext(typename MethodMockingContext<void, arglist...>::Context *stubbingContext)
+                : MethodMockingContext<void, arglist...>(stubbingContext) {
+        }
+
+        MockingContext(MockingContext &) = default;
+
+        MockingContext(MockingContext &&other)
+                : MethodMockingContext<void, arglist...>(std::move(other)) {
+        }
+
+        MockingContext<void, arglist...> &setMethodDetails(std::string mockName, std::string methodName) {
+            MethodMockingContext<void, arglist...>::setMethodDetails(mockName, methodName);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &Using(const arglist &... args) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        template<class ...arg_matcher>
+        MockingContext<void, arglist...> &Using(const arg_matcher &... arg_matchers) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(arg_matchers...);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &operator()(const arglist &... args) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
+            return *this;
+        }
+
+        MockingContext<void, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
+            return *this;
+        }
+
+        void operator=(std::function<void(arglist &...)> method) {
+            MethodMockingContext<void, arglist...>::setMethodBodyByAssignment(method);
+        }
+
+    };
+
+    class DtorMockingContext : public MethodMockingContext<void> {
+    public:
+
+        DtorMockingContext(MethodMockingContext<void>::Context *stubbingContext)
+                : MethodMockingContext<void>(stubbingContext) {
+        }
+
+        DtorMockingContext(DtorMockingContext &other) : MethodMockingContext<void>(other) {
+        }
+
+        DtorMockingContext(DtorMockingContext &&other) : MethodMockingContext<void>(std::move(other)) {
+        }
+
+        void operator=(std::function<void()> method) {
+            MethodMockingContext<void>::setMethodBodyByAssignment(method);
+        }
+
+        DtorMockingContext &setMethodDetails(std::string mockName, std::string methodName) {
+            MethodMockingContext<void>::setMethodDetails(mockName, methodName);
+            return *this;
+        }
+    };
+
+}
+
+namespace fakeit {
+
+
+    template<typename C, typename ... baseclasses>
+    class MockImpl : private MockObject<C>, public virtual ActualInvocationsSource {
+    public:
+
+        MockImpl(FakeitContext &fakeit, C &obj)
+                : MockImpl<C, baseclasses...>(fakeit, obj, true) {
+        }
+
+        MockImpl(FakeitContext &fakeit)
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
+            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+            fake->getVirtualTable().setCookie(1, this);
+        }
+
+        virtual ~MockImpl() NO_THROWS {
+            _proxy.detach();
+            if (_isOwner) {
+                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                delete fake;
+            }
+        }
+
+        void detach() {
+            _isOwner = false;
+            _proxy.detach();
+        }
+
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            std::vector<ActualInvocationsSource *> vec;
+            _proxy.getMethodMocks(vec);
+            for (ActualInvocationsSource *s : vec) {
+                s->getActualInvocations(into);
+            }
+        }
+
+	    void initDataMembersIfOwner()
+	    {
+		    if (_isOwner) {
+			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+			    fake->initializeDataMembersArea();
+		    }
+	    }
+
+	    void reset() {
+            _proxy.Reset();
+		    initDataMembersIfOwner();
+	    }
+
+		void clear()
+        {
+			std::vector<ActualInvocationsContainer *> vec;
+			_proxy.getMethodMocks(vec);
+			for (ActualInvocationsContainer *s : vec) {
+				s->clear();
+			}
+			initDataMembersIfOwner();
+        }
+
+        virtual C &get() override {
+            return _proxy.get();
+        }
+
+        virtual FakeitContext &getFakeIt() override {
+            return _fakeit;
+        }
+
+        template<class DATA_TYPE, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        DataMemberStubbingRoot<C, DATA_TYPE> stubDataMember(DATA_TYPE T::*member, const arglist &... ctorargs) {
+            _proxy.stubDataMember(member, ctorargs...);
+            return DataMemberStubbingRoot<T, DATA_TYPE>();
+        }
+
+        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
+            return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
+                   (*this, vMethod));
+        }
+
+        DtorMockingContext stubDtor() {
+            return DtorMockingContext(new DtorMockingContextImpl(*this));
+        }
+
+    private:
+        DynamicProxy<C, baseclasses...> _proxy;
+        C *_instance;
+        bool _isOwner;
+        FakeitContext &_fakeit;
+
+        template<typename R, typename ... arglist>
+        class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
+        protected:
+            MockImpl<C, baseclasses...> &_mock;
+
+            virtual RecordedMethodBody<R, arglist...> &getRecordedMethodBody() = 0;
+
+        public:
+            MethodMockingContextBase(MockImpl<C, baseclasses...> &mock) : _mock(mock) { }
+
+            virtual ~MethodMockingContextBase() = default;
+
+            void addMethodInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
+                ActualInvocationHandler<R, arglist...> *invocationHandler) {
+                getRecordedMethodBody().addMethodInvocationHandler(matcher, invocationHandler);
+            }
+
+            void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) {
+                getRecordedMethodBody().scanActualInvocations(scanner);
+            }
+
+            void setMethodDetails(std::string mockName, std::string methodName) {
+                getRecordedMethodBody().setMethodDetails(mockName, methodName);
+            }
+
+            bool isOfMethod(MethodInfo &method) {
+                return getRecordedMethodBody().isOfMethod(method);
+            }
+
+            ActualInvocationsSource &getInvolvedMock() {
+                return _mock;
+            }
+
+            std::string getMethodName() {
+                return getRecordedMethodBody().getMethod().name();
+            }
+
+        };
+
+        template<typename R, typename ... arglist>
+        class MethodMockingContextImpl : public MethodMockingContextBase<R, arglist...> {
+        protected:
+
+            R (C::*_vMethod)(arglist...);
+
+        public:
+            virtual ~MethodMockingContextImpl() = default;
+
+            MethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
+                    : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
+            }
+
+
+            virtual std::function<R(arglist&...)> getOriginalMethod() override {
+                void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
+                C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, std::forward<arglist>(args)...);
+                };
+            }
+        };
+
+
+        template<int id, typename R, typename ... arglist>
+        class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
+        protected:
+
+            virtual RecordedMethodBody<R, arglist...> &getRecordedMethodBody() override {
+                return MethodMockingContextBase<R, arglist...>::_mock.template stubMethodIfNotStubbed<id>(
+                        MethodMockingContextBase<R, arglist...>::_mock._proxy,
+                        MethodMockingContextImpl<R, arglist...>::_vMethod);
+            }
+
+        public:
+
+            UniqueMethodMockingContextImpl(MockImpl<C, baseclasses...> &mock, R (C::*vMethod)(arglist...))
+                    : MethodMockingContextImpl<R, arglist...>(mock, vMethod) {
+            }
+        };
+
+        class DtorMockingContextImpl : public MethodMockingContextBase<void> {
+
+        protected:
+
+            virtual RecordedMethodBody<void> &getRecordedMethodBody() override {
+                return MethodMockingContextBase<void>::_mock.stubDtorIfNotStubbed(
+                        MethodMockingContextBase<void>::_mock._proxy);
+            }
+
+        public:
+            virtual ~DtorMockingContextImpl() = default;
+
+            DtorMockingContextImpl(MockImpl<C, baseclasses...> &mock)
+                    : MethodMockingContextBase<void>(mock) {
+            }
+
+            virtual std::function<void()> getOriginalMethod() override {
+                C &instance = MethodMockingContextBase<void>::_mock.get();
+                return [=, &instance]() -> void {
+                };
+            }
+
+        };
+
+        static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
+            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
+                    1));
+            return mock;
+        }
+
+        void unmocked() {
+            ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
+            UnexpectedMethodCallEvent event(UnexpectedType::Unmocked, invocation);
+            auto &fakeit = getMockImpl(this)->_fakeit;
+            fakeit.handle(event);
+
+            std::string format = fakeit.format(event);
+            UnexpectedMethodCallException e(format);
+            throw e;
+        }
+
+        static C *createFakeInstance() {
+            FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
+            void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
+            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+            return reinterpret_cast<C *>(fake);
+        }
+
+        template<typename R, typename ... arglist>
+        void *getOriginalMethod(R (C::*vMethod)(arglist...)) {
+            auto vt = _proxy.getOriginalVT();
+            auto offset = VTUtils::getOffset(vMethod);
+            void *origMethodPtr = vt.getMethod(offset);
+            return origMethodPtr;
+        }
+
+        void *getOriginalDtor() {
+            auto vt = _proxy.getOriginalVT();
+            auto offset = VTUtils::getDestructorOffset<C>();
+            void *origMethodPtr = vt.getMethod(offset);
+            return origMethodPtr;
+        }
+
+        template<unsigned int id, typename R, typename ... arglist>
+        RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
+                                                                  R (C::*vMethod)(arglist...)) {
+            if (!proxy.isMethodStubbed(vMethod)) {
+                proxy.template stubMethod<id>(vMethod, createRecordedMethodBody < R, arglist... > (*this, vMethod));
+            }
+            Destructible *d = proxy.getMethodMock(vMethod);
+            RecordedMethodBody<R, arglist...> *methodMock = dynamic_cast<RecordedMethodBody<R, arglist...> *>(d);
+            return *methodMock;
+        }
+
+        RecordedMethodBody<void> &stubDtorIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy) {
+            if (!proxy.isDtorStubbed()) {
+                proxy.stubDtor(createRecordedDtorBody(*this));
+            }
+            Destructible *d = proxy.getDtorMock();
+            RecordedMethodBody<void> *dtorMock = dynamic_cast<RecordedMethodBody<void> *>(d);
+            return *dtorMock;
+        }
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
+        }
+
+        template<typename R, typename ... arglist>
+        static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
+                                                                           R(C::*vMethod)(arglist...)) {
+            return new RecordedMethodBody<R, arglist...>(mock.getFakeIt(), typeid(vMethod).name());
+        }
+
+        static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
+            return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
+        }
+
+    };
+}
+namespace fakeit {
+
+    template<typename R, typename... Args>
+    struct Prototype;
+
+    template<typename R, typename... Args>
+    struct Prototype<R(Args...)> {
+
+        typedef R Type(Args...);
+
+        typedef R ConstType(Args...) const;
+
+        template<class C>
+        struct MemberType {
+
+            typedef Type(C::*type);
+            typedef ConstType(C::*cosntType);
+
+            static type get(type t) {
+                return t;
+            }
+
+            static cosntType getconst(cosntType t) {
+                return t;
+            }
+
+        };
+
+    };
+
+    template<int X, typename R, typename C, typename... arglist>
+    struct UniqueMethod {
+        R (C::*method)(arglist...);
+
+        UniqueMethod(R (C::*vMethod)(arglist...)) : method(vMethod) { }
+
+        int uniqueId() {
+            return X;
+        }
+
+
+
+
+    };
+
+}
+
+
+namespace fakeit {
+    namespace internal {
+    }
+    using namespace fakeit::internal;
+
+    template<typename C, typename ... baseclasses>
+    class Mock : public ActualInvocationsSource {
+        MockImpl<C, baseclasses...> impl;
+    public:
+        virtual ~Mock() = default;
+
+        static_assert(std::is_polymorphic<C>::value, "Can only mock a polymorphic type");
+
+        Mock() : impl(Fakeit) {
+        }
+
+        explicit Mock(C &obj) : impl(Fakeit, obj) {
+        }
+
+        virtual C &get() {
+            return impl.get();
+        }
+
+        C &operator()() {
+            return get();
+        }
+
+        void Reset() {
+            impl.reset();
+        }
+
+		void ClearInvocationHistory() {
+			impl.clear();
+		}
+
+        template<class DATA_TYPE, typename ... arglist,
+                class = typename std::enable_if<std::is_member_object_pointer<DATA_TYPE C::*>::value>::type>
+        DataMemberStubbingRoot<C, DATA_TYPE> Stub(DATA_TYPE C::* member, const arglist &... ctorargs) {
+            return impl.stubDataMember(member, ctorargs...);
+        }
+
+        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
+            return impl.template stubMethod<id>(vMethod);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
+        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
+            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        DtorMockingContext dtor() {
+            return impl.stubDtor();
+        }
+
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
+            impl.getActualInvocations(into);
+        }
+
+    };
+
+}
+
+#include <exception>
+
+namespace fakeit {
+
+    class RefCount {
+    private:
+        int count;
+
+    public:
+        void AddRef() {
+            count++;
+        }
+
+        int Release() {
+            return --count;
+        }
+    };
+
+    template<typename T>
+    class smart_ptr {
+    private:
+        T *pData;
+        RefCount *reference;
+
+    public:
+        smart_ptr() : pData(0), reference(0) {
+            reference = new RefCount();
+            reference->AddRef();
+        }
+
+        smart_ptr(T *pValue) : pData(pValue), reference(0) {
+            reference = new RefCount();
+            reference->AddRef();
+        }
+
+        smart_ptr(const smart_ptr<T> &sp) : pData(sp.pData), reference(sp.reference) {
+            reference->AddRef();
+        }
+
+        ~smart_ptr() THROWS {
+            if (reference->Release() == 0) {
+                delete reference;
+                delete pData;
+            }
+        }
+
+        T &operator*() {
+            return *pData;
+        }
+
+        T *operator->() {
+            return pData;
+        }
+
+        smart_ptr<T> &operator=(const smart_ptr<T> &sp) {
+            if (this != &sp) {
+
+
+                if (reference->Release() == 0) {
+                    delete reference;
+                    delete pData;
+                }
+
+
+
+                pData = sp.pData;
+                reference = sp.reference;
+                reference->AddRef();
+            }
+            return *this;
+        }
+    };
+
+}
+
+namespace fakeit {
+
+    class WhenFunctor {
+
+        struct StubbingChange {
+
+            friend class WhenFunctor;
+
+            virtual ~StubbingChange() THROWS {
+
+                if (std::uncaught_exception()) {
+                    return;
+                }
+
+                _xaction.commit();
+            }
+
+            StubbingChange(StubbingChange &other) :
+                    _xaction(other._xaction) {
+            }
+
+        private:
+
+            StubbingChange(Xaction &xaction)
+                    : _xaction(xaction) {
+            }
+
+            Xaction &_xaction;
+        };
+
+    public:
+
+        template<typename R, typename ... arglist>
+        struct MethodProgress : MethodStubbingProgress<R, arglist...> {
+
+            friend class WhenFunctor;
+
+            virtual ~MethodProgress() override = default;
+
+            MethodProgress(MethodProgress &other) :
+                    _progress(other._progress), _context(other._context) {
+            }
+
+            MethodProgress(StubbingContext<R, arglist...> &xaction) :
+                    _progress(new StubbingChange(xaction)), _context(xaction) {
+            }
+
+        protected:
+
+            virtual MethodStubbingProgress<R, arglist...> &DoImpl(Action<R, arglist...> *action) override {
+                _context.appendAction(action);
+                return *this;
+            }
+
+        private:
+            smart_ptr<StubbingChange> _progress;
+            StubbingContext<R, arglist...> &_context;
+        };
+
+
+        WhenFunctor() {
+        }
+
+        template<typename R, typename ... arglist>
+        MethodProgress<R, arglist...> operator()(const StubbingContext<R, arglist...> &stubbingContext) {
+            StubbingContext<R, arglist...> &rootWithoutConst = const_cast<StubbingContext<R, arglist...> &>(stubbingContext);
+            MethodProgress<R, arglist...> progress(rootWithoutConst);
+            return progress;
+        }
+
+    };
+
+}
+namespace fakeit {
+
+    class FakeFunctor {
+    private:
+        template<typename R, typename ... arglist>
+        void fake(const StubbingContext<R, arglist...> &root) {
+            StubbingContext<R, arglist...> &rootWithoutConst = const_cast<StubbingContext<R, arglist...> &>(root);
+            rootWithoutConst.appendAction(new ReturnDefaultValue<R, arglist...>());
+            rootWithoutConst.commit();
+        }
+
+        void operator()() {
+        }
+
+    public:
+
+        template<typename H, typename ... M>
+        void operator()(const H &head, const M &... tail) {
+            fake(head);
+            this->operator()(tail...);
+        }
+
+    };
+
+}
+#include <set>
+#include <set>
+
+
+namespace fakeit {
+
+    struct InvocationUtils {
+
+        static void sortByInvocationOrder(std::unordered_set<Invocation *> &ivocations,
+                                          std::vector<Invocation *> &result) {
+            auto comparator = [](Invocation *a, Invocation *b) -> bool {
+                return a->getOrdinal() < b->getOrdinal();
+            };
+            std::set<Invocation *, bool (*)(Invocation *a, Invocation *b)> sortedIvocations(comparator);
+            for (auto i : ivocations)
+                sortedIvocations.insert(i);
+
+            for (auto i : sortedIvocations)
+                result.push_back(i);
+        }
+
+        static void collectActualInvocations(std::unordered_set<Invocation *> &actualInvocations,
+                                             std::vector<ActualInvocationsSource *> &invocationSources) {
+            for (auto source : invocationSources) {
+                source->getActualInvocations(actualInvocations);
+            }
+        }
+
+        static void selectNonVerifiedInvocations(std::unordered_set<Invocation *> &actualInvocations,
+                                                 std::unordered_set<Invocation *> &into) {
+            for (auto invocation : actualInvocations) {
+                if (!invocation->isVerified()) {
+                    into.insert(invocation);
+                }
+            }
+        }
+
+        static void collectInvocationSources(std::vector<ActualInvocationsSource *> &) {
+        }
+
+        template<typename ... list>
+        static void collectInvocationSources(std::vector<ActualInvocationsSource *> &into,
+                                             const ActualInvocationsSource &mock,
+                                             const list &... tail) {
+            into.push_back(const_cast<ActualInvocationsSource *>(&mock));
+            collectInvocationSources(into, tail...);
+        }
+
+        static void collectSequences(std::vector<Sequence *> &) {
+        }
+
+        template<typename ... list>
+        static void collectSequences(std::vector<Sequence *> &vec, const Sequence &sequence, const list &... tail) {
+            vec.push_back(&const_cast<Sequence &>(sequence));
+            collectSequences(vec, tail...);
+        }
+
+        static void collectInvolvedMocks(std::vector<Sequence *> &allSequences,
+                                         std::vector<ActualInvocationsSource *> &involvedMocks) {
+            for (auto sequence : allSequences) {
+                sequence->getInvolvedMocks(involvedMocks);
+            }
+        }
+
+        template<class T>
+        static T &remove_const(const T &s) {
+            return const_cast<T &>(s);
+        }
+
+    };
+
+}
+
+#include <memory>
+
+#include <vector>
+#include <unordered_set>
+
+namespace fakeit {
+    struct MatchAnalysis {
+        std::vector<Invocation *> actualSequence;
+        std::vector<Invocation *> matchedInvocations;
+        int count;
+
+        void run(InvocationsSourceProxy &involvedInvocationSources, std::vector<Sequence *> &expectedPattern) {
+            getActualInvocationSequence(involvedInvocationSources, actualSequence);
+            count = countMatches(expectedPattern, actualSequence, matchedInvocations);
+        }
+
+    private:
+        static void getActualInvocationSequence(InvocationsSourceProxy &involvedMocks,
+                                                std::vector<Invocation *> &actualSequence) {
+            std::unordered_set<Invocation *> actualInvocations;
+            collectActualInvocations(involvedMocks, actualInvocations);
+            InvocationUtils::sortByInvocationOrder(actualInvocations, actualSequence);
+        }
+
+        static int countMatches(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
+                                std::vector<Invocation *> &matchedInvocations) {
+            int end = -1;
+            int count = 0;
+            int startSearchIndex = 0;
+            while (findNextMatch(pattern, actualSequence, startSearchIndex, end, matchedInvocations)) {
+                count++;
+                startSearchIndex = end;
+            }
+            return count;
+        }
+
+        static void collectActualInvocations(InvocationsSourceProxy &involvedMocks,
+                                             std::unordered_set<Invocation *> &actualInvocations) {
+            involvedMocks.getActualInvocations(actualInvocations);
+        }
+
+        static bool findNextMatch(std::vector<Sequence *> &pattern, std::vector<Invocation *> &actualSequence,
+                                  int startSearchIndex, int &end,
+                                  std::vector<Invocation *> &matchedInvocations) {
+            for (auto sequence : pattern) {
+                int index = findNextMatch(sequence, actualSequence, startSearchIndex);
+                if (index == -1) {
+                    return false;
+                }
+                collectMatchedInvocations(actualSequence, matchedInvocations, index, sequence->size());
+                startSearchIndex = index + sequence->size();
+            }
+            end = startSearchIndex;
+            return true;
+        }
+
+
+        static void collectMatchedInvocations(std::vector<Invocation *> &actualSequence,
+                                              std::vector<Invocation *> &matchedInvocations, int start,
+                                              int length) {
+            int indexAfterMatchedPattern = start + length;
+            for (; start < indexAfterMatchedPattern; start++) {
+                matchedInvocations.push_back(actualSequence[start]);
+            }
+        }
+
+
+        static bool isMatch(std::vector<Invocation *> &actualSequence,
+                            std::vector<Invocation::Matcher *> &expectedSequence, int start) {
+            bool found = true;
+            for (unsigned int j = 0; found && j < expectedSequence.size(); j++) {
+                Invocation *actual = actualSequence[start + j];
+                Invocation::Matcher *expected = expectedSequence[j];
+                found = found && expected->matches(*actual);
+            }
+            return found;
+        }
+
+        static int findNextMatch(Sequence *&pattern, std::vector<Invocation *> &actualSequence, int startSearchIndex) {
+            std::vector<Invocation::Matcher *> expectedSequence;
+            pattern->getExpectedSequence(expectedSequence);
+            for (int i = startSearchIndex; i < ((int) actualSequence.size() - (int) expectedSequence.size() + 1); i++) {
+                if (isMatch(actualSequence, expectedSequence, i)) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+    };
+}
+
+namespace fakeit {
+
+    struct SequenceVerificationExpectation {
+
+        friend class SequenceVerificationProgress;
+
+        ~SequenceVerificationExpectation() THROWS {
+            if (std::uncaught_exception()) {
+                return;
+            }
+            VerifyExpectation(_fakeit);
+        }
+
+        void setExpectedPattern(std::vector<Sequence *> expectedPattern) {
+            _expectedPattern = expectedPattern;
+        }
+
+        void setExpectedCount(const int count) {
+            _expectedCount = count;
+        }
+
+        void setFileInfo(const char * file, int line, const char * callingMethod) {
+            _file = file;
+            _line = line;
+            _testMethod = callingMethod;
+        }
+
+    private:
+
+        VerificationEventHandler &_fakeit;
+        InvocationsSourceProxy _involvedInvocationSources;
+        std::vector<Sequence *> _expectedPattern;
+        int _expectedCount;
+
+        const char * _file;
+        int _line;
+		const char * _testMethod;
+        bool _isVerified;
+
+        SequenceVerificationExpectation(
+                VerificationEventHandler &fakeit,
+                InvocationsSourceProxy mocks,
+                std::vector<Sequence *> &expectedPattern) :
+                _fakeit(fakeit),
+                _involvedInvocationSources(mocks),
+                _expectedPattern(expectedPattern),
+                _expectedCount(-1),
+                _line(0),
+                _isVerified(false) {
+        }
+
+
+        void VerifyExpectation(VerificationEventHandler &verificationErrorHandler) {
+            if (_isVerified)
+                return;
+            _isVerified = true;
+
+            MatchAnalysis ma;
+            ma.run(_involvedInvocationSources, _expectedPattern);
+
+            if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
+                return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+            }
+
+            if (isExactVerification() && exactLimitNotMatched(ma.count)) {
+                return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+            }
+
+            markAsVerified(ma.matchedInvocations);
+        }
+
+        std::vector<Sequence *> &collectSequences(std::vector<Sequence *> &vec) {
+            return vec;
+        }
+
+        template<typename ... list>
+        std::vector<Sequence *> &collectSequences(std::vector<Sequence *> &vec, const Sequence &sequence,
+                                                  const list &... tail) {
+            vec.push_back(&const_cast<Sequence &>(sequence));
+            return collectSequences(vec, tail...);
+        }
+
+
+        static void markAsVerified(std::vector<Invocation *> &matchedInvocations) {
+            for (auto i : matchedInvocations) {
+                i->markAsVerified();
+            }
+        }
+
+        bool isAtLeastVerification() {
+
+            return _expectedCount < 0;
+        }
+
+        bool isExactVerification() {
+            return !isAtLeastVerification();
+        }
+
+        bool atLeastLimitNotReached(int count) {
+            return count < -_expectedCount;
+        }
+
+        bool exactLimitNotMatched(int count) {
+            return count != _expectedCount;
+        }
+
+        void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,
+                                          std::vector<Invocation *> actualSequence, int count) {
+            SequenceVerificationEvent evt(VerificationType::Exact, _expectedPattern, actualSequence, _expectedCount,
+                                          count);
+            evt.setFileInfo(_file, _line, _testMethod);
+            return verificationErrorHandler.handle(evt);
+        }
+
+        void handleAtLeastVerificationEvent(VerificationEventHandler &verificationErrorHandler,
+                                            std::vector<Invocation *> actualSequence, int count) {
+            SequenceVerificationEvent evt(VerificationType::AtLeast, _expectedPattern, actualSequence, -_expectedCount,
+                                          count);
+            evt.setFileInfo(_file, _line, _testMethod);
+            return verificationErrorHandler.handle(evt);
+        }
+
+    };
+
+}
+namespace fakeit {
+    class ThrowFalseEventHandler : public VerificationEventHandler {
+
+        void handle(const SequenceVerificationEvent &) override {
+            throw false;
+        }
+
+        void handle(const NoMoreInvocationsVerificationEvent &) override {
+            throw false;
+        }
+    };
+}
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+namespace fakeit {
+
+    template<typename T>
+    static std::string to_string(const T &n) {
+        std::ostringstream stm;
+        stm << n;
+        return stm.str();
+    }
+
+}
+
+
+namespace fakeit {
+
+    struct FakeitContext;
+
+    class SequenceVerificationProgress {
+
+        friend class UsingFunctor;
+
+        friend class VerifyFunctor;
+
+        friend class UsingProgress;
+
+        smart_ptr<SequenceVerificationExpectation> _expectationPtr;
+
+        SequenceVerificationProgress(SequenceVerificationExpectation *ptr) : _expectationPtr(ptr) {
+        }
+
+        SequenceVerificationProgress(
+                FakeitContext &fakeit,
+                InvocationsSourceProxy sources,
+                std::vector<Sequence *> &allSequences) :
+                SequenceVerificationProgress(new SequenceVerificationExpectation(fakeit, sources, allSequences)) {
+        }
+
+        virtual void verifyInvocations(const int times) {
+            _expectationPtr->setExpectedCount(times);
+        }
+
+        class Terminator {
+            smart_ptr<SequenceVerificationExpectation> _expectationPtr;
+
+            bool toBool() {
+                try {
+                    ThrowFalseEventHandler eh;
+                    _expectationPtr->VerifyExpectation(eh);
+                    return true;
+                }
+                catch (bool e) {
+                    return e;
+                }
+            }
+
+        public:
+            Terminator(smart_ptr<SequenceVerificationExpectation> expectationPtr) : _expectationPtr(expectationPtr) { };
+
+            operator bool() {
+                return toBool();
+            }
+
+            bool operator!() const { return !const_cast<Terminator *>(this)->toBool(); }
+        };
+
+    public:
+
+        ~SequenceVerificationProgress() THROWS { };
+
+        operator bool() const {
+            return Terminator(_expectationPtr);
+        }
+
+        bool operator!() const { return !Terminator(_expectationPtr); }
+
+        Terminator Never() {
+            Exactly(0);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Once() {
+            Exactly(1);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Twice() {
+            Exactly(2);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator AtLeastOnce() {
+            verifyInvocations(-1);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Exactly(const int times) {
+            if (times < 0) {
+                throw std::invalid_argument(std::string("bad argument times:").append(fakeit::to_string(times)));
+            }
+            verifyInvocations(times);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator Exactly(const Quantity &q) {
+            Exactly(q.quantity);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator AtLeast(const int times) {
+            if (times < 0) {
+                throw std::invalid_argument(std::string("bad argument times:").append(fakeit::to_string(times)));
+            }
+            verifyInvocations(-times);
+            return Terminator(_expectationPtr);
+        }
+
+        Terminator AtLeast(const Quantity &q) {
+            AtLeast(q.quantity);
+            return Terminator(_expectationPtr);
+        }
+
+        SequenceVerificationProgress setFileInfo(const char * file, int line, const char * callingMethod) {
+            _expectationPtr->setFileInfo(file, line, callingMethod);
+            return *this;
+        }
+    };
+}
+
+namespace fakeit {
+
+    class UsingProgress {
+        fakeit::FakeitContext &_fakeit;
+        InvocationsSourceProxy _sources;
+
+        void collectSequences(std::vector<fakeit::Sequence *> &) {
+        }
+
+        template<typename ... list>
+        void collectSequences(std::vector<fakeit::Sequence *> &vec, const fakeit::Sequence &sequence,
+                              const list &... tail) {
+            vec.push_back(&const_cast<fakeit::Sequence &>(sequence));
+            collectSequences(vec, tail...);
+        }
+
+    public:
+
+        UsingProgress(fakeit::FakeitContext &fakeit, InvocationsSourceProxy source) :
+                _fakeit(fakeit),
+                _sources(source) {
+        }
+
+        template<typename ... list>
+        SequenceVerificationProgress Verify(const fakeit::Sequence &sequence, const list &... tail) {
+            std::vector<fakeit::Sequence *> allSequences;
+            collectSequences(allSequences, sequence, tail...);
+            SequenceVerificationProgress progress(_fakeit, _sources, allSequences);
+            return progress;
+        }
+
+    };
+}
+
+namespace fakeit {
+
+    class UsingFunctor {
+
+        friend class VerifyFunctor;
+
+        FakeitContext &_fakeit;
+
+    public:
+
+        UsingFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        template<typename ... list>
+        UsingProgress operator()(const ActualInvocationsSource &head, const list &... tail) {
+            std::vector<ActualInvocationsSource *> allMocks{&InvocationUtils::remove_const(head),
+                                                            &InvocationUtils::remove_const(tail)...};
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(allMocks)};
+            UsingProgress progress(_fakeit, aggregateInvocationsSource);
+            return progress;
+        }
+
+    };
+}
+#include <set>
+
+namespace fakeit {
+
+    class VerifyFunctor {
+
+        FakeitContext &_fakeit;
+
+
+    public:
+
+        VerifyFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        template<typename ... list>
+        SequenceVerificationProgress operator()(const Sequence &sequence, const list &... tail) {
+            std::vector<Sequence *> allSequences{&InvocationUtils::remove_const(sequence),
+                                                 &InvocationUtils::remove_const(tail)...};
+
+            std::vector<ActualInvocationsSource *> involvedSources;
+            InvocationUtils::collectInvolvedMocks(allSequences, involvedSources);
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(involvedSources)};
+
+            UsingProgress usingProgress(_fakeit, aggregateInvocationsSource);
+            return usingProgress.Verify(sequence, tail...);
+        }
+
+    };
+
+}
+#include <set>
+#include <memory>
+namespace fakeit {
+
+    class VerifyNoOtherInvocationsVerificationProgress {
+
+        friend class VerifyNoOtherInvocationsFunctor;
+
+        struct VerifyNoOtherInvocationsExpectation {
+
+            friend class VerifyNoOtherInvocationsVerificationProgress;
+
+            ~VerifyNoOtherInvocationsExpectation() THROWS {
+                if (std::uncaught_exception()) {
+                    return;
+                }
+
+                VerifyExpectation(_fakeit);
+            }
+
+            void setFileInfo(const char * file, int line, const char * callingMethod) {
+                _file = file;
+                _line = line;
+                _callingMethod = callingMethod;
+            }
+
+        private:
+
+            VerificationEventHandler &_fakeit;
+            std::vector<ActualInvocationsSource *> _mocks;
+
+			const char * _file;
+            int _line;
+			const char * _callingMethod;
+            bool _isVerified;
+
+            VerifyNoOtherInvocationsExpectation(VerificationEventHandler &fakeit,
+                                                std::vector<ActualInvocationsSource *> mocks) :
+                    _fakeit(fakeit),
+                    _mocks(mocks),
+                    _line(0),
+                    _isVerified(false) {
+            }
+
+            VerifyNoOtherInvocationsExpectation(VerifyNoOtherInvocationsExpectation &other) = default;
+
+            void VerifyExpectation(VerificationEventHandler &verificationErrorHandler) {
+                if (_isVerified)
+                    return;
+                _isVerified = true;
+
+                std::unordered_set<Invocation *> actualInvocations;
+                InvocationUtils::collectActualInvocations(actualInvocations, _mocks);
+
+                std::unordered_set<Invocation *> nonVerifiedInvocations;
+                InvocationUtils::selectNonVerifiedInvocations(actualInvocations, nonVerifiedInvocations);
+
+                if (nonVerifiedInvocations.size() > 0) {
+                    std::vector<Invocation *> sortedNonVerifiedInvocations;
+                    InvocationUtils::sortByInvocationOrder(nonVerifiedInvocations, sortedNonVerifiedInvocations);
+
+                    std::vector<Invocation *> sortedActualInvocations;
+                    InvocationUtils::sortByInvocationOrder(actualInvocations, sortedActualInvocations);
+
+                    NoMoreInvocationsVerificationEvent evt(sortedActualInvocations, sortedNonVerifiedInvocations);
+                    evt.setFileInfo(_file, _line, _callingMethod);
+                    return verificationErrorHandler.handle(evt);
+                }
+            }
+
+        };
+
+        fakeit::smart_ptr<VerifyNoOtherInvocationsExpectation> _ptr;
+
+        VerifyNoOtherInvocationsVerificationProgress(VerifyNoOtherInvocationsExpectation *ptr) :
+                _ptr(ptr) {
+        }
+
+        VerifyNoOtherInvocationsVerificationProgress(FakeitContext &fakeit,
+                                                     std::vector<ActualInvocationsSource *> &invocationSources)
+                : VerifyNoOtherInvocationsVerificationProgress(
+                new VerifyNoOtherInvocationsExpectation(fakeit, invocationSources)
+        ) {
+        }
+
+        bool toBool() {
+            try {
+                ThrowFalseEventHandler ev;
+                _ptr->VerifyExpectation(ev);
+                return true;
+            }
+            catch (bool e) {
+                return e;
+            }
+        }
+
+    public:
+
+
+        ~VerifyNoOtherInvocationsVerificationProgress() THROWS {
+        };
+
+        VerifyNoOtherInvocationsVerificationProgress setFileInfo(const char * file, int line,
+			const char * callingMethod) {
+            _ptr->setFileInfo(file, line, callingMethod);
+            return *this;
+        }
+
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
+        }
+
+        bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }
+
+    };
+
+}
+
+
+namespace fakeit {
+    class VerifyNoOtherInvocationsFunctor {
+
+        FakeitContext &_fakeit;
+
+    public:
+
+        VerifyNoOtherInvocationsFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        void operator()() {
+        }
+
+        template<typename ... list>
+        VerifyNoOtherInvocationsVerificationProgress operator()(const ActualInvocationsSource &head,
+                                                                const list &... tail) {
+            std::vector<ActualInvocationsSource *> invocationSources{&InvocationUtils::remove_const(head),
+                                                                     &InvocationUtils::remove_const(tail)...};
+            VerifyNoOtherInvocationsVerificationProgress progress{_fakeit, invocationSources};
+            return progress;
+        }
+    };
+
+}
+namespace fakeit {
+
+    class SpyFunctor {
+    private:
+
+        template<typename R, typename ... arglist>
+        void spy(const SpyingContext<R, arglist...> &root) {
+            SpyingContext<R, arglist...> &rootWithoutConst = const_cast<SpyingContext<R, arglist...> &>(root);
+            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethod();
+            rootWithoutConst.appendAction(new ReturnDelegateValue<R, arglist...>(methodFromOriginalVT));
+            rootWithoutConst.commit();
+        }
+
+        void operator()() {
+        }
+
+    public:
+
+        template<typename H, typename ... M>
+        void operator()(const H &head, const M &... tail) {
+            spy(head);
+            this->operator()(tail...);
+        }
+
+    };
+
+}
+
+#include <vector>
+#include <set>
+
+namespace fakeit {
+    class VerifyUnverifiedFunctor {
+
+        FakeitContext &_fakeit;
+
+    public:
+
+        VerifyUnverifiedFunctor(FakeitContext &fakeit) : _fakeit(fakeit) {
+        }
+
+        template<typename ... list>
+        SequenceVerificationProgress operator()(const Sequence &sequence, const list &... tail) {
+            std::vector<Sequence *> allSequences{&InvocationUtils::remove_const(sequence),
+                                                 &InvocationUtils::remove_const(tail)...};
+
+            std::vector<ActualInvocationsSource *> involvedSources;
+            InvocationUtils::collectInvolvedMocks(allSequences, involvedSources);
+
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(involvedSources)};
+            InvocationsSourceProxy unverifiedInvocationsSource{
+                    new UnverifiedInvocationsSource(aggregateInvocationsSource)};
+
+            UsingProgress usingProgress(_fakeit, unverifiedInvocationsSource);
+            return usingProgress.Verify(sequence, tail...);
+        }
+
+    };
+
+    class UnverifiedFunctor {
+    public:
+        UnverifiedFunctor(FakeitContext &fakeit) : Verify(fakeit) {
+        }
+
+        VerifyUnverifiedFunctor Verify;
+
+        template<typename ... list>
+        UnverifiedInvocationsSource operator()(const ActualInvocationsSource &head, const list &... tail) {
+            std::vector<ActualInvocationsSource *> allMocks{&InvocationUtils::remove_const(head),
+                                                            &InvocationUtils::remove_const(tail)...};
+            InvocationsSourceProxy aggregateInvocationsSource{new AggregateInvocationsSource(allMocks)};
+            UnverifiedInvocationsSource unverifiedInvocationsSource{aggregateInvocationsSource};
+            return unverifiedInvocationsSource;
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+    };
+}
+
+namespace fakeit {
+
+    static UsingFunctor Using(Fakeit);
+    static VerifyFunctor Verify(Fakeit);
+    static VerifyNoOtherInvocationsFunctor VerifyNoOtherInvocations(Fakeit);
+    static UnverifiedFunctor Unverified(Fakeit);
+    static SpyFunctor Spy;
+    static FakeFunctor Fake;
+    static WhenFunctor When;
+
+    template<class T>
+    class SilenceUnusedVariableWarnings {
+
+        void use(void *) {
+        }
+
+        SilenceUnusedVariableWarnings() {
+            use(&Fake);
+            use(&When);
+            use(&Spy);
+            use(&Using);
+            use(&Verify);
+            use(&VerifyNoOtherInvocations);
+            use(&_);
+        }
+    };
+
+}
+#ifdef _MSC_VER
+#define __func__ __FUNCTION__
+#endif
+
+#define MOCK_TYPE(mock) \
+    std::remove_reference<decltype(mock.get())>::type
+
+#define OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
+
+#define CONST_OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
+
+#define Dtor(mock) \
+    mock.dtor().setMethodDetails(#mock,"destructor")
+
+#define Method(mock, method) \
+    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+
+#define OverloadedMethod(mock, method, prototype) \
+    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define ConstOverloadedMethod(mock, method, prototype) \
+    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define Verify(...) \
+        Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)
+
+#define Using(...) \
+        Using( __VA_ARGS__ )
+
+#define VerifyNoOtherInvocations(...) \
+    VerifyNoOtherInvocations( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)
+
+#define Fake(...) \
+    Fake( __VA_ARGS__ )
+
+#define When(call) \
+    When(call)
+
+
+#endif

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-07-27 08:19:27.167600
+ *  Generated: 2018-08-17 00:15:04.801624
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -771,6 +771,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -860,7 +863,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -897,7 +900,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -5217,7 +5220,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -5243,6 +5247,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -7840,21 +7856,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7869,8 +7876,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -7914,11 +7921,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -8026,11 +8056,15 @@ namespace fakeit {
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8046,8 +8080,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8085,10 +8122,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8098,7 +8131,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8172,7 +8204,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+
+		C &operator()() {
             return get();
         }
 
@@ -8693,12 +8729,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:15:04.801624
+ *  Generated: 2018-08-17 00:22:19.101508
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5220,7 +5220,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -7921,11 +7922,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8204,9 +8205,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -5372,6 +5372,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:22:08.118789
+ *  Generated: 2019-06-01 12:15:03.464353
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -983,7 +983,19 @@ namespace fakeit {
         }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -5727,6 +5739,7 @@ namespace fakeit {
 
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif
@@ -8381,7 +8394,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8641,7 +8654,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -9003,7 +9016,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-07-27 08:19:42.956002
+ *  Generated: 2018-08-17 00:15:08.702350
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -771,6 +771,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -860,7 +863,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -897,7 +900,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -5218,7 +5221,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -5244,6 +5248,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -7841,21 +7857,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7870,8 +7877,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -7915,11 +7922,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -8027,11 +8057,15 @@ namespace fakeit {
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8047,8 +8081,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8086,10 +8123,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8099,7 +8132,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8173,7 +8205,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+
+		C &operator()() {
             return get();
         }
 
@@ -8694,12 +8730,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-10-28 14:16:25.648560
+ *  Generated: 2018-07-27 08:19:42.956002
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -250,6 +250,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -873,6 +902,17 @@ namespace fakeit {
             return out.str();
         }
 
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
     private:
 
         static std::string formatSequence(const Sequence &val) {
@@ -904,8 +944,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -937,17 +977,6 @@ namespace fakeit {
 
             out << " * " << val.getTimes();
             return out.str();
-        }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
         }
     };
 }
@@ -1143,11 +1172,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::QTestFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5841,6 +5872,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -8770,7 +8805,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9025,8 +9060,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -5373,6 +5373,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:15:08.702350
+ *  Generated: 2018-08-17 00:22:08.118789
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5221,7 +5221,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -7922,11 +7923,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8205,9 +8206,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-10-28 14:16:25.882948
+ *  Generated: 2018-07-27 08:19:50.521325
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -249,6 +249,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -872,6 +901,17 @@ namespace fakeit {
             return out.str();
         }
 
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
     private:
 
         static std::string formatSequence(const Sequence &val) {
@@ -903,8 +943,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -936,17 +976,6 @@ namespace fakeit {
 
             out << " * " << val.getTimes();
             return out.str();
-        }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
         }
     };
 }
@@ -1211,11 +1240,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::StandaloneFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5909,6 +5940,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -8824,7 +8859,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9079,8 +9114,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:22:01.852984
+ *  Generated: 2019-06-01 12:15:07.986646
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -982,7 +982,19 @@ namespace fakeit {
         }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -5795,6 +5807,7 @@ namespace fakeit {
 
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif
@@ -8449,7 +8462,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8709,7 +8722,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -9057,7 +9070,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-07-27 08:19:50.521325
+ *  Generated: 2018-08-17 00:15:19.223994
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -770,6 +770,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -859,7 +862,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -896,7 +899,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -5286,7 +5289,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -5312,6 +5316,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -7909,21 +7925,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7938,8 +7945,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -7983,11 +7990,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -8095,11 +8125,15 @@ namespace fakeit {
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8115,8 +8149,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8154,10 +8191,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8167,7 +8200,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8241,7 +8273,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+
+		C &operator()() {
             return get();
         }
 
@@ -8762,12 +8798,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -5441,6 +5441,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:15:19.223994
+ *  Generated: 2018-08-17 00:22:01.852984
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5289,7 +5289,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -7990,11 +7991,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8273,9 +8274,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:15:27.197440
+ *  Generated: 2018-08-17 00:21:55.739562
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5260,7 +5260,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    struct NoVirtualDtor : public std::runtime_error {
+    class NoVirtualDtor : public std::runtime_error {
+    public:
 		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
@@ -7961,11 +7962,11 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
-		std::shared_ptr<C> getShared() {
-			auto * a = &_instanceOwner;
-			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
-			return *b;
-		}
+
+
+
+
+
 
     private:
 
@@ -8244,9 +8245,9 @@ namespace fakeit {
             return impl.get();
         }
 
-		std::shared_ptr<C> getShared() {
-			return impl.getShared();
-		}
+
+
+
 
 		C &operator()() {
             return get();

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -5412,6 +5412,7 @@ namespace fakeit {
 			signature(0), offset(0), cdOffset(0),
 			typeDescriptorOffset(0), classDescriptorOffset(0)
 		{
+                    (void)unused;
 		}
 
 		dword_ signature;

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-07-27 08:20:40.997499
+ *  Generated: 2018-08-17 00:15:27.197440
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -771,6 +771,9 @@ namespace fakeit {
     };
 
 }
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 
@@ -860,7 +863,7 @@ namespace fakeit {
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
             if (UnexpectedType::Unmatched == e.getUnexpectedType()) {
-                out << "  Could not find Any recorded behavior to support this method call.";
+                out << "  Could not find any recorded behavior to support this method call.";
             } else {
                 out << "  An unmocked method was invoked. All used virtual methods must be stubbed!";
             }
@@ -897,7 +900,7 @@ namespace fakeit {
         virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
-            out << "Expected no more invocations!! But the following unverified invocations were found:" << std::endl;
+            out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;
             formatInvocationList(out, e.unverifedIvocations());
             return out.str();
         }
@@ -5257,7 +5260,8 @@ namespace fakeit {
 }
 
 namespace fakeit {
-    class NoVirtualDtor {
+    struct NoVirtualDtor : public std::runtime_error {
+		NoVirtualDtor() :std::runtime_error("Can't mock the destructor. No virtual destructor was found") {}
     };
 
     class VTUtils {
@@ -5283,6 +5287,18 @@ namespace fakeit {
         getDestructorOffset() {
             throw NoVirtualDtor();
         }
+
+		template<typename C>
+		static typename std::enable_if<std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return true;
+		}
+
+		template<typename C>
+		static typename std::enable_if<!std::has_virtual_destructor<C>::value, bool>::type
+			hasVirtualDestructor() {
+			return false;
+		}
 
         template<typename C>
         static unsigned int getVTSize() {
@@ -7880,21 +7896,12 @@ namespace fakeit {
         }
 
         MockImpl(FakeitContext &fakeit)
-                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+                : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
+            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
             fake->getVirtualTable().setCookie(1, this);
         }
 
         virtual ~MockImpl() NO_THROWS {
-            _proxy.detach();
-            if (_isOwner) {
-                FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
-                delete fake;
-            }
-        }
-
-        void detach() {
-            _isOwner = false;
             _proxy.detach();
         }
 
@@ -7909,8 +7916,8 @@ namespace fakeit {
 
 	    void initDataMembersIfOwner()
 	    {
-		    if (_isOwner) {
-			    FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(_instance);
+		    if (isOwner()) {
+			    FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
 			    fake->initializeDataMembersArea();
 		    }
 	    }
@@ -7954,11 +7961,34 @@ namespace fakeit {
             return DtorMockingContext(new DtorMockingContextImpl(*this));
         }
 
+		std::shared_ptr<C> getShared() {
+			auto * a = &_instanceOwner;
+			auto * b = fakeit::union_cast<typename std::shared_ptr<C>*>(a);
+			return *b;
+		}
+
     private:
-        DynamicProxy<C, baseclasses...> _proxy;
-        C *_instance;
-        bool _isOwner;
+
+
+
+
+
+
+
+
+
+		std::shared_ptr<FakeObject<C, baseclasses...>> _instanceOwner;
+		DynamicProxy<C, baseclasses...> _proxy;
         FakeitContext &_fakeit;
+
+        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
+                : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
+				, _proxy{obj}
+				, _fakeit(fakeit) {}
+
+        static FakeObject<C, baseclasses...>* asFakeObject(void* instance){
+            return reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+        }
 
         template<typename R, typename ... arglist>
         class MethodMockingContextBase : public MethodMockingContext<R, arglist...>::Context {
@@ -8066,11 +8096,15 @@ namespace fakeit {
         };
 
         static MockImpl<C, baseclasses...> *getMockImpl(void *instance) {
-            FakeObject<C, baseclasses...> *fake = reinterpret_cast<FakeObject<C, baseclasses...> *>(instance);
+            FakeObject<C, baseclasses...> *fake = asFakeObject(instance);
             MockImpl<C, baseclasses...> *mock = reinterpret_cast<MockImpl<C, baseclasses...> *>(fake->getVirtualTable().getCookie(
                     1));
             return mock;
         }
+
+        bool isOwner(){ return _instanceOwner != nullptr;}
+
+		void unmockedDtor() {}
 
         void unmocked() {
             ActualInvocation<> invocation(Invocation::nextInvocationOrdinal(), UnknownMethod::instance());
@@ -8086,8 +8120,11 @@ namespace fakeit {
         static C *createFakeInstance() {
             FakeObject<C, baseclasses...> *fake = new FakeObject<C, baseclasses...>();
             void *unmockedMethodStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmocked);
-            fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-            return reinterpret_cast<C *>(fake);
+			void *unmockedDtorStubPtr = union_cast<void *>(&MockImpl<C, baseclasses...>::unmockedDtor);
+			fake->getVirtualTable().initAll(unmockedMethodStubPtr);
+			if (VTUtils::hasVirtualDestructor<C>())
+				fake->setDtor(unmockedDtorStubPtr);
+			return reinterpret_cast<C *>(fake);
         }
 
         template<typename R, typename ... arglist>
@@ -8125,10 +8162,6 @@ namespace fakeit {
             return *dtorMock;
         }
 
-        MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
-                : _proxy{obj}, _instance(&obj), _isOwner(!isSpy), _fakeit(fakeit) {
-        }
-
         template<typename R, typename ... arglist>
         static RecordedMethodBody<R, arglist...> *createRecordedMethodBody(MockObject<C> &mock,
                                                                            R(C::*vMethod)(arglist...)) {
@@ -8138,7 +8171,6 @@ namespace fakeit {
         static RecordedMethodBody<void> *createRecordedDtorBody(MockObject<C> &mock) {
             return new RecordedMethodBody<void>(mock.getFakeIt(), "dtor");
         }
-
     };
 }
 namespace fakeit {
@@ -8212,7 +8244,11 @@ namespace fakeit {
             return impl.get();
         }
 
-        C &operator()() {
+		std::shared_ptr<C> getShared() {
+			return impl.getShared();
+		}
+
+		C &operator()() {
             return get();
         }
 
@@ -8733,12 +8769,12 @@ namespace fakeit {
             return !isAtLeastVerification();
         }
 
-        bool atLeastLimitNotReached(int count) {
-            return count < -_expectedCount;
+        bool atLeastLimitNotReached(int actualCount) {
+            return actualCount < -_expectedCount;
         }
 
-        bool exactLimitNotMatched(int count) {
-            return count != _expectedCount;
+        bool exactLimitNotMatched(int actualCount) {
+            return actualCount != _expectedCount;
         }
 
         void handleExactVerificationEvent(VerificationEventHandler &verificationErrorHandler,

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2017-10-28 14:16:26.132959
+ *  Generated: 2018-07-27 08:20:40.997499
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -250,6 +250,35 @@ namespace fakeit {
 			s += val;
 			s += "'";
 			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
 		}
 	};
 
@@ -873,6 +902,17 @@ namespace fakeit {
             return out.str();
         }
 
+        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
+            std::string expectedPatternStr;
+            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
+                Sequence *s = expectedPattern[i];
+                expectedPatternStr += formatSequence(*s);
+                if (i < expectedPattern.size() - 1)
+                    expectedPatternStr += " ... ";
+            }
+            return expectedPatternStr;
+        }
+
     private:
 
         static std::string formatSequence(const Sequence &val) {
@@ -904,8 +944,8 @@ namespace fakeit {
 
         static void formatInvocationList(std::ostream &out, const std::vector<fakeit::Invocation *> &actualSequence) {
             size_t max_size = actualSequence.size();
-            if (max_size > 5)
-                max_size = 5;
+            if (max_size > 50)
+                max_size = 50;
 
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
@@ -937,17 +977,6 @@ namespace fakeit {
 
             out << " * " << val.getTimes();
             return out.str();
-        }
-
-        static std::string formatExpectedPattern(const std::vector<fakeit::Sequence *> &expectedPattern) {
-            std::string expectedPatternStr;
-            for (unsigned int i = 0; i < expectedPattern.size(); i++) {
-                Sequence *s = expectedPattern[i];
-                expectedPatternStr += formatSequence(*s);
-                if (i < expectedPattern.size() - 1)
-                    expectedPatternStr += " ... ";
-            }
-            return expectedPatternStr;
         }
     };
 }
@@ -1182,11 +1211,13 @@ static fakeit::DefaultFakeit& Fakeit = fakeit::TpUnitFakeit::getInstance();
 #include <unordered_set>
 
 #include <memory>
+#undef max
 #include <functional>
 #include <type_traits>
 #include <vector>
 #include <array>
 #include <new>
+#include <limits>
 
 #include <functional>
 #include <type_traits>
@@ -5880,6 +5911,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = std::numeric_limits<int>::max();
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
@@ -8795,7 +8830,7 @@ namespace fakeit {
 
         ~SequenceVerificationProgress() THROWS { };
 
-        operator bool() {
+        operator bool() const {
             return Terminator(_expectationPtr);
         }
 
@@ -9050,8 +9085,8 @@ namespace fakeit {
             return *this;
         }
 
-        operator bool() {
-            return toBool();
+        operator bool() const {
+            return const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool();
         }
 
         bool operator!() const { return !const_cast<VerifyNoOtherInvocationsVerificationProgress *>(this)->toBool(); }

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2018-08-17 00:21:55.739562
+ *  Generated: 2019-06-01 12:15:13.144108
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -983,7 +983,19 @@ namespace fakeit {
         }
     };
 }
+#include <exception>
+
+
 namespace fakeit {
+#if __cplusplus >= 201703L
+    inline bool UncaughtException () {
+        return std::uncaught_exceptions() >= 1;
+    }
+#else
+    inline bool UncaughtException () {
+      return std::uncaught_exception();
+    }
+#endif
 
     struct FakeitException {
         std::exception err;
@@ -5766,6 +5778,7 @@ namespace fakeit {
 
 #ifdef __GNUG__
 #ifndef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #endif
@@ -8420,7 +8433,7 @@ namespace fakeit {
 
             virtual ~StubbingChange() THROWS {
 
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 
@@ -8680,7 +8693,7 @@ namespace fakeit {
         friend class SequenceVerificationProgress;
 
         ~SequenceVerificationExpectation() THROWS {
-            if (std::uncaught_exception()) {
+            if (UncaughtException()) {
                 return;
             }
             VerifyExpectation(_fakeit);
@@ -9028,7 +9041,7 @@ namespace fakeit {
             friend class VerifyNoOtherInvocationsVerificationProgress;
 
             ~VerifyNoOtherInvocationsExpectation() THROWS {
-                if (std::uncaught_exception()) {
+                if (UncaughtException()) {
                     return;
                 }
 

--- a/tests/VirtualOffsetSelectorTest.cpp
+++ b/tests/VirtualOffsetSelectorTest.cpp
@@ -25,7 +25,7 @@ struct VirtualOffsetSelectorTest : tpunit::TestFixture {
 
 
     void verifyAllIndexes() {
-        VirtualOffsetSelector os;
+        VirtualOffsetSelector<ConventionHelper::DefaultConvention> os;
         ASSERT_EQUAL(0, os.offset0(0));
         ASSERT_EQUAL(1, os.offset1(0));
         ASSERT_EQUAL(2, os.offset2(0));

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="gcc_stubbing_multiple_values_tests.cpp" />
     <ClCompile Include="gcc_type_info_tests.cpp" />
     <ClCompile Include="miscellaneous_tests.cpp" />
+    <ClCompile Include="msc_calling_convention_tests.cpp" />
     <ClCompile Include="msc_stubbing_multiple_values_tests.cpp" />
     <ClCompile Include="msc_type_info_tests.cpp" />
     <ClCompile Include="overloadded_methods_tests.cpp" />

--- a/tests/default_behaviore_tests.cpp
+++ b/tests/default_behaviore_tests.cpp
@@ -14,19 +14,20 @@
 
 using namespace fakeit;
 
-struct DefaultBehavioreTests: tpunit::TestFixture {
+struct DefaultBehavioreTests : tpunit::TestFixture {
 	DefaultBehavioreTests()
-			: tpunit::TestFixture(
-					//
-					TEST(DefaultBehavioreTests::scalar_types_should_return_zero), //
-					TEST(DefaultBehavioreTests::DefaultBeaviorOfVoidFunctionsIsToDoNothing), //
-					TEST(DefaultBehavioreTests::ReturnByValue_ReturnDefaultConstructedObject), //
-					TEST(DefaultBehavioreTests::ReturnByValue_ThrowExceptionIfNotDefaultConstructible), //
-					TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfAbstract), //
-					TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToDefaultConstructedObject), //
-					TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible), //
-					TEST(DefaultBehavioreTests::ReturnPtr_NullPtrIfPtrToAbstract)
-							) {
+		: tpunit::TestFixture(
+			//
+			TEST(DefaultBehavioreTests::scalar_types_should_return_zero), //
+			TEST(DefaultBehavioreTests::DefaultBeaviorOfVoidFunctionsIsToDoNothing), //
+			TEST(DefaultBehavioreTests::ReturnByValue_ReturnDefaultConstructedObject), //
+			TEST(DefaultBehavioreTests::ReturnByValue_ThrowExceptionIfNotDefaultConstructible), //
+			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfAbstract), //
+			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToDefaultConstructedObject), //
+			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible), //
+			TEST(DefaultBehavioreTests::ReturnPtr_NullPtrIfPtrToAbstract),
+			TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation)
+		) {
 	}
 
 	enum Color {
@@ -63,7 +64,7 @@ struct DefaultBehavioreTests: tpunit::TestFixture {
 
 	struct NotDefaultConstructible {
 		NotDefaultConstructible(int a)
-				: _a(a) {
+			: _a(a) {
 		}
 		bool operator==(const NotDefaultConstructible &other) const {
 			return _a == other._a;
@@ -91,41 +92,41 @@ struct DefaultBehavioreTests: tpunit::TestFixture {
 	void scalar_types_should_return_zero() {
 		Mock<ScalarFunctions> mock;
 
-		Fake(Method(mock,boolFunc));
-		Fake(Method(mock,charFunc));
-		Fake(Method(mock,char16Func));
-		Fake(Method(mock,char32Func));
-		Fake(Method(mock,wcharFunc));
-		Fake(Method(mock,shortFunc));
-		Fake(Method(mock,intFunc));
-		Fake(Method(mock,longFunc));
-		Fake(Method(mock,longLongFunc));
-		Fake(Method(mock,floatFunc));
-		Fake(Method(mock,doubleFunc));
-		Fake(Method(mock,longDoubleFunc));
-		Fake(Method(mock,enumFunc));
-		Fake(Method(mock,pIntFunc));
-		Fake(Method(mock,pScalarFuctionsfunc));
-		Fake(Method(mock,nullptrFunc));
-		Fake(Method(mock,pMemberFunc));
+		Fake(Method(mock, boolFunc));
+		Fake(Method(mock, charFunc));
+		Fake(Method(mock, char16Func));
+		Fake(Method(mock, char32Func));
+		Fake(Method(mock, wcharFunc));
+		Fake(Method(mock, shortFunc));
+		Fake(Method(mock, intFunc));
+		Fake(Method(mock, longFunc));
+		Fake(Method(mock, longLongFunc));
+		Fake(Method(mock, floatFunc));
+		Fake(Method(mock, doubleFunc));
+		Fake(Method(mock, longDoubleFunc));
+		Fake(Method(mock, enumFunc));
+		Fake(Method(mock, pIntFunc));
+		Fake(Method(mock, pScalarFuctionsfunc));
+		Fake(Method(mock, nullptrFunc));
+		Fake(Method(mock, pMemberFunc));
 
 		ScalarFunctions &i = mock.get();
 
 		//Default behavior of a scalar function is to return 0/false/null
 
 		ASSERT_EQUAL(false, i.boolFunc());
-		ASSERT_EQUAL((char ) 0, i.charFunc());
-		ASSERT_EQUAL((int )(char16_t ) 0, (int )i.char16Func());
-		ASSERT_EQUAL((char32_t ) 0, i.char32Func());
-		ASSERT_EQUAL((wchar_t ) 0, i.wcharFunc());
-		ASSERT_EQUAL((short ) 0, i.shortFunc());
-		ASSERT_EQUAL((int ) 0, i.intFunc());
-		ASSERT_EQUAL((long ) 0, i.longFunc());
-		ASSERT_EQUAL((long )0, (long )i.longLongFunc());
-		ASSERT_EQUAL((float ) 0, i.floatFunc());
-		ASSERT_EQUAL((double ) 0, i.doubleFunc());
-		ASSERT_EQUAL((double ) 0, (double ) i.longDoubleFunc());
-		ASSERT_EQUAL(0, (int ) i.enumFunc());
+		ASSERT_EQUAL((char)0, i.charFunc());
+		ASSERT_EQUAL((int)(char16_t)0, (int)i.char16Func());
+		ASSERT_EQUAL((char32_t)0, i.char32Func());
+		ASSERT_EQUAL((wchar_t)0, i.wcharFunc());
+		ASSERT_EQUAL((short)0, i.shortFunc());
+		ASSERT_EQUAL((int)0, i.intFunc());
+		ASSERT_EQUAL((long)0, i.longFunc());
+		ASSERT_EQUAL((long)0, (long)i.longLongFunc());
+		ASSERT_EQUAL((float)0, i.floatFunc());
+		ASSERT_EQUAL((double)0, i.doubleFunc());
+		ASSERT_EQUAL((double)0, (double)i.longDoubleFunc());
+		ASSERT_EQUAL(0, (int)i.enumFunc());
 		ASSERT_EQUAL(nullptr, i.pIntFunc());
 		ASSERT_EQUAL(nullptr, i.pScalarFuctionsfunc());
 		ASSERT_EQUAL(nullptr, i.nullptrFunc());
@@ -139,8 +140,8 @@ struct DefaultBehavioreTests: tpunit::TestFixture {
 
 	void DefaultBeaviorOfVoidFunctionsIsToDoNothing() {
 		Mock<VoidFunctions> mock;
-		Fake(Method(mock,proc1));
-		Fake(Method(mock,proc2));
+		Fake(Method(mock, proc1));
+		Fake(Method(mock, proc2));
 		VoidFunctions& i = mock.get();
 		i.proc1();
 		i.proc2(1);
@@ -148,15 +149,15 @@ struct DefaultBehavioreTests: tpunit::TestFixture {
 
 	void ReturnByValue_ReturnDefaultConstructedObject() {
 		Mock<DefaultConstructibleFunctions> mock;
-		Fake(Method(mock,stringfunc));
+		Fake(Method(mock, stringfunc));
 		DefaultConstructibleFunctions& i = mock.get();
 		ASSERT_EQUAL(std::string(), i.stringfunc());
 	}
 
 	void ReturnByReference_ReturnReferenceToDefaultConstructedObject() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock,scalarFunc));
-		Fake(Method(mock,stringFunc));
+		Fake(Method(mock, scalarFunc));
+		Fake(Method(mock, stringFunc));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(0, i.scalarFunc());
 		ASSERT_EQUAL(std::string(), i.stringFunc());
@@ -164,15 +165,16 @@ struct DefaultBehavioreTests: tpunit::TestFixture {
 
 	void ReturnByValue_ThrowExceptionIfNotDefaultConstructible() {
 		Mock<NonDefaultConstructibleFunctions> mock;
-		Fake(Method(mock,notDefaultConstructibleFunc));
+		Fake(Method(mock, notDefaultConstructibleFunc));
 		NonDefaultConstructibleFunctions& i = mock.get();
 		try {
 			i.notDefaultConstructibleFunc();
 			FAIL()
-			;
-		} catch (fakeit::DefaultValueInstatiationException& e) {
+				;
+		}
+		catch (fakeit::DefaultValueInstatiationException& e) {
 			auto expected = std::string("Type ") + std::string(typeid(NotDefaultConstructible).name())
-					+ std::string(" is not default constructible. Could not instantiate a default return value");
+				+ std::string(" is not default constructible. Could not instantiate a default return value");
 			std::string actual(e.what());
 			ASSERT_EQUAL(expected, actual);
 		}
@@ -180,23 +182,51 @@ struct DefaultBehavioreTests: tpunit::TestFixture {
 
 	void ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock,notDefaultConstructibleFunc));
+		Fake(Method(mock, notDefaultConstructibleFunc));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(nullptr, &i.notDefaultConstructibleFunc());
 	}
 
 	void ReturnByReference_ReturnReferenceToNullIfAbstract() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock,abstractTypeFunc));
+		Fake(Method(mock, abstractTypeFunc));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(nullptr, &i.abstractTypeFunc());
 	}
 
 	void ReturnPtr_NullPtrIfPtrToAbstract() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock,abstractTypeFunc2));
+		Fake(Method(mock, abstractTypeFunc2));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(nullptr, i.abstractTypeFunc2());
 	}
 
+	class ISomeInterface3 {
+	public:
+		virtual ~ISomeInterface3() {
+			int a = 0;
+			a++;
+		}
+
+		virtual void methodWithSomeSharedPointer(std::shared_ptr<ISomeInterface3> listener) = 0;
+	};
+
+	struct A {
+		//~A() {
+		//	int a = 0;
+		//	a++;
+		//}
+	};
+
+	void production_shared_ptr_mock_used_in_invocation() {
+		std::shared_ptr<ISomeInterface3> pMockInstance;
+		Mock<ISomeInterface3> mock;
+		fakeit::Fake(Dtor(mock));
+		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
+
+		pMockInstance = std::shared_ptr<ISomeInterface3>(&mock.get());
+		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
+
+		pMockInstance = nullptr;
+	}
 } __DefaultBehaviore;

--- a/tests/default_behaviore_tests.cpp
+++ b/tests/default_behaviore_tests.cpp
@@ -14,20 +14,19 @@
 
 using namespace fakeit;
 
-struct DefaultBehavioreTests : tpunit::TestFixture {
+struct DefaultBehavioreTests: tpunit::TestFixture {
 	DefaultBehavioreTests()
-		: tpunit::TestFixture(
-			//
-			TEST(DefaultBehavioreTests::scalar_types_should_return_zero), //
-			TEST(DefaultBehavioreTests::DefaultBeaviorOfVoidFunctionsIsToDoNothing), //
-			TEST(DefaultBehavioreTests::ReturnByValue_ReturnDefaultConstructedObject), //
-			TEST(DefaultBehavioreTests::ReturnByValue_ThrowExceptionIfNotDefaultConstructible), //
-			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfAbstract), //
-			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToDefaultConstructedObject), //
-			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible), //
-			TEST(DefaultBehavioreTests::ReturnPtr_NullPtrIfPtrToAbstract),
-			TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation)
-		) {
+			: tpunit::TestFixture(
+					//
+					TEST(DefaultBehavioreTests::scalar_types_should_return_zero), //
+					TEST(DefaultBehavioreTests::DefaultBeaviorOfVoidFunctionsIsToDoNothing), //
+					TEST(DefaultBehavioreTests::ReturnByValue_ReturnDefaultConstructedObject), //
+					TEST(DefaultBehavioreTests::ReturnByValue_ThrowExceptionIfNotDefaultConstructible), //
+					TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfAbstract), //
+					TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToDefaultConstructedObject), //
+					TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible), //
+					TEST(DefaultBehavioreTests::ReturnPtr_NullPtrIfPtrToAbstract)
+							) {
 	}
 
 	enum Color {
@@ -64,7 +63,7 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 
 	struct NotDefaultConstructible {
 		NotDefaultConstructible(int a)
-			: _a(a) {
+				: _a(a) {
 		}
 		bool operator==(const NotDefaultConstructible &other) const {
 			return _a == other._a;
@@ -92,41 +91,41 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 	void scalar_types_should_return_zero() {
 		Mock<ScalarFunctions> mock;
 
-		Fake(Method(mock, boolFunc));
-		Fake(Method(mock, charFunc));
-		Fake(Method(mock, char16Func));
-		Fake(Method(mock, char32Func));
-		Fake(Method(mock, wcharFunc));
-		Fake(Method(mock, shortFunc));
-		Fake(Method(mock, intFunc));
-		Fake(Method(mock, longFunc));
-		Fake(Method(mock, longLongFunc));
-		Fake(Method(mock, floatFunc));
-		Fake(Method(mock, doubleFunc));
-		Fake(Method(mock, longDoubleFunc));
-		Fake(Method(mock, enumFunc));
-		Fake(Method(mock, pIntFunc));
-		Fake(Method(mock, pScalarFuctionsfunc));
-		Fake(Method(mock, nullptrFunc));
-		Fake(Method(mock, pMemberFunc));
+		Fake(Method(mock,boolFunc));
+		Fake(Method(mock,charFunc));
+		Fake(Method(mock,char16Func));
+		Fake(Method(mock,char32Func));
+		Fake(Method(mock,wcharFunc));
+		Fake(Method(mock,shortFunc));
+		Fake(Method(mock,intFunc));
+		Fake(Method(mock,longFunc));
+		Fake(Method(mock,longLongFunc));
+		Fake(Method(mock,floatFunc));
+		Fake(Method(mock,doubleFunc));
+		Fake(Method(mock,longDoubleFunc));
+		Fake(Method(mock,enumFunc));
+		Fake(Method(mock,pIntFunc));
+		Fake(Method(mock,pScalarFuctionsfunc));
+		Fake(Method(mock,nullptrFunc));
+		Fake(Method(mock,pMemberFunc));
 
 		ScalarFunctions &i = mock.get();
 
 		//Default behavior of a scalar function is to return 0/false/null
 
 		ASSERT_EQUAL(false, i.boolFunc());
-		ASSERT_EQUAL((char)0, i.charFunc());
-		ASSERT_EQUAL((int)(char16_t)0, (int)i.char16Func());
-		ASSERT_EQUAL((char32_t)0, i.char32Func());
-		ASSERT_EQUAL((wchar_t)0, i.wcharFunc());
-		ASSERT_EQUAL((short)0, i.shortFunc());
-		ASSERT_EQUAL((int)0, i.intFunc());
-		ASSERT_EQUAL((long)0, i.longFunc());
-		ASSERT_EQUAL((long)0, (long)i.longLongFunc());
-		ASSERT_EQUAL((float)0, i.floatFunc());
-		ASSERT_EQUAL((double)0, i.doubleFunc());
-		ASSERT_EQUAL((double)0, (double)i.longDoubleFunc());
-		ASSERT_EQUAL(0, (int)i.enumFunc());
+		ASSERT_EQUAL((char ) 0, i.charFunc());
+		ASSERT_EQUAL((int )(char16_t ) 0, (int )i.char16Func());
+		ASSERT_EQUAL((char32_t ) 0, i.char32Func());
+		ASSERT_EQUAL((wchar_t ) 0, i.wcharFunc());
+		ASSERT_EQUAL((short ) 0, i.shortFunc());
+		ASSERT_EQUAL((int ) 0, i.intFunc());
+		ASSERT_EQUAL((long ) 0, i.longFunc());
+		ASSERT_EQUAL((long )0, (long )i.longLongFunc());
+		ASSERT_EQUAL((float ) 0, i.floatFunc());
+		ASSERT_EQUAL((double ) 0, i.doubleFunc());
+		ASSERT_EQUAL((double ) 0, (double ) i.longDoubleFunc());
+		ASSERT_EQUAL(0, (int ) i.enumFunc());
 		ASSERT_EQUAL(nullptr, i.pIntFunc());
 		ASSERT_EQUAL(nullptr, i.pScalarFuctionsfunc());
 		ASSERT_EQUAL(nullptr, i.nullptrFunc());
@@ -140,8 +139,8 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 
 	void DefaultBeaviorOfVoidFunctionsIsToDoNothing() {
 		Mock<VoidFunctions> mock;
-		Fake(Method(mock, proc1));
-		Fake(Method(mock, proc2));
+		Fake(Method(mock,proc1));
+		Fake(Method(mock,proc2));
 		VoidFunctions& i = mock.get();
 		i.proc1();
 		i.proc2(1);
@@ -149,15 +148,15 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 
 	void ReturnByValue_ReturnDefaultConstructedObject() {
 		Mock<DefaultConstructibleFunctions> mock;
-		Fake(Method(mock, stringfunc));
+		Fake(Method(mock,stringfunc));
 		DefaultConstructibleFunctions& i = mock.get();
 		ASSERT_EQUAL(std::string(), i.stringfunc());
 	}
 
 	void ReturnByReference_ReturnReferenceToDefaultConstructedObject() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock, scalarFunc));
-		Fake(Method(mock, stringFunc));
+		Fake(Method(mock,scalarFunc));
+		Fake(Method(mock,stringFunc));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(0, i.scalarFunc());
 		ASSERT_EQUAL(std::string(), i.stringFunc());
@@ -165,16 +164,15 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 
 	void ReturnByValue_ThrowExceptionIfNotDefaultConstructible() {
 		Mock<NonDefaultConstructibleFunctions> mock;
-		Fake(Method(mock, notDefaultConstructibleFunc));
+		Fake(Method(mock,notDefaultConstructibleFunc));
 		NonDefaultConstructibleFunctions& i = mock.get();
 		try {
 			i.notDefaultConstructibleFunc();
 			FAIL()
-				;
-		}
-		catch (fakeit::DefaultValueInstatiationException& e) {
+			;
+		} catch (fakeit::DefaultValueInstatiationException& e) {
 			auto expected = std::string("Type ") + std::string(typeid(NotDefaultConstructible).name())
-				+ std::string(" is not default constructible. Could not instantiate a default return value");
+					+ std::string(" is not default constructible. Could not instantiate a default return value");
 			std::string actual(e.what());
 			ASSERT_EQUAL(expected, actual);
 		}
@@ -182,51 +180,23 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 
 	void ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock, notDefaultConstructibleFunc));
+		Fake(Method(mock,notDefaultConstructibleFunc));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(nullptr, &i.notDefaultConstructibleFunc());
 	}
 
 	void ReturnByReference_ReturnReferenceToNullIfAbstract() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock, abstractTypeFunc));
+		Fake(Method(mock,abstractTypeFunc));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(nullptr, &i.abstractTypeFunc());
 	}
 
 	void ReturnPtr_NullPtrIfPtrToAbstract() {
 		Mock<ReferenceFunctions> mock;
-		Fake(Method(mock, abstractTypeFunc2));
+		Fake(Method(mock,abstractTypeFunc2));
 		ReferenceFunctions& i = mock.get();
 		ASSERT_EQUAL(nullptr, i.abstractTypeFunc2());
 	}
 
-	class ISomeInterface3 {
-	public:
-		virtual ~ISomeInterface3() {
-			int a = 0;
-			a++;
-		}
-
-		virtual void methodWithSomeSharedPointer(std::shared_ptr<ISomeInterface3> listener) = 0;
-	};
-
-	struct A {
-		//~A() {
-		//	int a = 0;
-		//	a++;
-		//}
-	};
-
-	void production_shared_ptr_mock_used_in_invocation() {
-		std::shared_ptr<ISomeInterface3> pMockInstance;
-		Mock<ISomeInterface3> mock;
-		fakeit::Fake(Dtor(mock));
-		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
-
-		pMockInstance = std::shared_ptr<ISomeInterface3>(&mock.get());
-		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
-
-		pMockInstance = nullptr;
-	}
 } __DefaultBehaviore;

--- a/tests/default_behaviore_tests.cpp
+++ b/tests/default_behaviore_tests.cpp
@@ -203,19 +203,9 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 
 	class ISomeInterface3 {
 	public:
-		virtual ~ISomeInterface3() {
-			int a = 0;
-			a++;
-		}
+		virtual ~ISomeInterface3() {}
 
 		virtual void methodWithSomeSharedPointer(std::shared_ptr<ISomeInterface3> listener) = 0;
-	};
-
-	struct A {
-		//~A() {
-		//	int a = 0;
-		//	a++;
-		//}
 	};
 
 	void production_shared_ptr_mock_used_in_invocation() {
@@ -224,9 +214,10 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 		fakeit::Fake(Dtor(mock));
 		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
 
-		pMockInstance = std::shared_ptr<ISomeInterface3>(&mock.get());
+		pMockInstance = mock.getShared();
 		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
 
 		pMockInstance = nullptr;
 	}
+
 } __DefaultBehaviore;

--- a/tests/default_behaviore_tests.cpp
+++ b/tests/default_behaviore_tests.cpp
@@ -26,8 +26,8 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToDefaultConstructedObject), //
 			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible), //
 			TEST(DefaultBehavioreTests::ReturnPtr_NullPtrIfPtrToAbstract),
-			//TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation),
-			TEST(DefaultBehavioreTests::should_survive_delete_of_mock_instance_by_user)
+			TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation)
+			//TEST(DefaultBehavioreTests::should_survive_delete_of_mock_instance_by_user)
 		) {
 	}
 
@@ -224,14 +224,12 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 //		pMockInstance = nullptr;
 //	}
 
-	void should_survive_delete_of_mock_instance_by_user() {
+	void production_shared_ptr_mock_used_in_invocation() {
 		Mock<ISomeInterface3> mock;
 		std::shared_ptr<ISomeInterface3> pMockInstance(&mock.get());
 		fakeit::Fake(Dtor(mock));
 		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
-
 		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
-
 		pMockInstance = nullptr;
 	}
 

--- a/tests/default_behaviore_tests.cpp
+++ b/tests/default_behaviore_tests.cpp
@@ -26,7 +26,7 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToDefaultConstructedObject), //
 			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible), //
 			TEST(DefaultBehavioreTests::ReturnPtr_NullPtrIfPtrToAbstract),
-			TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation),
+			//TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation),
 			TEST(DefaultBehavioreTests::should_survive_delete_of_mock_instance_by_user)
 		) {
 	}
@@ -212,17 +212,17 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 		virtual void methodWithSomeSharedPointer(std::shared_ptr<ISomeInterface3> listener) = 0;
 	};
 
-	void production_shared_ptr_mock_used_in_invocation() {
-		std::shared_ptr<ISomeInterface3> pMockInstance;
-		Mock<ISomeInterface3> mock;
-		fakeit::Fake(Dtor(mock));
-		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
-
-		pMockInstance = mock.getShared();
-		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
-
-		pMockInstance = nullptr;
-	}
+//	void production_shared_ptr_mock_used_in_invocation() {
+//		std::shared_ptr<ISomeInterface3> pMockInstance;
+//		Mock<ISomeInterface3> mock;
+//		fakeit::Fake(Dtor(mock));
+//		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
+//
+//		pMockInstance = mock.getShared();
+//		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
+//
+//		pMockInstance = nullptr;
+//	}
 
 	void should_survive_delete_of_mock_instance_by_user() {
 		Mock<ISomeInterface3> mock;

--- a/tests/default_behaviore_tests.cpp
+++ b/tests/default_behaviore_tests.cpp
@@ -26,7 +26,8 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToDefaultConstructedObject), //
 			TEST(DefaultBehavioreTests::ReturnByReference_ReturnReferenceToNullIfNotDefaultConstructible), //
 			TEST(DefaultBehavioreTests::ReturnPtr_NullPtrIfPtrToAbstract),
-			TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation)
+			TEST(DefaultBehavioreTests::production_shared_ptr_mock_used_in_invocation),
+			TEST(DefaultBehavioreTests::should_survive_delete_of_mock_instance_by_user)
 		) {
 	}
 
@@ -203,7 +204,10 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 
 	class ISomeInterface3 {
 	public:
-		virtual ~ISomeInterface3() {}
+		virtual ~ISomeInterface3() {
+			int a = 0;
+			a++;
+		}
 
 		virtual void methodWithSomeSharedPointer(std::shared_ptr<ISomeInterface3> listener) = 0;
 	};
@@ -215,6 +219,17 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
 
 		pMockInstance = mock.getShared();
+		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
+
+		pMockInstance = nullptr;
+	}
+
+	void should_survive_delete_of_mock_instance_by_user() {
+		Mock<ISomeInterface3> mock;
+		std::shared_ptr<ISomeInterface3> pMockInstance(&mock.get());
+		fakeit::Fake(Dtor(mock));
+		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
+
 		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
 
 		pMockInstance = nullptr;

--- a/tests/default_event_formatting_tests.cpp
+++ b/tests/default_event_formatting_tests.cpp
@@ -96,7 +96,7 @@ struct DefaultEventFormatting: tpunit::TestFixture {
 		}
 		catch (UnexpectedMethodCallException& e)
 		{
-			std::string expectedMsg{"Unexpected method invocation: mock.func(1)\n  Could not find Any recorded behavior to support this method call."};
+			std::string expectedMsg{"Unexpected method invocation: mock.func(1)\n  Could not find any recorded behavior to support this method call."};
 			std::string actual{to_string(e)};
 			ASSERT_EQUAL(expectedMsg, actual);
 		}
@@ -168,7 +168,7 @@ struct DefaultEventFormatting: tpunit::TestFixture {
 		catch (NoMoreInvocationsVerificationException& e) {
             std::string expectedMsg{ formatLineNumner("test file", 1) };
             expectedMsg += ": Verification error\n";
-			expectedMsg += "Expected no more invocations!! But the following unverified invocations were found:\n";
+			expectedMsg += "Expected no more invocations!! but the following unverified invocations were found:\n";
 			expectedMsg += "  mock.func(2)";//
 
 			std::string actualMsg{to_string(e)};//

--- a/tests/dtor_mocking_tests.cpp
+++ b/tests/dtor_mocking_tests.cpp
@@ -23,7 +23,8 @@ struct DtorMocking : tpunit::TestFixture
             TEST(DtorMocking::call_dtor_without_delete),
             TEST(DtorMocking::spy_dtor),
 			TEST(DtorMocking::production_takes_ownwership_with_uniqe_ptr),
-			TEST(DtorMocking::production_takes_ownership_interface_with_more_methods)
+			TEST(DtorMocking::production_takes_ownership_interface_with_more_methods),
+			TEST(DtorMocking::should_fail_faking_when_no_virtual_dtor_exists)
 		)
 	{
 	}
@@ -81,7 +82,7 @@ struct DtorMocking : tpunit::TestFixture
 	}
 
     struct A {
-        virtual ~A(){}
+		virtual ~A(){}
     };
 
 	void spy_dtor() {
@@ -109,6 +110,16 @@ struct DtorMocking : tpunit::TestFixture
 
 		std::unique_ptr<SomeInterface2> ptr = std::unique_ptr<SomeInterface2>(&m.get());		
 		ptr = nullptr;
+	}
+
+	struct NoVirtualDestructor {
+		~NoVirtualDestructor() {}
+		virtual void foo() = 0;
+	};
+
+	void should_fail_faking_when_no_virtual_dtor_exists() {
+		Mock<NoVirtualDestructor> m;
+		ASSERT_THROW(Fake(Dtor(m)), std::runtime_error);
 	}
 
 } __DtorMocking;

--- a/tests/dtor_mocking_tests.cpp
+++ b/tests/dtor_mocking_tests.cpp
@@ -22,7 +22,8 @@ struct DtorMocking : tpunit::TestFixture
             TEST(DtorMocking::mock_virtual_dtor_by_assignment),
             TEST(DtorMocking::call_dtor_without_delete),
             TEST(DtorMocking::spy_dtor),
-			TEST(DtorMocking::production_takes_ownwership_with_uniqe_ptr)//
+			TEST(DtorMocking::production_takes_ownwership_with_uniqe_ptr),
+			TEST(DtorMocking::production_takes_ownership_interface_with_more_methods)
 		)
 	{
 	}
@@ -93,5 +94,21 @@ struct DtorMocking : tpunit::TestFixture
         Verify(Dtor(mock)).Twice();
 		ASSERT_THROW(Verify(Dtor(mock)).Once(), fakeit::VerificationException);
     }
+
+	class SomeInterface2 {
+	public:
+		virtual void DoSomething() = 0;
+		virtual ~SomeInterface2() = default;
+	};
+
+	void production_takes_ownership_interface_with_more_methods() {
+		Mock<SomeInterface2> m;
+
+		Fake(Method(m, DoSomething));
+		Fake(Dtor(m));
+
+		std::unique_ptr<SomeInterface2> ptr = std::unique_ptr<SomeInterface2>(&m.get());		
+		ptr = nullptr;
+	}
 
 } __DtorMocking;

--- a/tests/msc_calling_convention_tests.cpp
+++ b/tests/msc_calling_convention_tests.cpp
@@ -66,7 +66,9 @@ void inst()
 struct MscCallingConventionTests : tpunit::TestFixture {
 	MscCallingConventionTests() :
 		tpunit::TestFixture(
-			TEST( MscCallingConventionTests::cdecl_convention )//
+			TEST( MscCallingConventionTests::cdecl_convention ), //
+			TEST( MscCallingConventionTests::stdcall_convention ), //
+			TEST( MscCallingConventionTests::thiscall_convention )//
 		)  //
 	{
 	}
@@ -93,6 +95,58 @@ struct MscCallingConventionTests : tpunit::TestFixture {
 
 		// Invoke the mocked methods.
 		CdeclClass& instance = mockCdecl.get();
+		instance.DoThing();
+		ASSERT_EQUAL( 5, instance.GetValue() );
+	};
+
+	// A class where all the members use the __stdcall convention.
+	// This is how COM objects are.
+	class StdcallClass{
+	public:
+		virtual void __stdcall DoThing() {}
+
+		virtual int __stdcall GetValue()
+		{
+			return 4;
+		}
+	};
+
+	// Mock a class with stdcall members.
+	void stdcall_convention()
+	{
+		// Mock the class.
+		Mock< StdcallClass > mock;
+		Fake( Method( mock, DoThing ) );
+		When( Method( mock, GetValue ) ).AlwaysReturn( 5 );
+
+		// Invoke the mocked methods.
+		StdcallClass& instance = mock.get();
+		instance.DoThing();
+		ASSERT_EQUAL( 5, instance.GetValue() );
+	};
+
+	// A class where all the members use the __stdcall convention.
+	// This is the the default for member functions on 32-bit MSVC.
+	class ThiscallClass{
+	public:
+		virtual void __thiscall DoThing() {}
+
+		virtual int __thiscall GetValue()
+		{
+			return 4;
+		}
+	};
+
+	// Mock a class with thiscall members.
+	void thiscall_convention()
+	{
+		// Mock the class.
+		Mock< ThiscallClass > mock;
+		Fake( Method( mock, DoThing ) );
+		When( Method( mock, GetValue ) ).AlwaysReturn( 5 );
+
+		// Invoke the mocked methods.
+		ThiscallClass& instance = mock.get();
 		instance.DoThing();
 		ASSERT_EQUAL( 5, instance.GetValue() );
 	};

--- a/tests/msc_calling_convention_tests.cpp
+++ b/tests/msc_calling_convention_tests.cpp
@@ -25,37 +25,6 @@ int gg()
 	return 1;
 }
 
-struct func_traits{
-
-	static int (*f())()
-	{
-		return &gg;
-	}
-	
-	template<typename T, typename R, typename... arglist>
-	static R( T::* remove_cv( R( T::*vMethod )( arglist... ) const volatile ))( arglist... ) {
-		return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
-	};
-	
-	template<typename T, typename R, typename... arglist>
-	static R( T::* remove_cv( R( T::*vMethod )( arglist... ) volatile ))( arglist... ) {
-		return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
-	};
-
-	template<typename T, typename R, typename... arglist>
-	static R( T::* remove_cv( R( T::*vMethod )( arglist... ) const ))( arglist... ) {
-		return reinterpret_cast<void (T::*)(arglist...)>(vMethod)
-	};
-
-	template<typename T, typename R, typename... arglist>
-	static R( T::* remove_cv( R( T::*vMethod )( arglist... ) ))( arglist... ) {
-		return vMethod;
-	};
-
-	template<typename Func>
-	using remove_cv_t = decltype( remove_cv( std::declval<Func>() ) );
-};
-
 using cleanedFooType = func_traits::remove_cv_t< fooType >;
 
 template<typename A, typename B>

--- a/tests/msc_calling_convention_tests.cpp
+++ b/tests/msc_calling_convention_tests.cpp
@@ -1,0 +1,45 @@
+// These tests only make sense with the Visual Studio compiler, since only it has the calling convention options.
+#ifdef _MSC_VER
+
+#include "tpunit++.hpp"
+#include "fakeit.hpp"
+
+using namespace fakeit;
+
+// Tests for the MSVC calling conventions.
+struct MscCallingConventionTests : tpunit::TestFixture {
+	MscCallingConventionTests() :
+		tpunit::TestFixture(
+			TEST( MscCallingConventionTests::cdecl_convention )//
+		)  //
+	{
+	}
+
+	// A class where all the members use the __cdecl convention.
+	// This is the default on x64.
+	class CdeclClass{
+	public:
+		virtual void __cdecl DoThing() {}
+
+		virtual int __cdecl GetValue()
+		{
+			return 4;
+		}
+	};
+
+	// Mock a class with cdecl members.
+	void cdecl_convention()
+	{
+		// Mock the class.
+		Mock< CdeclClass > mockCdecl;
+		Fake( Method( mockCdecl, DoThing ) );
+		When( Method( mockCdecl, GetValue ) ).AlwaysReturn( 5 );
+
+		// Invoke the mocked methods.
+		CdeclClass& instance = mockCdecl.get();
+		instance.DoThing();
+		ASSERT_EQUAL( 5, instance.GetValue() );
+	};
+};
+
+#endif // _MSC_VER

--- a/tests/verification_tests.cpp
+++ b/tests/verification_tests.cpp
@@ -63,7 +63,8 @@ struct BasicVerification: tpunit::TestFixture {
 					TEST(BasicVerification::verify_after_paramter_was_changed__with_Matching), //
 					TEST(BasicVerification::verify_after_paramter_was_changed_with_argument_matcher), //
 					TEST(BasicVerification::verify_no_invocations),
-					TEST(BasicVerification::verify_after_paramter_was_changed_with_Using)) //
+					TEST(BasicVerification::verify_after_paramter_was_changed_with_Using), //
+					TEST(BasicVerification::verificationShouldTolerateNullString))
 	{
 	}
 
@@ -569,5 +570,25 @@ struct BasicVerification: tpunit::TestFixture {
 		ASSERT_TRUE(!Verify(Method(mock, func).Using(1)).Never());
 		ASSERT_FALSE(!VerifyNoOtherInvocations(Method(mock, func)));
     }
+
+	void verificationShouldTolerateNullString(){
+		struct RefEater {
+			virtual int eatChar(char*) = 0;
+			virtual int eatConstChar(const char*) = 0;
+		};
+
+		Mock<RefEater> mock;
+		When( Method( mock, eatChar ) ).AlwaysReturn( 0 );
+		When( Method( mock, eatConstChar ) ).AlwaysReturn( 0 );
+
+		RefEater& obj = mock.get();
+		obj.eatConstChar( nullptr );
+		obj.eatChar( nullptr );
+
+		Verify(Method(mock,eatChar)).Exactly(1);
+		Verify(Method(mock,eatConstChar)).Exactly(1);
+		ASSERT_THROW(Verify(Method(mock, eatChar)).Exactly(3), fakeit::VerificationException);
+		ASSERT_THROW(Verify(Method(mock, eatConstChar)).Exactly(3), fakeit::VerificationException);
+	}
 
 } __BasicVerification;

--- a/tests/verification_tests.cpp
+++ b/tests/verification_tests.cpp
@@ -583,10 +583,13 @@ struct BasicVerification: tpunit::TestFixture {
 
 		RefEater& obj = mock.get();
 		obj.eatConstChar( nullptr );
+		obj.eatConstChar( "string" );
 		obj.eatChar( nullptr );
+		char str[] = { 'a', '\0' };
+		obj.eatChar( str );
 
-		Verify(Method(mock,eatChar)).Exactly(1);
-		Verify(Method(mock,eatConstChar)).Exactly(1);
+		Verify(Method(mock,eatChar)).Exactly(2);
+		Verify(Method(mock,eatConstChar)).Exactly(2);
 		ASSERT_THROW(Verify(Method(mock, eatChar)).Exactly(3), fakeit::VerificationException);
 		ASSERT_THROW(Verify(Method(mock, eatConstChar)).Exactly(3), fakeit::VerificationException);
 	}


### PR DESCRIPTION
I'm working on making mocking COM objects in 32-bit MSVC builds possible. Their members use the __stdcall calling convention, so this requires adding calling convention support to fakeit.

This MR to my own repo exists for staging.